### PR TITLE
use browser chromium in integtest.sh

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -82,9 +82,9 @@ npm install
 if [ $SECURITY_ENABLED = "true" ]
 then
    echo "run security enabled tests"
-   yarn cypress:run-with-security --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
+   yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
 else
    echo "run security disabled tests"
-   yarn cypress:run-without-security --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
+   yarn cypress:run-without-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
 
 fi


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

The build repo has switched to use the latest Docker image with Chromium support. https://github.com/opensearch-project/opensearch-build/pull/1748 We expect to see more stable test results since the existing Electron browser installed along with Cypress 5.6.0 is quite old.


### Issues Resolved

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
