### PR TITLE
[ISM] show all rows for test

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
@@ -75,6 +75,9 @@ describe('Indices', () => {
     });
 
     it('successfully', () => {
+      cy.get('[data-test-subj="tablePaginationPopoverButton"]').click();
+      cy.get('.euiContextMenuItem__text').contains('50 rows').click();
+
       // Confirm that the regular indices are shown.
       cy.contains('index-1');
       cy.contains('index-2');


### PR DESCRIPTION
### Description

When all the suites run together. There might an issue
with cleanup and the expected amount of rows on this page.
Which would cause this test to be "flakey"

Here we ensure the largest amount of rows are shown because
within the test run the expected data stream index might be
on the next row if there are 20 plus indices.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
