### PR TITLE
Fix reports downloading flaky test

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/04-download.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/04-download.spec.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/// <reference types="cypress" />
+
 import { WAIT_TIME, BASE_PATH } from '../../../utils/constants';
 
 describe('Cypress', () => {
@@ -27,7 +29,7 @@ describe('Cypress', () => {
     );
 
     cy.wait(12500);
-    cy.get('#landingPageOnDemandDownload').click({ force: true });
+    cy.get('[id="landingPageOnDemandDownload"]').contains('PDF').click({ force: true });
     cy.get('body').then($body => {
       if ($body.find('#downloadInProgressLoadingModal').length > 0) {
         return;


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description

By default this test clicks on the first report, which is CSV and its model disappears instantly. Changing it to PDF to give more time for cypress to capture the downloading model. 

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
