### PR TITLE
switch to use chromium browser

### DIFF
--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -72,7 +72,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: monterey-test
-          command: yarn cypress:run-with-security --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js'
+          command: yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js'
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/cypress-workflow-plugins-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-plugins-bundle-snapshot-based.yml
@@ -72,7 +72,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: monterey-test
-          command: yarn cypress:run-plugin-tests-with-security
+          command: yarn cypress:run-plugin-tests-with-security --browser chromium
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/cypress-workflow-vanilla-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-vanilla-snapshot-based.yml
@@ -72,7 +72,7 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           working-directory: monetery-test
-          command: yarn cypress:run-without-security --spec 'cypress/integration/core-opensearch-dashboards/vanilla-opensearch-dashboards/*.js'
+          command: yarn cypress:run-without-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/vanilla-opensearch-dashboards/*.js'
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

Update the PR workflows to use chromium since we have already done such for infra integration. https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/main/integtest.sh#L96

### Issues Resolved


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
