### PR TITLE
[Docs] backport port process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,6 +260,7 @@ We deeply appreciate everyone who takes the time to make a contribution. We will
 
 During the PR process, expect that there will be some back-and-forth. Please try to respond to comments in a timely fashion, and if you don't wish to continue with the PR, let us know. If a PR takes too many iterations for its complexity or size, we may reject it. Additionally, if you stop responding we may close the PR as abandoned. In either case, if you feel this was done in error, please add a comment on the PR.
 
-If we accept the PR, a [maintainer](MAINTAINERS.md) will merge your change and usually take care of backporting it to appropriate branches ourselves.
+If we accept the PR, a [maintainer](MAINTAINERS.md) will merge your change and usually take care of backporting it to appropriate branches ourselves. For the backporting process, once the PR is merged a [maintainer](MAINTAINERS.md) will label it with the appropriate target branch then the backport workflow will do the rest. For example, the label `backport 1.x` label will be added to the PR that is to be backported to `1.x`. The backport branches are named in the form `backport/backport-<original PR number>-to-<base>`. These branches will be cleaned up by an auto delete workflow once the backport PR is merged.
+
 
 If we reject the PR, we will close the pull request with a comment explaining why. This decision isn't always final: if you feel we have misunderstood your intended change or otherwise think that we should reconsider then please continue the conversation with a comment on the PR and we'll do our best to address any further points you raise.


### PR DESCRIPTION
### Description

Update CONTRIBUTING to include information for maintainers
on how to backport.

Issue resolved:
https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/160

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/160

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
