### PR TITLE
add a workflow for tuning numTestsKeptInMemory 

### DIFF
--- a/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
@@ -1,7 +1,7 @@
 name: Release signoff for bundled OpenSearch Dashboards with Dashboards plugins (x64, Chromium, numTestsKeptInMemory=0)
 on:
   schedule:
-    - cron: '30 */3 * * *'
+    - cron: '20 */3 * * *'
 env:
   VERSION: '1.3.0'
 jobs:

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
@@ -1,0 +1,82 @@
+name: Release signoff for bundled OpenSearch Dashboards with Dashboards plugins (x64, Chromium, numTestsKeptInMemory=0)
+on:
+  schedule:
+    - cron: '30 */3 * * *'
+env:
+  VERSION: '1.3.0'
+jobs:
+  tests:
+    name: Run Cypress E2E tests
+    runs-on: ubuntu-latest
+    env:
+      # prevents extra Cypress installation progress messages
+      CI: 1
+      # avoid warnings like "tput: No value for $TERM and no -T specified"
+      TERM: xterm
+    steps:
+      - name: Get and run OpenSearch
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          cd opensearch-${{ env.VERSION }}/
+          ./opensearch-tar-install.sh &
+          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+      - name: Get OpenSearch-Dashboards
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+      - name: Get node and yarn versions
+        id: versions
+        run: |
+          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")"
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.versions.outputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Run OpenSearch-Dashboards server
+        run: |
+          cd opensearch-dashboards-${{ env.VERSION }}
+          bin/opensearch-dashboards serve &
+          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+      - name: Checkout functional-test
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}
+          path: functional-test
+      - name: Get Cypress version
+        id: cypress_version
+        run: |
+          echo "::set-output name=cypress_version::$(cat ./functional-test/package.json | jq '.devDependencies.cypress' | tr -d '"')"
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+        env:
+          CYPRESS_INSTALL_BINARY: ${{ steps.cypress_version.outputs.cypress_version }}
+      - name: Run npm install
+        run: |
+          cd functional-test
+          npm install
+      - run: npx cypress cache list
+      - run: npx cypress cache path
+      - name: Cypress tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: functional-test
+          command: yarn cypress:release-chromium-0
+          wait-on: 'http://localhost:5601'
+      # Screenshots are only captured on failure, will change this once we do visual regression tests
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: functional-test/cypress/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: cypress-videos
+          path: functional-test/cypress/videos

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
@@ -1,0 +1,82 @@
+name: Release signoff for bundled OpenSearch Dashboards with Dashboards plugins (x64, Chromium, numTestsKeptInMemory=10)
+on:
+  schedule:
+    - cron: '30 */3 * * *'
+env:
+  VERSION: '1.3.0'
+jobs:
+  tests:
+    name: Run Cypress E2E tests
+    runs-on: ubuntu-latest
+    env:
+      # prevents extra Cypress installation progress messages
+      CI: 1
+      # avoid warnings like "tput: No value for $TERM and no -T specified"
+      TERM: xterm
+    steps:
+      - name: Get and run OpenSearch
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          cd opensearch-${{ env.VERSION }}/
+          ./opensearch-tar-install.sh &
+          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+      - name: Get OpenSearch-Dashboards
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+      - name: Get node and yarn versions
+        id: versions
+        run: |
+          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")"
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.versions.outputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Run OpenSearch-Dashboards server
+        run: |
+          cd opensearch-dashboards-${{ env.VERSION }}
+          bin/opensearch-dashboards serve &
+          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+      - name: Checkout functional-test
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}
+          path: functional-test
+      - name: Get Cypress version
+        id: cypress_version
+        run: |
+          echo "::set-output name=cypress_version::$(cat ./functional-test/package.json | jq '.devDependencies.cypress' | tr -d '"')"
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+        env:
+          CYPRESS_INSTALL_BINARY: ${{ steps.cypress_version.outputs.cypress_version }}
+      - name: Run npm install
+        run: |
+          cd functional-test
+          npm install
+      - run: npx cypress cache list
+      - run: npx cypress cache path
+      - name: Cypress tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: functional-test
+          command: yarn cypress:release-chromium --numTestsKeptInMemory 10
+          wait-on: 'http://localhost:5601'
+      # Screenshots are only captured on failure, will change this once we do visual regression tests
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: functional-test/cypress/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: cypress-videos
+          path: functional-test/cypress/videos

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
@@ -66,7 +66,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: functional-test
-          command: env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --numTestsKeptInMemory 10 --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
+          command: yarn cypress:release-chromium-10
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
@@ -66,7 +66,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: functional-test
-          command: yarn cypress:release-chromium --numTestsKeptInMemory 10
+          command: env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --numTestsKeptInMemory 10 --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
@@ -66,7 +66,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: functional-test
-          command: env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --numTestsKeptInMemory 20 --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
+          command: yarn cypress:release-chromium-20
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
@@ -1,0 +1,82 @@
+name: Release signoff for bundled OpenSearch Dashboards with Dashboards plugins (x64, Chromium, numTestsKeptInMemory=20)
+on:
+  schedule:
+    - cron: '15 */3 * * *'
+env:
+  VERSION: '1.3.0'
+jobs:
+  tests:
+    name: Run Cypress E2E tests
+    runs-on: ubuntu-latest
+    env:
+      # prevents extra Cypress installation progress messages
+      CI: 1
+      # avoid warnings like "tput: No value for $TERM and no -T specified"
+      TERM: xterm
+    steps:
+      - name: Get and run OpenSearch
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          cd opensearch-${{ env.VERSION }}/
+          ./opensearch-tar-install.sh &
+          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+      - name: Get OpenSearch-Dashboards
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+      - name: Get node and yarn versions
+        id: versions
+        run: |
+          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")"
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.versions.outputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Run OpenSearch-Dashboards server
+        run: |
+          cd opensearch-dashboards-${{ env.VERSION }}
+          bin/opensearch-dashboards serve &
+          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+      - name: Checkout functional-test
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}
+          path: functional-test
+      - name: Get Cypress version
+        id: cypress_version
+        run: |
+          echo "::set-output name=cypress_version::$(cat ./functional-test/package.json | jq '.devDependencies.cypress' | tr -d '"')"
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+        env:
+          CYPRESS_INSTALL_BINARY: ${{ steps.cypress_version.outputs.cypress_version }}
+      - name: Run npm install
+        run: |
+          cd functional-test
+          npm install
+      - run: npx cypress cache list
+      - run: npx cypress cache path
+      - name: Cypress tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: functional-test
+          command: yarn cypress:release-chromium --numTestsKeptInMemory 20
+          wait-on: 'http://localhost:5601'
+      # Screenshots are only captured on failure, will change this once we do visual regression tests
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: functional-test/cypress/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: cypress-videos
+          path: functional-test/cypress/videos

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
@@ -66,7 +66,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: functional-test
-          command: yarn cypress:release-chromium --numTestsKeptInMemory 20
+          command: env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --numTestsKeptInMemory 20 --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
@@ -1,0 +1,82 @@
+name: Release signoff for bundled OpenSearch Dashboards with Dashboards plugins (x64, Chromium, numTestsKeptInMemory=5)
+on:
+  schedule:
+    - cron: '30 */3 * * *'
+env:
+  VERSION: '1.3.0'
+jobs:
+  tests:
+    name: Run Cypress E2E tests
+    runs-on: ubuntu-latest
+    env:
+      # prevents extra Cypress installation progress messages
+      CI: 1
+      # avoid warnings like "tput: No value for $TERM and no -T specified"
+      TERM: xterm
+    steps:
+      - name: Get and run OpenSearch
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          cd opensearch-${{ env.VERSION }}/
+          ./opensearch-tar-install.sh &
+          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+      - name: Get OpenSearch-Dashboards
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+          tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+      - name: Get node and yarn versions
+        id: versions
+        run: |
+          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")"
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.versions.outputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Run OpenSearch-Dashboards server
+        run: |
+          cd opensearch-dashboards-${{ env.VERSION }}
+          bin/opensearch-dashboards serve &
+          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+      - name: Checkout functional-test
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}
+          path: functional-test
+      - name: Get Cypress version
+        id: cypress_version
+        run: |
+          echo "::set-output name=cypress_version::$(cat ./functional-test/package.json | jq '.devDependencies.cypress' | tr -d '"')"
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+        env:
+          CYPRESS_INSTALL_BINARY: ${{ steps.cypress_version.outputs.cypress_version }}
+      - name: Run npm install
+        run: |
+          cd functional-test
+          npm install
+      - run: npx cypress cache list
+      - run: npx cypress cache path
+      - name: Cypress tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: functional-test
+          command: yarn cypress:release-chromium-5
+          wait-on: 'http://localhost:5601'
+      # Screenshots are only captured on failure, will change this once we do visual regression tests
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: functional-test/cypress/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: cypress-videos
+          path: functional-test/cypress/videos

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
@@ -1,7 +1,7 @@
 name: Release signoff for bundled OpenSearch Dashboards with Dashboards plugins (x64, Chromium, numTestsKeptInMemory=5)
 on:
   schedule:
-    - cron: '30 */3 * * *'
+    - cron: '35 */3 * * *'
 env:
   VERSION: '1.3.0'
 jobs:

--- a/cypress.json
+++ b/cypress.json
@@ -7,6 +7,7 @@
   "reporterOptions": {
     "configFile": "reporter-config.json"
   },
+  "numTestsKeptInMemory": 50,
   "viewportWidth": 2000,
   "viewportHeight": 1320,
   "env": {

--- a/cypress.json
+++ b/cypress.json
@@ -7,7 +7,6 @@
   "reporterOptions": {
     "configFile": "reporter-config.json"
   },
-  "numTestsKeptInMemory": 50,
   "viewportWidth": 2000,
   "viewportHeight": 1320,
   "env": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "cypress:release-chrome": "yarn cypress:run-with-security --browser chrome --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
     "cypress:release-electron": "yarn cypress:run-with-security --browser electron --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
     "cypress:release-chromium": "yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
-    "cypress:release-chromium-10": "yarn cypress:run-with-security --browser chromium --numTestsKeptInMemory 10 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
-    "cypress:release-chromium-20": "yarn cypress:run-with-security --browser chromium --numTestsKeptInMemory 20 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
+    "cypress:release-chromium-10": "yarn cypress:run-with-security --browser chromium --config numTestsKeptInMemory=10 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
+    "cypress:release-chromium-20": "yarn cypress:run-with-security --browser chromium --config numTestsKeptInMemory=20 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
     "cypress:release-firefox": "yarn cypress:run-with-security --browser firefox --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "cypress:release-chrome": "yarn cypress:run-with-security --browser chrome --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
     "cypress:release-electron": "yarn cypress:run-with-security --browser electron --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
     "cypress:release-chromium": "yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
+    "cypress:release-chromium-10": "yarn cypress:run-with-security --browser chromium --numTestsKeptInMemory 10 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
+    "cypress:release-chromium-20": "yarn cypress:run-with-security --browser chromium --numTestsKeptInMemory 20 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
     "cypress:release-firefox": "yarn cypress:run-with-security --browser firefox --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "cypress:release-chromium": "yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
     "cypress:release-chromium-10": "yarn cypress:run-with-security --browser chromium --config numTestsKeptInMemory=10 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
     "cypress:release-chromium-20": "yarn cypress:run-with-security --browser chromium --config numTestsKeptInMemory=20 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
+    "cypress:release-chromium-5": "yarn cypress:run-with-security --browser chromium --config numTestsKeptInMemory=5 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
+    "cypress:release-chromium-0": "yarn cypress:run-with-security --browser chromium --config numTestsKeptInMemory=0 --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'",
     "cypress:release-firefox": "yarn cypress:run-with-security --browser firefox --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'"
   },
   "repository": {


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

Tune parameter `numTestsKeptInMemory` https://docs.cypress.io/guides/references/configuration#Global By default is is 50

### Issues Resolved


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
