### PR TITLE
Revert "use default browser (#112)"

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/01-create.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/01-create.spec.js
@@ -25,15 +25,15 @@ describe('Cypress', () => {
     cy.wait(WAIT_TIME);
   });
 
-  it.skip('Visits Reporting homepage', () => {
+  it('Visits Reporting homepage', () => {
     visitReportingLandingPage();
   });
 
-  it.skip('Visit Create page', () => {
+  it('Visit Create page', () => {
     visitCreateReportDefinitionPage();
   });
 
-  it.skip('Create a new on-demand dashboard report definition', () => {
+  it('Create a new on-demand dashboard report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress dashboard on-demand report');
     setReportDefinitionDescription('Description for cypress test');
@@ -48,7 +48,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a new on-demand visualization report definition', ()=> {
+  it('Create a new on-demand visualization report definition', ()=> {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress vis on-demand report');
     setReportDefinitionDescription('Description for cypress test');
@@ -60,7 +60,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a new on-demand saved search report definition', () => {
+  it('Create a new on-demand saved search report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress saved search on-demand report');
     setReportDefinitionDescription('Description for cypress test');
@@ -72,7 +72,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a new dashboard daily recurring report definition', () => {
+  it('Create a new dashboard daily recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress dashboard daily scheduled report');
     setReportDefinitionDescription('Description for cypress test');
@@ -88,7 +88,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a new visualization daily recurring report definition', () => {
+  it('Create a new visualization daily recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress vis daily scheduled report');
     setReportDefinitionDescription('Description for cypress test');
@@ -101,7 +101,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a new saved search daily recurring report definition', () => {
+  it('Create a new saved search daily recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress search daily scheduled report');
     setReportDefinitionDescription('Description for cypress test');
@@ -113,7 +113,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a new dashboard interval recurring report definition', () => {
+  it('Create a new dashboard interval recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress dashboard recurring report');
     setReportDefinitionDescription('Description for cypress test');
@@ -132,7 +132,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a new visualization interval recurring report definition', () => {
+  it('Create a new visualization interval recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress vis interval recurring report');
     selectReportSource('#visualizationReportSource');
@@ -147,7 +147,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a new saved search interval recurring report definition', () => {
+  it('Create a new saved search interval recurring report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress saved search interval recurring report');
     selectReportSource('#savedSearchReportSource');
@@ -162,7 +162,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a dashboard cron-based report definition', () => {
+  it('Create a dashboard cron-based report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress dashboard cron definition');
     selectReportSourceComboBox();
@@ -179,7 +179,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a visualization cron-based report definition', () => {
+  it('Create a visualization cron-based report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress vis cron definition');
     selectReportSource('#visualizationReportSource');
@@ -194,7 +194,7 @@ describe('Cypress', () => {
     verifyOnReportingLandingPage();
   });
 
-  it.skip('Create a saved search cron-based report definition', () => {
+  it('Create a saved search cron-based report definition', () => {
     visitCreateReportDefinitionPage();
     setReportDefinitionName('Cypress search cron definition');
     selectReportSource('#savedSearchReportSource');

--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -6,7 +6,7 @@
 import { BASE_PATH } from '../../../utils/constants';
 
 describe('Cypress', () => {
-  it.skip('Visit edit page, update name and description', () => {
+  it('Visit edit page, update name and description', () => {
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
     cy.location('pathname', { timeout: 60000 }).should(
       'include',
@@ -39,7 +39,7 @@ describe('Cypress', () => {
     cy.get('#reportDefinitionDetailsLink').should('exist');
   });
 
-  it.skip('Visit edit page, change report trigger', () => {
+  it('Visit edit page, change report trigger', () => {
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
     cy.location('pathname', { timeout: 60000 }).should(
       'include',
@@ -68,7 +68,7 @@ describe('Cypress', () => {
     cy.get('#reportDefinitionDetailsLink').should('exist');
   });
 
-  it.skip('Visit edit page, change report trigger back', () => {
+  it('Visit edit page, change report trigger back', () => {
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
     cy.location('pathname', { timeout: 60000 }).should(
       'include',

--- a/cypress/integration/plugins/reports-dashboards/03-details.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/03-details.spec.js
@@ -6,7 +6,7 @@
 import { WAIT_TIME, visitReportingLandingPage } from "../../../utils/constants";
 
 describe('Cypress', () => {
-  it.skip('Visit report definition details page', () => {
+  it('Visit report definition details page', () => {
     visitReportingLandingPage();
     cy.wait(WAIT_TIME);
     visitReportDefinitionDetailsPage();
@@ -16,7 +16,7 @@ describe('Cypress', () => {
     verifyGenerateReportFromFileFormatExists();
   });
 
-  it.skip('Go to edit report definition from report definition details', () => {
+  it('Go to edit report definition from report definition details', () => {
     visitReportingLandingPage();
     cy.wait(WAIT_TIME);
     visitReportDefinitionDetailsPage();
@@ -25,7 +25,7 @@ describe('Cypress', () => {
     verifyEditReportDefinitionURL();
   });
 
-  it.skip('Verify report source URL on report definition details', () => {
+  it('Verify report source URL on report definition details', () => {
     visitReportingLandingPage();
     cy.wait(WAIT_TIME);
     visitReportDefinitionDetailsPage();
@@ -34,7 +34,7 @@ describe('Cypress', () => {
     
   });
 
-  it.skip('Delete report definition from details page', () => {
+  it('Delete report definition from details page', () => {
     visitReportingLandingPage();
     cy.wait(5000);
     visitReportDefinitionDetailsPage();
@@ -43,14 +43,14 @@ describe('Cypress', () => {
     verifyDeleteSuccess();
   });
 
-  it.skip('Visit report details page', () => {
+  it('Visit report details page', () => {
     visitReportingLandingPage();
     cy.wait(5000);
     visitReportDetailsPage();
     verifyReportDetailsURL();
   });
 
-  it.skip('Verify report source URL on report details', () => {
+  it('Verify report source URL on report details', () => {
     visitReportingLandingPage();
     cy.wait(WAIT_TIME);
     visitReportDetailsPage();

--- a/cypress/integration/plugins/reports-dashboards/04-download.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/04-download.spec.js
@@ -19,7 +19,7 @@ describe('Cypress', () => {
     cy.wait(3000);
   });
 
-  it.skip('Download from reporting homepage', () => {
+  it('Download from reporting homepage', () => {
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
     cy.location('pathname', { timeout: 60000 }).should(
       'include',
@@ -38,7 +38,7 @@ describe('Cypress', () => {
     })
   });
 
-  it.skip('Download pdf from in-context menu', () => {
+  it('Download pdf from in-context menu', () => {
     cy.visit(`${BASE_PATH}/app/dashboards#`);
     cy.wait(5000);
 
@@ -54,7 +54,7 @@ describe('Cypress', () => {
     cy.get('#reportGenerationProgressModal');
   });
 
-  it.skip('Download png from in-context menu', () => {
+  it('Download png from in-context menu', () => {
     cy.visit(`${BASE_PATH}/app/dashboards#`);
     cy.wait(5000);
 
@@ -69,7 +69,7 @@ describe('Cypress', () => {
     cy.get('#reportGenerationProgressModal');
   });
 
-  it.skip('Download csv from saved search in-context menu', () => {
+  it('Download csv from saved search in-context menu', () => {
     cy.visit(`${BASE_PATH}/app/discover#`);
     cy.wait(5000);
 
@@ -86,7 +86,7 @@ describe('Cypress', () => {
     cy.get('#generateCSV').click({ force: true });
   });
 
-  it.skip('Download from Report definition details page', () => {
+  it('Download from Report definition details page', () => {
     // create an on-demand report definition 
 
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);


### PR DESCRIPTION
This reverts commit 376ac6483748402df4c987c75d981989bc87f41e.

Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

Will explore more options to handle the crashed default browser.

### Issues Resolved


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
