### PR TITLE
unify the sh and Github workflow

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -82,10 +82,9 @@ npm install
 if [ $SECURITY_ENABLED = "true" ]
 then
    echo "run security enabled tests"
+   yarn cypress:run-with-security --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
 else
    echo "run security disabled tests"
-fi
+   yarn cypress:run-without-security --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
 
-env TZ=America/Los_Angeles \
-    npx cypress run --env SECURITY_ENABLED=$SECURITY_ENABLED \
-    --spec "cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*"
+fi


### PR DESCRIPTION
### Description

Make the shell script calling integ test by using the same way as Github workflow to avoid discrepancy.

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/1709

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
