### PR TITLE
Fix one AD test

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/detector_list_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/detector_list_spec.js
@@ -114,6 +114,8 @@ describe('Detector list page', () => {
         cy.visit(AD_URL.DETECTOR_LIST);
       }
     );
+    cy.getElementByTestId('detectorListHeader').contains('(1)');
+    cy.getElementByTestId('detectorListTable').contains('stopped-detector');
     cy.getElementByTestId('createDetectorButton').click();
     cy.getElementByTestId('defineOrEditDetectorTitle').should('exist');
   });


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Fixes one AD test that is still occasionally failing on both Cypress 5.x and 9.x. Checks that the detector list page is in a certain state before trying to click a button.

Testing done:
- Replicated failure: [link](https://github.com/ohltyler/anomaly-detection-dashboards-plugin-1/runs/5669200562?check_suite_focus=true)
- Made the change and updated AD CI to temporarily point to the change. The change is reflected starting on attempt 3 onwards (running multiple times to confirm no failures): [link](https://github.com/ohltyler/anomaly-detection-dashboards-plugin-1/actions/runs/2036306657)

### Issues Resolved

Closes #147 

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
