### PR TITLE
Add workflow to run release tests every 3 hours

### DIFF
--- a/.github/workflows/release-signoff.yml
+++ b/.github/workflows/release-signoff.yml
@@ -1,4 +1,4 @@
-name: Release signoff for bundled OpenSearch Dashboards with Dashboards plugins
+name: Release signoff for bundled OpenSearch Dashboards with Dashboards plugins (x64)
 on:
   schedule:
     - cron: '0 */3 * * *'

--- a/.github/workflows/release-signoff.yml
+++ b/.github/workflows/release-signoff.yml
@@ -56,6 +56,10 @@ jobs:
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
         env:
           CYPRESS_INSTALL_BINARY: ${{ steps.cypress_version.outputs.cypress_version }}
+      - name: Run npm install
+        run: |
+          cd functional-test
+          npm install
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests

--- a/.github/workflows/release-signoff.yml
+++ b/.github/workflows/release-signoff.yml
@@ -1,4 +1,4 @@
-name: Release signoff for OpenSearch Dashboards and Dashboards plugins
+name: Release signoff for bundled OpenSearch Dashboards with Dashboards plugins
 on:
   schedule:
     - cron: '0 */3 * * *'

--- a/.github/workflows/release-signoff.yml
+++ b/.github/workflows/release-signoff.yml
@@ -1,0 +1,78 @@
+name: Release signoff for OpenSearch Dashboards
+on:
+  schedule:
+    - cron: '0 */3 * * *'
+env:
+  VERSION: '1.3.0'
+jobs:
+  tests:
+    name: Run Cypress E2E tests
+    runs-on: ubuntu-latest
+    env:
+      # prevents extra Cypress installation progress messages
+      CI: 1
+      # avoid warnings like "tput: No value for $TERM and no -T specified"
+      TERM: xterm
+    steps:
+      - name: Get and run OpenSearch
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          cd opensearch-${{ env.VERSION }}/
+          ./opensearch-tar-install.sh &
+          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+      - name: Get OpenSearch-Dashboards
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+      - name: Get node and yarn versions
+        id: versions
+        run: |
+          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")"
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.versions.outputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Run OpenSearch-Dashboards server
+        run: |
+          cd opensearch-dashboards-${{ env.VERSION }}
+          bin/opensearch-dashboards serve &
+          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+      - name: Checkout monterey-test
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}
+          path: monterey-test
+      - name: Get Cypress version
+        id: cypress_version
+        run: |
+          echo "::set-output name=cypress_version::$(cat ./monterey-test/package.json | jq '.devDependencies.cypress' | tr -d '"')"
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+        env:
+          CYPRESS_INSTALL_BINARY: ${{ steps.cypress_version.outputs.cypress_version }}
+      - run: npx cypress cache list
+      - run: npx cypress cache path
+      - name: Cypress tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: monterey-test
+          command: env TZ=America/Los_Angeles cypress run --browser chrome --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --spec 'cypress/integration/plugins/*/*.js'
+          wait-on: 'http://localhost:5601'
+      # Screenshots are only captured on failure, will change this once we do visual regression tests
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: monterey-test/cypress/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: cypress-videos
+          path: monterey-test/cypress/videos

--- a/.github/workflows/release-signoff.yml
+++ b/.github/workflows/release-signoff.yml
@@ -1,4 +1,4 @@
-name: Release signoff for OpenSearch Dashboards
+name: Release signoff for OpenSearch Dashboards and Dashboards plugins
 on:
   schedule:
     - cron: '0 */3 * * *'

--- a/.github/workflows/release-signoff.yml
+++ b/.github/workflows/release-signoff.yml
@@ -62,7 +62,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: monterey-test
-          command: env TZ=America/Los_Angeles cypress run --browser chrome --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --spec 'cypress/integration/plugins/*/*.js'
+          command: env TZ=America/Los_Angeles cypress run --browser chrome --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --spec ''cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*''
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/release-signoff.yml
+++ b/.github/workflows/release-signoff.yml
@@ -62,7 +62,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: monterey-test
-          command: env TZ=America/Los_Angeles cypress run --browser chrome --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --spec ''cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*''
+          command: env TZ=America/Los_Angeles cypress run --browser chrome --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/release-signoff.yml
+++ b/.github/workflows/release-signoff.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")"
+          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")"
       - name: Setup node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release-signoff.yml
+++ b/.github/workflows/release-signoff.yml
@@ -62,7 +62,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: functional-test
-          command: env TZ=America/Los_Angeles cypress run --browser chrome --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
+          command: yarn cypress:release
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/release-signoff.yml
+++ b/.github/workflows/release-signoff.yml
@@ -39,15 +39,15 @@ jobs:
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
           timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
-      - name: Checkout monterey-test
+      - name: Checkout functional-test
         uses: actions/checkout@v2
         with:
           repository: ${{github.repository}}
-          path: monterey-test
+          path: functional-test
       - name: Get Cypress version
         id: cypress_version
         run: |
-          echo "::set-output name=cypress_version::$(cat ./monterey-test/package.json | jq '.devDependencies.cypress' | tr -d '"')"
+          echo "::set-output name=cypress_version::$(cat ./functional-test/package.json | jq '.devDependencies.cypress' | tr -d '"')"
       - name: Cache Cypress
         id: cache-cypress
         uses: actions/cache@v1
@@ -61,7 +61,7 @@ jobs:
       - name: Cypress tests
         uses: cypress-io/github-action@v2
         with:
-          working-directory: monterey-test
+          working-directory: functional-test
           command: env TZ=America/Los_Angeles cypress run --browser chrome --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
@@ -69,10 +69,10 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: monterey-test/cypress/screenshots
+          path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v1
         if: always()
         with:
           name: cypress-videos
-          path: monterey-test/cypress/videos
+          path: functional-test/cypress/videos

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "cypress:run-with-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200",
     "cypress:run-plugin-tests-without-security": "yarn cypress:run-without-security --spec 'cypress/integration/plugins/*/*.js'",
     "cypress:run-plugin-tests-with-security": "yarn cypress:run-with-security --spec 'cypress/integration/plugins/*/*.js'",
-    "cypress:release": "yarn cypress:run-with-security --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'"
+    "cypress:release": "yarn cypress:run-with-security --browser chrome --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "cypress:run-without-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=false",
     "cypress:run-with-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200",
     "cypress:run-plugin-tests-without-security": "yarn cypress:run-without-security --spec 'cypress/integration/plugins/*/*.js'",
-    "cypress:run-plugin-tests-with-security": "yarn cypress:run-with-security --spec 'cypress/integration/plugins/*/*.js'"
+    "cypress:run-plugin-tests-with-security": "yarn cypress:run-with-security --spec 'cypress/integration/plugins/*/*.js'",
+    "cypress:release": "yarn cypress:run-with-security --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

This can serve as a sign off. Use browser chrome. Run every 3 hours. The host has x64 per https://github.com/actions/virtual-environments/blob/releases/ubuntu20/20220306/images/linux/Ubuntu2004-Readme.md There is no official support for ARM64 yet.

### Issues Resolved

Resolves https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/118

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
