### PR TITLE
Fix ISM test failure

### DIFF
--- a/cypress/fixtures/plugins/index-management-dashboards-plugin/sample_rollover_policy.json
+++ b/cypress/fixtures/plugins/index-management-dashboards-plugin/sample_rollover_policy.json
@@ -7,7 +7,10 @@
         "name": "hot",
         "actions": [
           {
-            "rollover": {}
+            "rollover": {},
+            "retry": {
+              "count": 0
+            }
           }
         ],
         "transitions": [


### PR DESCRIPTION
Signed-off-by: bowenlan-amzn <bowenlan23@gmail.com>

### Description

Fix the test failure, [test run](https://github.com/opensearch-project/opensearch-dashboards-functional-test/runs/5425516829?check_suite_focus=true)

```
  1) Managed indices
       can have policies retried
         successfully:
     AssertionError: Timed out retrying: Expected to find content: 'Failed' but never did.
      at Context.eval (http://localhost:5601/__cypress/tests?p=cypress/integration/plugins/index-management-dashboards-plugin/managed_indices_spec.js:253:10)
```

The failure reason is we [update the cypress in our plugin repo](https://github.com/opensearch-project/index-management-dashboards-plugin/commit/5ed6c25ae769bb40d447c5e3e55fb7f89007b926#diff-9de9f25f3db58b6b6d7ad1ebbb4d33690ab9021f99bdb8361cf2697608c3847eR10-R13), but didn't sync the change to this functional test repo.

This is an evidence that we should proactively advise plugin owners to remove the test from their plugin repo once they migrate them here.
And if we advise this, a subsequent question is how would plugin owner run the test now in this functional test repo during the feature development inside plugin repo.

Here are some thoughts:
1. First merge the change of new feature in plugin repo.
2. Add corresponding cypress test in this functional test repo.
3. Use a GitHub workflow in plugin repo to run the cypress test in this functional test repo. We trigger this GitHub workflow by daily and [manually](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow),

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
