### PR TITLE
allow phased addition of dashboards plugins

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -79,12 +79,23 @@ fi
 
 npm install
 
+TEST_FILES='cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js'
+
+# TEST_FILES+=',cypress/integration/plugins/anomaly-detection-dashboards-plugin/*'
+# TEST_FILES+=',cypress/integration/plugins/gantt-chart-dashboards/*'
+# TEST_FILES+=',cypress/integration/plugins/alerting-dashboards-plugin/*'
+# TEST_FILES+=',cypress/integration/plugins/index-management-dashboards-plugin/*'
+# TEST_FILES+=',cypress/integration/plugins/observability-dashboards/*'
+# TEST_FILES+=',cypress/integration/plugins/query-workbench-dashboards/*'
+# TEST_FILES+=',cypress/integration/plugins/reports-dashboards/*'
+# TEST_FILES+=',cypress/integration/plugins/security/*'
+
 if [ $SECURITY_ENABLED = "true" ]
 then
    echo "run security enabled tests"
-   yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
+   yarn cypress:run-with-security --browser chromium --spec $TEST_FILES
 else
    echo "run security disabled tests"
-   yarn cypress:run-without-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js,cypress/integration/plugins/*/*'
+   yarn cypress:run-without-security --browser chromium --spec $TEST_FILES
 
 fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-dashboards-functional-test",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Maintains functional tests for OpenSearch Dashboards and Dashboards plugins",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

At the beginning of each release, the Dashboards plugins are added gradually. Thus allow the FTRepo to support such so that tests won't run all the plugins. Once one plugin is supported in the bundle, we can uncomment the corresponding test files.

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/84

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
