### PR TITLE
skip flaky test and update document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,13 +51,13 @@ $ npm uninstall @opensearch-dashboards-test/opensearch-dashboards-test-library &
 You can run the cypress tests by cli:
 
 ```
-$ npx cypress run --spec "cypress/integration/vanilla-opensearch-dashboards/*.js"
+$ npx cypress run --spec "cypress/integration/core-opensearch-dashboards/vanilla-opensearch-dashboards/*.js"
 ```
 
 By default, it uses headless mode (hide the broswer) You can turn on the browser display by:
 
 ```
-$ npx cypress run --spec "cypress/integration/vanilla-opensearch-dashboards/*.js --headed"
+$ npx cypress run --spec "cypress/integration/core-opensearch-dashboards/vanilla-opensearch-dashboards/*.js --headed"
 ```
 
 You can also manually trigger the test via browser UI by:
@@ -69,7 +69,7 @@ $ npx cypress open
 And you can override certain cypress config or environment variable by appling additional cli arguments, for example to override the baseUrl and OpensearchUrl to test a remote endpoint:
 
 ```
-$ npx cypress run --spec "cypress/integration/vanilla-opensearch-dashboards/*.js" --env "openSearchUrl=https://foo.com" --config "baseUrl=https://foo.com/_dashboards"
+$ npx cypress run --spec "cypress/integration/core-opensearch-dashboards/vanilla-opensearch-dashboards/*.js" --env "openSearchUrl=https://foo.com" --config "baseUrl=https://foo.com/_dashboards"
 ```
 
 ### Formatting

--- a/cypress/integration/core-opensearch-dashboards/vanilla-opensearch-dashboards/dashboard_filtering_spec.js
+++ b/cypress/integration/core-opensearch-dashboards/vanilla-opensearch-dashboards/dashboard_filtering_spec.js
@@ -265,7 +265,7 @@ describe('dashboard filtering', () => {
         );
       });
 
-      it('Filter disabled: goal and guages', () => {
+      it.skip('Filter disabled: goal and guages', () => {
         // Goal label should be 7,544, and the gauge label should be 39.958%%
         // Inconsistency: original code says that the goal label should have "7,544",
         // but sometimes the goal displays "7,565". It may have been related to a


### PR DESCRIPTION
Signed-off-by: Tao Liu <liutaoaz@amazon.com>

### Description

This PR is skipping one flaky test, and update the CONTRIBUTING.md.

### Issues Resolved

resolves https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/90

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### Tests
According to the Cypress: https://github.com/cypress-io/cypress/issues/3092

Cypress considers a pending test to be any of the following:

```
it.skip(), context.skip, etc
it('some test') (no callback)
```

```
  dashboard filtering
    ✓ Buffer test for importing test environment data (25069ms)
    Adding and removing filters from a dashboard
      adding a filter that excludes all data
        ✓ Nonpinned filter: filters on pie charts (25448ms)
        ✓ Nonpinned filter: area, bar and heatmap charts filtered (147ms)
        ✓ Nonpinned filter: data tables are filtered
        ✓ Nonpinned filter: goal and guages are filtered (56ms)
        ✓ Nonpinned filter: tsvb time series shows no data message
        ✓ Nonpinned filter: metric value shows no data
        ✓ Nonpinned filter: tag cloud values are filtered
        ✓ Nonpinned filter: tsvb metric is filtered
        ✓ Nonpinned filter: tsvb top n is filtered (55ms)
        ✓ Nonpinned filter: saved search is filtered
        ✓ Nonpinned filter: vega is filtered (165ms)
      using a pinned filter that excludes all data
        ✓ Pinned filter: filters on pie charts (2623ms)
        ✓ Pinned filter: area, bar and heatmap charts filtered (172ms)
        ✓ Pinned filter: data tables are filtered
        ✓ Pinned filter: goal and guages are filtered (48ms)
        ✓ Pinned filter: metric value shows no data
        ✓ Pinned filter: tag cloud values are filtered
        ✓ Pinned filter: tsvb metric is filtered
        ✓ Pinned filter: tsvb top n is filtered (48ms)
        ✓ Pinned filter: saved search is filtered
        ✓ Pinned filter: vega is filtered (144ms)
      disabling a filter unfilters the data on
        ✓ Filter disabled: pie charts (3277ms)
        ✓ Filter disabled: area, bar and heatmap charts (109ms)
        ✓ Filter disabled: data tables (179ms)
        - Filter disabled: goal and guages
        ✓ Filter disabled: metric value
        ✓ Filter disabled: tag cloud (54ms)
        ✓ Filter disabled: tsvb metric
        ✓ Filter disabled: tsvb top n (48ms)
        ✓ Filter disabled: tsvb markdown
        ✓ Filter disabled: saved search is filtered
        ✓ Filter disabled: vega is filtered (156ms)
    nested filtering
      ✓ visualization saved with a query filters data (13582ms)
      ✓ Nested visualization filter pills filters data as expected (2897ms)
      ✓ Removing filter pills and query unfiters data as expected (4093ms)
      ✓ Pie chart linked to saved search filters data (3206ms)
      ✓ Pie chart linked to saved search filters shows no data with conflicting dashboard query (850ms)


  37 passing (1m)
  1 pending


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        38                                                                               │
  │ Passing:      37                                                                               │
  │ Failing:      0                                                                                │
  │ Pending:      1                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     1 minute, 23 seconds                                                             │
  │ Spec Ran:     core-opensearch-dashboards/vanilla-opensearch-dashboards/dashboard_filtering_spe │
  │               c.js                                                                             │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
```
