### PR TITLE
use default browser

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/01-create.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/01-create.spec.js
@@ -25,15 +25,15 @@ describe('Cypress', () => {
     cy.wait(WAIT_TIME);
   });
 
-  it('Visits Reporting homepage', () => {
+  it.skip('Visits Reporting homepage', () => {
     visitReportingLandingPage();
   });
 
-  it('Visit Create page', () => {
+  it.skip('Visit Create page', () => {
     visitCreateReportDefinitionPage();
   });
 
-  it('Create a new on-demand dashboard report definition', () => {
+  it.skip('Create a new on-demand dashboard report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress dashboard on-demand report');
     setReportDefinitionDescription('Description for cypress test');
@@ -48,7 +48,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a new on-demand visualization report definition', ()=> {
+  it.skip('Create a new on-demand visualization report definition', ()=> {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress vis on-demand report');
     setReportDefinitionDescription('Description for cypress test');
@@ -60,7 +60,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a new on-demand saved search report definition', () => {
+  it.skip('Create a new on-demand saved search report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress saved search on-demand report');
     setReportDefinitionDescription('Description for cypress test');
@@ -72,7 +72,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a new dashboard daily recurring report definition', () => {
+  it.skip('Create a new dashboard daily recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress dashboard daily scheduled report');
     setReportDefinitionDescription('Description for cypress test');
@@ -88,7 +88,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a new visualization daily recurring report definition', () => {
+  it.skip('Create a new visualization daily recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress vis daily scheduled report');
     setReportDefinitionDescription('Description for cypress test');
@@ -101,7 +101,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a new saved search daily recurring report definition', () => {
+  it.skip('Create a new saved search daily recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress search daily scheduled report');
     setReportDefinitionDescription('Description for cypress test');
@@ -113,7 +113,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a new dashboard interval recurring report definition', () => {
+  it.skip('Create a new dashboard interval recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress dashboard recurring report');
     setReportDefinitionDescription('Description for cypress test');
@@ -132,7 +132,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a new visualization interval recurring report definition', () => {
+  it.skip('Create a new visualization interval recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress vis interval recurring report');
     selectReportSource('#visualizationReportSource');
@@ -147,7 +147,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a new saved search interval recurring report definition', () => {
+  it.skip('Create a new saved search interval recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress saved search interval recurring report');
     selectReportSource('#savedSearchReportSource');
@@ -162,7 +162,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a dashboard cron-based report definition', () => {
+  it.skip('Create a dashboard cron-based report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress dashboard cron definition');
     selectReportSourceComboBox();
@@ -179,7 +179,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a visualization cron-based report definition', () => {
+  it.skip('Create a visualization cron-based report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress vis cron definition');
     selectReportSource('#visualizationReportSource');
@@ -194,7 +194,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it('Create a saved search cron-based report definition', () => {
+  it.skip('Create a saved search cron-based report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress search cron definition');
     selectReportSource('#savedSearchReportSource');

--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -6,7 +6,7 @@
 import { BASE_PATH } from '../../../utils/constants';
 
 describe('Cypress', () => {
-  it('Visit edit page, update name and description', () => {
+  it.skip('Visit edit page, update name and description', () => {
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
     cy.location('pathname', { timeout: 60000 }).should(
       'include',
@@ -39,7 +39,7 @@ describe('Cypress', () => {
     cy.get('#reportDefinitionDetailsLink').should('exist');
   });
 
-  it('Visit edit page, change report trigger', () => {
+  it.skip('Visit edit page, change report trigger', () => {
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
     cy.location('pathname', { timeout: 60000 }).should(
       'include',
@@ -68,7 +68,7 @@ describe('Cypress', () => {
     cy.get('#reportDefinitionDetailsLink').should('exist');
   });
 
-  it('Visit edit page, change report trigger back', () => {
+  it.skip('Visit edit page, change report trigger back', () => {
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
     cy.location('pathname', { timeout: 60000 }).should(
       'include',

--- a/cypress/integration/plugins/reports-dashboards/03-details.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/03-details.spec.js
@@ -6,7 +6,7 @@
 import { WAIT_TIME, visitReportingLandingPage } from "../../../utils/constants";
 
 describe('Cypress', () => {
-  it('Visit report definition details page', () => {
+  it.skip('Visit report definition details page', () => {
     visitReportingLandingPage();
     cy.wait(WAIT_TIME);
     visitReportDefinitionDetailsPage();
@@ -16,7 +16,7 @@ describe('Cypress', () => {
     verifyGenerateReportFromFileFormatExists();
   });
 
-  it('Go to edit report definition from report definition details', () => {
+  it.skip('Go to edit report definition from report definition details', () => {
     visitReportingLandingPage();
     cy.wait(WAIT_TIME);
     visitReportDefinitionDetailsPage();
@@ -25,7 +25,7 @@ describe('Cypress', () => {
     verifyEditReportDefinitionURL();
   });
 
-  it('Verify report source URL on report definition details', () => {
+  it.skip('Verify report source URL on report definition details', () => {
     visitReportingLandingPage();
     cy.wait(WAIT_TIME);
     visitReportDefinitionDetailsPage();
@@ -34,7 +34,7 @@ describe('Cypress', () => {
     
   });
 
-  it('Delete report definition from details page', () => {
+  it.skip('Delete report definition from details page', () => {
     visitReportingLandingPage();
     cy.wait(5000);
     visitReportDefinitionDetailsPage();
@@ -43,14 +43,14 @@ describe('Cypress', () => {
     verifyDeleteSuccess();
   });
 
-  it('Visit report details page', () => {
+  it.skip('Visit report details page', () => {
     visitReportingLandingPage();
     cy.wait(5000);
     visitReportDetailsPage();
     verifyReportDetailsURL();
   });
 
-  it('Verify report source URL on report details', () => {
+  it.skip('Verify report source URL on report details', () => {
     visitReportingLandingPage();
     cy.wait(WAIT_TIME);
     visitReportDetailsPage();

--- a/cypress/integration/plugins/reports-dashboards/04-download.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/04-download.spec.js
@@ -19,7 +19,7 @@ describe('Cypress', () => {
     cy.wait(3000);
   });
 
-  it('Download from reporting homepage', () => {
+  it.skip('Download from reporting homepage', () => {
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
     cy.location('pathname', { timeout: 60000 }).should(
       'include',
@@ -38,7 +38,7 @@ describe('Cypress', () => {
     })
   });
 
-  it('Download pdf from in-context menu', () => {
+  it.skip('Download pdf from in-context menu', () => {
     cy.visit(`${BASE_PATH}/app/dashboards#`);
     cy.wait(5000);
 
@@ -54,7 +54,7 @@ describe('Cypress', () => {
     cy.get('#reportGenerationProgressModal');
   });
 
-  it('Download png from in-context menu', () => {
+  it.skip('Download png from in-context menu', () => {
     cy.visit(`${BASE_PATH}/app/dashboards#`);
     cy.wait(5000);
 
@@ -69,7 +69,7 @@ describe('Cypress', () => {
     cy.get('#reportGenerationProgressModal');
   });
 
-  it('Download csv from saved search in-context menu', () => {
+  it.skip('Download csv from saved search in-context menu', () => {
     cy.visit(`${BASE_PATH}/app/discover#`);
     cy.wait(5000);
 
@@ -86,7 +86,7 @@ describe('Cypress', () => {
     cy.get('#generateCSV').click({ force: true });
   });
 
-  it('Download from Report definition details page', () => {
+  it.skip('Download from Report definition details page', () => {
     // create an on-demand report definition 
 
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "cypress:open": "cypress open",
-    "cypress:run-without-security": "env TZ=America/Los_Angeles cypress run --browser chrome --headless --env SECURITY_ENABLED=false",
-    "cypress:run-with-security": "env TZ=America/Los_Angeles cypress run --browser chrome --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200",
+    "cypress:run-without-security": "env TZ=America/Los_Angeles cypress run --headless --env SECURITY_ENABLED=false",
+    "cypress:run-with-security": "env TZ=America/Los_Angeles cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200",
     "cypress:run-plugin-tests-without-security": "yarn cypress:run-without-security --spec 'cypress/integration/plugins/*/*.js'",
     "cypress:run-plugin-tests-with-security": "yarn cypress:run-with-security --spec 'cypress/integration/plugins/*/*.js'"
   },


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

See error to run the tests from infra.

```
$ env TZ=America/Los_Angeles cypress run --browser chrome --headless --env SECURITY_ENABLED=false --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
Can't run because you've entered an invalid browser name.

Browser: 'chrome' was not found on your system or is not supported by Cypress.

```
Thus remove browser parameter.

### Issues Resolved


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
