### PR TITLE
disable color in output

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "cypress:open": "cypress open",
-    "cypress:run-without-security": "env TZ=America/Los_Angeles cypress run --headless --env SECURITY_ENABLED=false",
-    "cypress:run-with-security": "env TZ=America/Los_Angeles cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200",
+    "cypress:run-without-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=false",
+    "cypress:run-with-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200",
     "cypress:run-plugin-tests-without-security": "yarn cypress:run-without-security --spec 'cypress/integration/plugins/*/*.js'",
     "cypress:run-plugin-tests-with-security": "yarn cypress:run-with-security --spec 'cypress/integration/plugins/*/*.js'"
   },


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

The output is in garbled status. https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/1.3.0/1484/linux/x64/test-results/b94f426463b24046a2ed33c5be290508/integ-test/functionalTestDashboards/without-security/test-results/stdout.txt

### Issues Resolved

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
