### PR TITLE
add version argument to integ test shell

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -16,11 +16,12 @@ function usage() {
     echo -e "-p BIND_PORT\t, defaults to 9200 or 5601 depends on OpenSearch or Dashboards, can be changed to any port for the cluster location."
     echo -e "-s SECURITY_ENABLED\t(true | false), defaults to true. Specify the OpenSearch/Dashboards have security enabled or not."
     echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
+    echo -e "-v VERSION\t, no defaults, indicates the OpenSearch version to test."
     echo -e "-h\tPrint this message."
     echo "--------------------------------------------------------------------------"
 }
 
-while getopts ":hb:p:s:c:" arg; do
+while getopts ":hb:p:s:c:v:" arg; do
     case $arg in
         h)
             usage
@@ -38,6 +39,9 @@ while getopts ":hb:p:s:c:" arg; do
         c)
             CREDENTIAL=$OPTARG
             ;;
+        v)
+            VERSION=$OPTARG
+            ;;        
         :)
             echo "-${OPTARG} requires an argument"
             usage


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description
Add the support for `version` argument.

During https://github.com/opensearch-project/opensearch-build/issues/604 I noticed the integ test command failed with `Invalid option: -v`

```
Executing "/tmp/tmpz2xuwc_d/functionalTestDashboards/integtest.sh -b localhost -p 5601 -s false -v 1.2.0" in /tmp/tmpz2xuwc_d/functionalTestDashboards
2021-11-30 02:14:32 INFO     status,  is 1
2021-11-30 02:14:32 INFO     stdout is Invalid option: -v
```

After checking this repo, I realized that this option is not available. 

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/39
 
### Test

The previous `-v` error is gone.

```
./integtest.sh -b localhost -p 5601 -s false -v 1.2.0
./integtest.sh: line 80: npm: command not found
```

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
