### PR TITLE
upgrade to 1.3.0 and use latest url

### DIFF
--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -9,7 +9,7 @@ on:
       - main
       - dev-*
 env:
-  VERSION: '1.2.0'
+  VERSION: '1.3.0'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -26,14 +26,14 @@ jobs:
           java-version: 14
       - name: Get and run OpenSearch
         run: |
-          wget https://artifacts.opensearch.org/releases/bundle/opensearch/${{ env.VERSION }}/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/
           ./opensearch-tar-install.sh &
           timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
-        run: |
-          wget https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/${{ env.VERSION }}/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+        run: |          
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
       - name: Get node and yarn versions
         id: versions

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -32,7 +32,7 @@ jobs:
           ./opensearch-tar-install.sh &
           timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
-        run: |          
+        run: |
           wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
       - name: Get node and yarn versions
@@ -46,7 +46,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Run OpenSearch-Dashboards server
         run: |
-          cd opensearch-dashboards-${{ env.VERSION }}-linux-x64
+          cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
           timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Checkout monterey-test

--- a/.github/workflows/cypress-workflow-plugins-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-plugins-bundle-snapshot-based.yml
@@ -46,7 +46,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Run OpenSearch-Dashboards server
         run: |
-          cd opensearch-dashboards-${{ env.VERSION }}-linux-x64
+          cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
           timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Checkout monterey-test

--- a/.github/workflows/cypress-workflow-plugins-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-plugins-bundle-snapshot-based.yml
@@ -9,7 +9,7 @@ on:
       - main
       - dev-*
 env:
-  VERSION: '1.2.0'
+  VERSION: '1.3.0'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -26,14 +26,14 @@ jobs:
           java-version: 14
       - name: Get and run OpenSearch
         run: |
-          wget https://artifacts.opensearch.org/releases/bundle/opensearch/${{ env.VERSION }}/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/
           ./opensearch-tar-install.sh &
           timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
         run: |
-          wget https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/${{ env.VERSION }}/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
       - name: Get node and yarn versions
         id: versions

--- a/.github/workflows/cypress-workflow-vanilla-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-vanilla-snapshot-based.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - dev-*
+env:
+  VERSION: '1.3.0'
 jobs:
   tests:
     name: Run Cypress E2E tests
@@ -24,19 +26,19 @@ jobs:
           java-version: 14
       - name: Get and run OpenSearch
         run: |
-          wget https://artifacts.opensearch.org/snapshots/core/opensearch/1.2.0-SNAPSHOT/opensearch-min-1.2.0-SNAPSHOT-linux-x64-latest.tar.gz
-          tar -xzf opensearch-min-1.2.0-SNAPSHOT-linux-x64-latest.tar.gz
-          cd opensearch-1.2.0-SNAPSHOT/
+          wget https://artifacts.opensearch.org/snapshots/core/opensearch/${{ env.VERSION }}-SNAPSHOT/opensearch-min-${{ env.VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
+          tar -xzf opensearch-min-${{ env.VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
+          cd opensearch-${{ env.VERSION }}-SNAPSHOT/
           bin/opensearch &
           timeout 300 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
         run: |
-          wget https://artifacts.opensearch.org/snapshots/core/opensearch-dashboards/1.2.0-SNAPSHOT/opensearch-dashboards-min-1.2.0-SNAPSHOT-linux-x64-latest.tar.gz
-          tar -xzf opensearch-dashboards-min-1.2.0-SNAPSHOT-linux-x64-latest.tar.gz
+          wget https://artifacts.opensearch.org/snapshots/core/opensearch-dashboards/${{ env.VERSION }}-SNAPSHOT/opensearch-dashboards-min-${{ env.VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
+          tar -xzf opensearch-dashboards-min-${{ env.VERSION }}-SNAPSHOT-linux-x64-latest.tar.gz
       - name: Get node and yarn versions
         id: versions
         run: |
-          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-1.2.0-SNAPSHOT-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")"
+          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-SNAPSHOT-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")"
       - name: Setup node
         uses: actions/setup-node@v1
         with:
@@ -44,7 +46,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Run OpenSearch-Dashboards server
         run: |
-          cd opensearch-dashboards-1.2.0-SNAPSHOT-linux-x64
+          cd opensearch-dashboards-${{ env.VERSION }}-SNAPSHOT-linux-x64
           bin/opensearch-dashboards serve &
           timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Checkout Monterey test cases

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-dashboards-functional-test",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "description": "Maintains functional tests for OpenSearch Dashboards and Dashboards plugins",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

Upgrade the main branch to 1.3.0 and use the `latest` url since it is ready. https://github.com/opensearch-project/opensearch-build/issues/1492

### Issues Resolved


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
