### PR TITLE
add npm install and executable for integ test shell

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -73,6 +73,8 @@ then
   PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
 
+npm install
+
 if [ $SECURITY_ENABLED = "true" ]
 then
    echo "run security enabled tests"


### PR DESCRIPTION
### Description
During infra team's Jenkins test, we noticed some issues to fix. Thus this PR is to add npm install and executable for integ test shell

1. add package install. (Plugins use osd bootstrap)
2. `chmod 775 integtest.sh`

 
### Issues Resolved
https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/3
 
### Check List
- [Check with Infra Jenkins ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
