### PR TITLE
[CI] build TEST_FILES for CI based on build manifest

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+. ./test_finder.sh
+
 function usage() {
     echo ""
     echo "This script is used to run integration tests for plugin installed on a remote OpenSearch/Dashboards cluster."
@@ -77,25 +79,21 @@ then
   PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
 
+TEST_FILES=$(get_test_list)
+
 npm install
 
-TEST_FILES='cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js'
-
-# TEST_FILES+=',cypress/integration/plugins/anomaly-detection-dashboards-plugin/*'
-# TEST_FILES+=',cypress/integration/plugins/gantt-chart-dashboards/*'
-# TEST_FILES+=',cypress/integration/plugins/alerting-dashboards-plugin/*'
-# TEST_FILES+=',cypress/integration/plugins/index-management-dashboards-plugin/*'
-# TEST_FILES+=',cypress/integration/plugins/observability-dashboards/*'
-# TEST_FILES+=',cypress/integration/plugins/query-workbench-dashboards/*'
-# TEST_FILES+=',cypress/integration/plugins/reports-dashboards/*'
-# TEST_FILES+=',cypress/integration/plugins/security/*'
-
+## WARNING: THIS LOGIC NEEDS TO BE THE LAST IN THIS FILE! ##
+# Cypress returns back the test failure count in the error code
+# The CI outputs the error code as test failure count.
+#
+# We need to ensure the cypress tests are the last execute process to
+# the error code gets passed to the CI.
 if [ $SECURITY_ENABLED = "true" ]
 then
    echo "run security enabled tests"
-   yarn cypress:run-with-security --browser chromium --spec $TEST_FILES
+   yarn cypress:run-with-security --browser chromium --spec "$TEST_FILES"
 else
    echo "run security disabled tests"
-   yarn cypress:run-without-security --browser chromium --spec $TEST_FILES
-
+   yarn cypress:run-without-security --browser chromium --spec "$TEST_FILES"
 fi

--- a/integtest.sh
+++ b/integtest.sh
@@ -79,9 +79,9 @@ then
   PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
 
-TEST_FILES=$(get_test_list)
-
 npm install
+
+TEST_FILES=$(get_test_list)
 
 ## WARNING: THIS LOGIC NEEDS TO BE THE LAST IN THIS FILE! ##
 # Cypress returns back the test failure count in the error code

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+OSD_BUILD_MANIFEST='../local-test-cluster/opensearch-dashboards-*/manifest.yml'
+OSD_TEST_PATH='cypress/integration/core-opensearch-dashboards'
+OSD_PLUGIN_TEST_PATH='cypress/integration/plugins'
+
+# Checks if build manifest in parent directory of current directory under local-test-cluster/opensearch-dashboards-*
+# When the test script executed in the CI, it scales up OpenSearch Dashboards under local-test-cluster with a 
+# manifest that contains the existing components.
+#
+# If the build manifest exists in the expected path then we can read the components to execute component tests if the
+# component exists. If the build manifest does not exist then we can just use a default list of tests.
+function get_test_list() {
+    [ -f $OSD_MANIFEST_PATH ] && generate_test_list_from_build_manifest || generate_test_list
+}
+
+function generate_test_list() {
+    DEFAULT_TEST_FILES="$OSD_TEST_PATH/opensearch-dashboards/*.js"
+    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/alerting-dashboards-plugin/*"
+    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/anomaly-detection-dashboards-plugin/*"
+    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/gantt-chart-dashboards/*"
+    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/index-management-dashboards-plugin/*"
+    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/observability-dashboards/*"
+    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/query-workbench-dashboards/*"
+    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/reports-dashboards/*"
+    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/security/*"
+
+    echo "$DEFAULT_TEST_FILES"
+}
+
+function generate_test_list_from_build_manifest() {
+    MANIFEST_TEST_FILES="$OSD_TEST_PATH/opensearch-dashboards/*.js"
+
+    grep -q 'alertingDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/alerting-dashboards-plugin/*" || true
+    grep -q 'anomalyDetectionDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/anomaly-detection-dashboards-plugin/*" || true
+    grep -q 'ganttChartDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/gantt-chart-dashboards/*" || true
+    grep -q 'indexManagementDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/index-management-dashboards-plugin/*" || true
+    grep -q 'observabilityDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/observability-dashboards/*" || true
+    grep -q 'queryWorkbenchDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/query-workbench-dashboards/*" || true
+    grep -q 'reportsDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/reports-dashboards/*" || true
+    grep -q 'securityDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/security/*" || true
+
+    echo "$MANIFEST_TEST_FILES"
+}


### PR DESCRIPTION
### Description
Within the CI, we know the location of the build manifest of
the OpenSearch Dashboards that got scaled up in prep for the
execution of these tests within this repo.

We can use that knowledge to determine the set of tests that
are valid against the distribution that this repo is being
executed on.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Alternative to: 
https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/153

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
