### PR TITLE
Fix AD historical analysis integ test

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/historical_analysis_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/historical_analysis_spec.js
@@ -106,19 +106,20 @@ context('Historical results page', () => {
       cy.get(`[aria-label="Next time window"]`).click();
       cy.contains('Refresh').click();
       verifyNoAnomaliesInCharts();
-
-      cy.getElementByTestId('superDatePickerToggleQuickMenuButton').click();
+      
       cy.get(`[aria-label="Previous time window"]`).click();
       cy.contains('Refresh').click();
       verifyAnomaliesInCharts();
     });
 
     it('Aggregations render anomalies', () => {
-      cy.get(`[aria-label="Daily max"]`).click();
+      cy.contains('Refresh').click();
+      cy.wait(2000);
+      cy.get(`[title="Daily max"]`).click();
       verifyAnomaliesInCharts();
-      cy.get(`[aria-label="Weekly max"]`).click();
+      cy.get(`[title="Weekly max"]`).click();
       verifyAnomaliesInCharts();
-      cy.get(`[aria-label="Monthly max"]`).click();
+      cy.get(`[title="Monthly max"]`).click();
       verifyAnomaliesInCharts();
     });
 

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/historical_analysis_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/historical_analysis_spec.js
@@ -107,6 +107,7 @@ context('Historical results page', () => {
       cy.contains('Refresh').click();
       verifyNoAnomaliesInCharts();
       
+      cy.getElementByTestId('superDatePickerToggleQuickMenuButton').click();
       cy.get(`[aria-label="Previous time window"]`).click();
       cy.contains('Refresh').click();
       verifyAnomaliesInCharts();


### PR DESCRIPTION
Signed-off-by: Amit Galitzky <amgalitz@amazon.com>

### Description

Changed AD historical test to get HTML element by `title` instead of `aria-label`. The aria-label doesn't show up in the markdown since 2.0 bump. I will continue investigating adding aria-label back but for now tests shouldn't need to fail cause of this. Also added a refresh click before this test is executed to decrease flakiness.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
