### PR TITLE
add config to support remote endpoint test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules
 cypress/videos/
+cypress/results/
 .DS_Store
 **/.DS_Store
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
 - [Contributing to OpenSearch](#contributing-to-opensearch)
+- [Developer Guide](#developer-guide)
+  - [Run Tests](#run-tests)
 - [First Things First](#first-things-first)
 - [Ways to Contribute](#ways-to-contribute)
   - [Bug Reports](#bug-reports)
@@ -12,6 +14,33 @@
 ## Contributing to OpenSearch
 
 OpenSearch is a community project that is built and maintained by people just like **you**. We're glad you're interested in helping out. There are several different ways you can do it, but before we talk about that, let's talk about how to get started.
+
+## Developer Guide
+
+### Run Tests
+
+You can run the cypress tests by cli: 
+
+```
+$ npx cypress run --spec "cypress/integration/security-disabled/*.js"
+```
+
+By default, it uses headless mode (hide the broswer) You can turn on the brower display by: 
+
+```
+$ npx cypress run --spec "cypress/integration/security-disabled/*.js --headed"
+```
+
+You can also manually trigger the test via browser UI by: 
+
+```
+$ npx cypress open
+```
+
+And you can override certain cypress config or environment variable by appling additional cli arguments, for example to override the baseUrl and OpensearchUrl to test a remote endpoint:
+```
+$ npx cypress run --spec "cypress/integration/security-disabled/*.js" --env "openSearchUrl=https://foo.com" --config "baseUrl=https://foo.com/_dashboards"
+```
 
 ## First Things First
 

--- a/cypress.json
+++ b/cypress.json
@@ -4,5 +4,10 @@
   "reporter": "cypress-multi-reporters",
   "reporterOptions": {
     "configFile": "reporter-config.json"
+  },
+  "env": {
+    "openSearchUrl": "http://localhost:9200",
+    "userName": "admin",
+    "password": "admin"
   }
 }

--- a/cypress/integration/security-disabled/dashboard_filtering_spec.js
+++ b/cypress/integration/security-disabled/dashboard_filtering_spec.js
@@ -12,7 +12,7 @@ import { TestFixtureHandler, CommonUI, DashboardPage, MiscUtils } from '@opensea
  * 8) Test adding another pie graph to the dashboard and applying a filter to both graphs
  */
 
-const testFixtureHandler = new TestFixtureHandler(cy)
+const testFixtureHandler = new TestFixtureHandler(cy, Cypress.env('openSearchUrl'))
 const commonUI = new CommonUI(cy)
 const dashboardPage = new DashboardPage(cy)
 const miscUtils = new MiscUtils(cy)

--- a/cypress/integration/security-enabled/login-page-spec.js
+++ b/cypress/integration/security-enabled/login-page-spec.js
@@ -4,13 +4,13 @@ const loginPage = new LoginPage(cy);
 
 describe('login into security enabled cluster', () => {
     beforeEach(() => {
-        cy.visit('localhost:5601');
+        cy.visit('/');
     })
 
     it('type user name and password to login', () => {
-        loginPage.enterUserName('admin')
+        loginPage.enterUserName(Cypress.env('userName'))
 
-        loginPage.enterPassword('admin')
+        loginPage.enterPassword(Cypress.env('password'))
 
         loginPage.submit()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,9 +86,9 @@
       }
     },
     "@opensearch-dashboards-test/opensearch-dashboards-test-library": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@opensearch-dashboards-test/opensearch-dashboards-test-library/-/opensearch-dashboards-test-library-1.0.2.tgz",
-      "integrity": "sha512-qzBchmYj31AIT3fnjhgRnjfPCBVQ0CoJd5l2ojY/sbTILtJkmOalj6KSnit+rGM3tJ0W0dDNbJgE6jw/3CKWfA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@opensearch-dashboards-test/opensearch-dashboards-test-library/-/opensearch-dashboards-test-library-1.0.3.tgz",
+      "integrity": "sha512-fHYyj7TEeuc+AXiIlYduahwRnzH8ddz9hnJiLc8429A4mVKg+pdrlxFkup3lvH+5U6JgVxTpbO8J/XKAt6U7/A=="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/opensearch-project/opensearch-dashboards-functional-test",
   "dependencies": {
-    "@opensearch-dashboards-test/opensearch-dashboards-test-library": "^1.0.2"
+    "@opensearch-dashboards-test/opensearch-dashboards-test-library": "^1.0.3"
   },
   "devDependencies": {
     "cypress": "^6.9.1",


### PR DESCRIPTION
Signed-off-by: Tengda He <tengh@amazon.com>

### Description
- adding a separate cypress environment variable for OpenSearch endpoint url, the baseUrl will be reserved for OpenSearchDashboard endpoint. This way allows easy config for API call to OpenSearch endpoint.
- move the username and password parameter to  cypress environment variable
- cypress environment variable supports CLI overrides as well.


### Test
- all existing test suites passed for remote endpoint in staging environment
- fgac tests passed
- non fgac tests passed

### Issues Resolved
#8 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
