### PR TITLE
Fixed ID tag name in AD test

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/detector_list_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/detector_list_spec.js
@@ -103,7 +103,7 @@ describe('Detector list', () => {
         cy.visit(BASE_AD_DETECTOR_LIST_PATH);
       }
     );
-    cy.get('[data-test-subj=addDetector]').click({ force: true });
+    cy.get('[data-test-subj=createDetectorButton]').click({ force: true });
     cy.contains('span', 'Create detector');
   });
 


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description
Changed `data-test-subj` tag for 'Redirect to create detector' test to correct ID tag that is used in AD dashboards-plugin

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
