### PR TITLE
Clean up flaky failures in AD plugin

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_detector_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_detector_spec.js
@@ -80,14 +80,10 @@ context('Create detector workflow', () => {
     cy.getElementByTestId('featureTable').contains(TEST_FEATURE_NAME);
     cy.getElementByTestId('createDetectorButton').click();
 
-    // Clean up the created detector. Extract detector ID from the detector configuration page
-    cy.getElementByTestId('detectorIdCell').within(() => {
-      cy.get('.euiText--medium')
-        .invoke('text')
-        .then((detectorId) => {
-          cy.log('Deleting detector with ID: ' + detectorId);
-          cy.deleteDetector(detectorId);
-        });
-    });
+    // Lands on the config page by default. Delete the detector to clean up.
+    cy.getElementByTestId('actionsButton').click();
+    cy.getElementByTestId('deleteDetectorItem').click();
+    cy.getElementByTestId('typeDeleteField').type('delete', { force: true });
+    cy.getElementByTestId('confirmButton').click();
   });
 });


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

The logic to delete the detector in the create detector workflow test would occasionally fail, due to trying to delete it too soon after creation. Because of this failure to delete, it had cascading effects on other tests, where they were expecting empty pages / no detectors, but instead was displaying this test detector which failed to delete.

This fixes the logic in the deletion by utilizing the UI instead of making a direct API call, which provides the benefits of (1) more closely replicating how a user would interact with the plugin and (2) provides more time for the detector to be created, as the modal to delete won't be functional until the detector has been created and is available to delete.

Testing:
- Debugged failures by replicating in github runners and downloading the videos to confirm why they were failing
- Confirmed I could replicate all of the failures seen before in AD's remote integ test workflow
- Changed the AD remote integ test workflow (in a test branch) to point to this forked version of FTRepo to confirm the fix. Ran multiple times and cannot see any failures now (you can see all of the successful runs [here](https://github.com/ohltyler/anomaly-detection-dashboards-plugin-1/actions/runs/2031254251/attempts/1) by clicking through each of the attempts)

### Issues Resolved

Closes https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/211

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
