### PR TITLE
Run against infra's docker image

### DIFF
--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -42,6 +42,7 @@ jobs:
           tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
       - name: Run OpenSearch-Dashboards server
         run: |
+          cd /usr/share/opensearch
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
           timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -45,7 +45,7 @@ jobs:
           cd /usr/share/opensearch
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ !("$(curl -s localhost:5601/api/status | grep -q 'green') ]]; do sleep 5; done'
       - name: Checkout cypress-test
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -32,19 +32,19 @@ jobs:
       - name: Switch user
         run: |
           echo 'switch user'
-          echo $USER
-          su opensearch
-          echo $USER
+          echo 'user is '$USER
+          sudo su opensearch
+          echo 'user is '$USER
       - name: Get and run OpenSearch
         run: |
-          echo $USER
+          echo 'user is '$USER
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/
           echo 'update user'
-          echo $USER
-          su opensearch
-          echo $USER
+          echo 'user is '$USER
+          sudo su opensearch
+          echo 'user is '$USER
           ./opensearch-tar-install.sh &
           timeout 100 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Get and run OpenSearch
         run: |
+          pwd
+          ls
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -19,17 +19,18 @@ jobs:
     runs-on: ubuntu-latest
     container: 
       image: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
+      options: --user root
     env:
       # prevents extra Cypress installation progress messages
       CI: 1
       # avoid warnings like "tput: No value for $TERM and no -T specified"
       TERM: xterm
     steps:
+      - name: Install JQ
+        run: |
+          yum install jq -y
       - name: Get and run OpenSearch
         run: |
-          pwd
-          ls
-          cd /usr/share/opensearch
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/
@@ -37,24 +38,22 @@ jobs:
           timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
         run: |
-          cd /usr/share/opensearch
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
       - name: Run OpenSearch-Dashboards server
         run: |
-          cd /usr/share/opensearch
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          sleep 60
+          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Checkout cypress-test
         uses: actions/checkout@v2
         with:
           repository: ${{github.repository}}
-          path: /usr/share/opensearch/cypress-test
+          path: cypress-test
       - name: Cypress tests
         uses: cypress-io/github-action@v2
         with:
-          working-directory: /usr/share/opensearch/cypress-test
+          working-directory: cypress-test
           command: ${{ inputs.test-command }}
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
@@ -62,16 +61,16 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: /usr/share/opensearch/cypress-test/cypress/screenshots
+          path: cypress-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v1
         if: always()
         with:
           name: cypress-videos
-          path: /usr/share/opensearch/cypress-test/cypress/videos
+          path: cypress-test/cypress/videos
       # Test reports was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v1
         if: always()
         with:
           name: cypress-results
-          path: /usr/share/opensearch/cypress-test/cypress/results
+          path: cypress-test/cypress/results

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -27,14 +27,14 @@ jobs:
     steps:
       - name: Get and run OpenSearch
         run: |
-          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          curl -fsSL https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/
           ./opensearch-tar-install.sh &
           timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
         run: |
-          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+          curl -fsSL https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
       - name: Run OpenSearch-Dashboards server
         run: |

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -31,8 +31,8 @@ jobs:
           yum install jq -y
       - name: Switch user
         run: |
-          adduser -c "User" integ-test
-          su integ-test          
+          # adduser -c "User" integ-test
+          su opensearch
       - name: Get and run OpenSearch
         run: |
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -31,13 +31,18 @@ jobs:
           yum install jq -y
       - name: Switch user
         run: |
-          # adduser -c "User" integ-test
+          echo $USER
           su opensearch
+          echo $USER
       - name: Get and run OpenSearch
         run: |
+          echo $USER
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/
+          echo $USER
+          su opensearch
+          echo $USER
           ./opensearch-tar-install.sh &
           timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
@@ -47,6 +52,10 @@ jobs:
       - name: Run OpenSearch-Dashboards server
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
+          echo $USER
+          su opensearch
+          echo $USER
+
           bin/opensearch-dashboards serve &
           timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Checkout cypress-test

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           pwd
           ls
+          cd /usr/share/opensearch
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -45,7 +45,7 @@ jobs:
           cd /usr/share/opensearch
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ ! $(curl -s localhost:5601/api/status | grep -q 'green') ]]; do sleep 5; done'
+          sleep 60
       - name: Checkout cypress-test
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     container: 
       image: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
+      options: --user root
     env:
       # prevents extra Cypress installation progress messages
       CI: 1
@@ -35,7 +36,7 @@ jobs:
           echo 'switch user'
           echo 'user is '$USER
           whoami
-          su opensearch
+          su - opensearch
           echo 'user is '$USER
           whoami
       - name: Get and run OpenSearch
@@ -47,7 +48,7 @@ jobs:
           echo 'update user'
           echo 'user is '$USER
           whoami
-          su opensearch
+          su - opensearch
           whoami
           echo 'user is '$USER
           ./opensearch-tar-install.sh &
@@ -60,7 +61,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           echo $USER
-          su opensearch
+          su - opensearch
           echo $USER
 
           bin/opensearch-dashboards serve &

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -45,7 +45,7 @@ jobs:
           cd /usr/share/opensearch
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ !("$(curl -s localhost:5601/api/status | grep -q 'green') ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ ! $(curl -s localhost:5601/api/status | grep -q 'green') ]]; do sleep 5; done'
       - name: Checkout cypress-test
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -48,7 +48,7 @@ jobs:
           echo 'update user'
           echo 'user is '$USER
           whoami
-          su - opensearch
+          su - opensearch -s /bin/sh
           whoami
           echo 'user is '$USER
           ./opensearch-tar-install.sh &

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     container: 
       image: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
-      options: --user root
+      # options: --user root
     env:
       # prevents extra Cypress installation progress messages
       CI: 1
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Install JQ
         run: |
-          yum install jq -y
+          sudo yum install jq -y
       - name: Get and run OpenSearch
         run: |
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -29,9 +29,10 @@ jobs:
       - name: Install JQ
         run: |
           yum install jq -y
-      - name: Exit root
+      - name: Switch user
         run: |
-          exit          
+          adduser --disabled-password --shell /bin/bash --gecos "User" integ-test
+          su integ-test          
       - name: Get and run OpenSearch
         run: |
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -25,10 +25,6 @@ jobs:
       # avoid warnings like "tput: No value for $TERM and no -T specified"
       TERM: xterm
     steps:
-      - name: Set up JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 14
       - name: Get and run OpenSearch
         run: |
           wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
@@ -40,15 +36,6 @@ jobs:
         run: |
           wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
-      - name: Get node and yarn versions
-        id: versions
-        run: |
-          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")"
-      - name: Setup node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ steps.versions.outputs.node_version }}
-          registry-url: 'https://registry.npmjs.org'
       - name: Run OpenSearch-Dashboards server
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -36,7 +36,7 @@ jobs:
           echo 'switch user'
           echo 'user is '$USER
           whoami
-          su - opensearch
+          su - opensearch -s /bin/sh
           echo 'user is '$USER
           whoami
       - name: Get and run OpenSearch

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -50,25 +50,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{github.repository}}
-          path: cypress-test
-      - name: Get Cypress version
-        id: cypress_version
-        run: |
-          echo "::set-output name=cypress_version::$(cat ./cypress-test/package.json | jq '.devDependencies.cypress' | tr -d '"')"
-      - name: Cache Cypress
-        id: cache-cypress
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/Cypress
-          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
-        env:
-          CYPRESS_INSTALL_BINARY: ${{ steps.cypress_version.outputs.cypress_version }}
-      - run: npx cypress cache list
-      - run: npx cypress cache path
+          path: /usr/share/opensearch/cypress-test
       - name: Cypress tests
         uses: cypress-io/github-action@v2
         with:
-          working-directory: cypress-test
+          working-directory: /usr/share/opensearch/cypress-test
           command: ${{ inputs.test-command }}
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
@@ -76,16 +62,16 @@ jobs:
         if: failure()
         with:
           name: cypress-screenshots
-          path: cypress-test/cypress/screenshots
+          path: /usr/share/opensearch/cypress-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v1
         if: always()
         with:
           name: cypress-videos
-          path: cypress-test/cypress/videos
+          path: /usr/share/opensearch/cypress-test/cypress/videos
       # Test reports was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v1
         if: always()
         with:
           name: cypress-results
-          path: cypress-test/cypress/results
+          path: /usr/share/opensearch/cypress-test/cypress/results

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -17,6 +17,8 @@ jobs:
   tests:
     name: Run Cypress E2E tests for ${{ inputs.test-name }}
     runs-on: ubuntu-latest
+    container: 
+      image: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
     env:
       # prevents extra Cypress installation progress messages
       CI: 1

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     container: 
       image: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
-      # options: --user root
+      options: --user root
     env:
       # prevents extra Cypress installation progress messages
       CI: 1
@@ -28,7 +28,10 @@ jobs:
     steps:
       - name: Install JQ
         run: |
-          sudo yum install jq -y
+          yum install jq -y
+      - name: Exit root
+        run: |
+          exit          
       - name: Get and run OpenSearch
         run: |
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -37,6 +37,7 @@ jobs:
           timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
         run: |
+          cd /usr/share/opensearch
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
       - name: Run OpenSearch-Dashboards server

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -19,53 +19,40 @@ jobs:
     runs-on: ubuntu-latest
     container: 
       image: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
-      options: --user root
+      # options: --user root
     env:
       # prevents extra Cypress installation progress messages
       CI: 1
       # avoid warnings like "tput: No value for $TERM and no -T specified"
       TERM: xterm
     steps:
-      - name: Install JQ
-        run: |
-          echo 'user is '$USER
-          whoami
-          yum install jq -y
-      - name: Switch user
-        run: |
-          echo 'switch user'
-          echo 'user is '$USER
-          whoami
-          su - opensearch -s /bin/sh
-          echo 'user is '$USER
-          whoami
-      - name: Get and run OpenSearch
-        run: |
-          echo 'user is '$USER
-          curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
-          tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
-          cd opensearch-${{ env.VERSION }}/
-          echo 'update user'
-          echo 'user is '$USER
-          whoami
-          su - opensearch -s /bin/sh
-          whoami
-          echo 'user is '$USER
-          ./opensearch-tar-install.sh &
-          timeout 100 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
-      - name: Get OpenSearch-Dashboards
-        run: |
-          curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
-          tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
-      - name: Run OpenSearch-Dashboards server
-        run: |
-          cd opensearch-dashboards-${{ env.VERSION }}
-          echo $USER
-          su - opensearch
-          echo $USER
+      # - name: Get and run OpenSearch
+      #   run: |
+      #     echo 'user is '$USER
+      #     curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+      #     tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+      #     cd opensearch-${{ env.VERSION }}/
+      #     echo 'update user'
+      #     echo 'user is '$USER
+      #     whoami
+      #     su - opensearch -s /bin/sh
+      #     whoami
+      #     echo 'user is '$USER
+      #     ./opensearch-tar-install.sh &
+      #     timeout 100 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+      # - name: Get OpenSearch-Dashboards
+      #   run: |
+      #     curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+      #     tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+      # - name: Run OpenSearch-Dashboards server
+      #   run: |
+      #     cd opensearch-dashboards-${{ env.VERSION }}
+      #     echo $USER
+      #     su - opensearch
+      #     echo $USER
 
-          bin/opensearch-dashboards serve &
-          timeout 100 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+      #     bin/opensearch-dashboards serve &
+      #     timeout 100 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Checkout cypress-test
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -31,7 +31,7 @@ jobs:
           yum install jq -y
       - name: Switch user
         run: |
-          adduser --disabled-password --shell /bin/bash --gecos "User" integ-test
+          adduser --gecos "User" integ-test
           su integ-test          
       - name: Get and run OpenSearch
         run: |

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -31,7 +31,7 @@ jobs:
           yum install jq -y
       - name: Switch user
         run: |
-          adduser --gecos "User" integ-test
+          adduser -c "User" integ-test
           su integ-test          
       - name: Get and run OpenSearch
         run: |

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -33,8 +33,10 @@ jobs:
         run: |
           echo 'switch user'
           echo 'user is '$USER
-          sudo su opensearch
+          whoami
+          su opensearch
           echo 'user is '$USER
+          whoami
       - name: Get and run OpenSearch
         run: |
           echo 'user is '$USER
@@ -43,7 +45,9 @@ jobs:
           cd opensearch-${{ env.VERSION }}/
           echo 'update user'
           echo 'user is '$USER
-          sudo su opensearch
+          whoami
+          su opensearch
+          whoami
           echo 'user is '$USER
           ./opensearch-tar-install.sh &
           timeout 100 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -44,7 +44,7 @@ jobs:
           su opensearch
           echo $USER
           ./opensearch-tar-install.sh &
-          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+          timeout 100 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
         run: |
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
@@ -57,7 +57,7 @@ jobs:
           echo $USER
 
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 100 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Checkout cypress-test
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     container: 
       image: opensearchstaging/ci-runner:ci-runner-rockylinux8-opensearch-dashboards-integtest-v1
-      options: --user root
     env:
       # prevents extra Cypress installation progress messages
       CI: 1
@@ -28,6 +27,8 @@ jobs:
     steps:
       - name: Install JQ
         run: |
+          echo 'user is '$USER
+          whoami
           yum install jq -y
       - name: Switch user
         run: |

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -27,14 +27,14 @@ jobs:
     steps:
       - name: Get and run OpenSearch
         run: |
-          curl -fsSL https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
+          curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/
           ./opensearch-tar-install.sh &
           timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
       - name: Get OpenSearch-Dashboards
         run: |
-          curl -fsSL https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+          curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
       - name: Run OpenSearch-Dashboards server
         run: |

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -31,6 +31,7 @@ jobs:
           yum install jq -y
       - name: Switch user
         run: |
+          echo 'switch user'
           echo $USER
           su opensearch
           echo $USER
@@ -40,6 +41,7 @@ jobs:
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/
+          echo 'update user'
           echo $USER
           su opensearch
           echo $USER


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

Currently the tests are running inside Github hosted Ubtuntu directly. This is different from where they run in infra https://github.com/opensearch-project/opensearch-build/blob/main/manifests/1.3.0/opensearch-dashboards-1.3.0-test.yml#L6

To bring parity, make the Github actions run against the test docker image as well.


### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/120

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
