### PR TITLE
Run core and plugin tests in single run command in integtest.sh

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -86,4 +86,4 @@ else
    echo "run security disabled tests"
 fi
 
-npx cypress run --env SECURITY_ENABLED=$SECURITY_ENABLED --spec "(?=cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js)(?=cypress/integration/plugins/*/*.js)"
+npx cypress run --env SECURITY_ENABLED=$SECURITY_ENABLED --spec "cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*"

--- a/integtest.sh
+++ b/integtest.sh
@@ -86,5 +86,4 @@ else
    echo "run security disabled tests"
 fi
 
-npx cypress run --env SECURITY_ENABLED=$SECURITY_ENABLED --spec "cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js"
-npx cypress run --env SECURITY_ENABLED=$SECURITY_ENABLED --spec "cypress/integration/plugins/*/*.js"
+npx cypress run --env SECURITY_ENABLED=$SECURITY_ENABLED --spec "(?=cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js)(?=cypress/integration/plugins/*/*.js)"


### PR DESCRIPTION
### Description
Changes cypress run command in `integtest.sh` to run core and plugin tests in a single run to persist all test artifacts (videos, screenshots, etc.).

See [cypress documentation](https://docs.cypress.io/guides/guides/command-line#cypress-run-spec-lt-spec-gt) for details on running multiple files and/or globs.
 
### Issues Resolved
Closes #68 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
