### PR TITLE
[Notifications] onboard sanity tests for notifications plugin

### DIFF
--- a/.github/workflows/notifications-release-e2e-workflow.yml
+++ b/.github/workflows/notifications-release-e2e-workflow.yml
@@ -1,0 +1,13 @@
+name: Notifications Release tests workflow in Bundled OpenSearch Dashboards
+on:
+  pull_request:
+    branches:
+      - main
+      - dev-*
+jobs:
+  tests:
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Notifications
+      test-command: yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/notifications-dashboards/*'
+      version: 2.0.0-rc1

--- a/cypress/integration/plugins/notifications-dashboards/channels.spec.js
+++ b/cypress/integration/plugins/notifications-dashboards/channels.spec.js
@@ -1,0 +1,275 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="cypress" />
+
+import { delay, NOTIFICATIONS_PLUGIN_NAME } from '../../../utils/plugins/notifications-dashboards/constants';
+import { BASE_PATH } from "../../../utils/base_constants";
+
+describe('Test create channels', () => {
+  beforeEach(() => {
+    cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#create-channel`);
+    cy.wait(delay * 3);
+  });
+
+  it('creates a slack channel and send test message', () => {
+    cy.get('[data-test-subj="create-channel-create-button"]').click();
+    cy.contains('Some fields are invalid.').should('exist');
+
+    cy.get('[placeholder="Enter channel name"]').type('Test slack channel');
+    cy.get('.euiCheckbox__input[id="alerting"]').click({ force: true });
+    cy.get('[data-test-subj="create-channel-slack-webhook-input"]').type(
+      'https://sample-slack-webhook'
+    );
+    cy.wait(delay);
+    cy.get('[data-test-subj="create-channel-send-test-message-button"]').click({
+      force: true,
+    });
+    cy.wait(delay);
+    // This needs some time to appear as it will wait for backend call to timeout
+    cy.contains('test message.').should('exist');
+
+    cy.get('[data-test-subj="create-channel-create-button"]').click({
+      force: true,
+    });
+    cy.contains('successfully created.').should('exist');
+  });
+
+  it('creates a chime channel', () => {
+    cy.get('[placeholder="Enter channel name"]').type('Test chime channel');
+    cy.get('.euiCheckbox__input[id="reports"]').click({ force: true });
+
+    cy.get('.euiSuperSelectControl').contains('Slack').click({ force: true });
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text')
+      .contains('Chime')
+      .click({ force: true });
+    cy.wait(delay);
+
+    cy.get('[data-test-subj="create-channel-chime-webhook-input"]').type(
+      'https://sample-chime-webhook'
+    );
+    cy.wait(delay);
+
+    cy.get('[data-test-subj="create-channel-create-button"]').click();
+    cy.contains('successfully created.').should('exist');
+  });
+
+  it('creates a email channel', () => {
+    cy.get('[placeholder="Enter channel name"]').type('Test email channel');
+    cy.get('.euiCheckbox__input[id="reports"]').click({ force: true });
+
+    cy.get('.euiSuperSelectControl').contains('Slack').click({ force: true });
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text')
+      .contains('Email')
+      .click({ force: true });
+    cy.wait(delay);
+
+    // custom data-test-subj does not work on combo box
+    cy.get('[data-test-subj="comboBoxInput"]').eq(0).click({ force: true });
+    cy.contains('test-tls-sender').click();
+
+    cy.get('.euiButton__text')
+      .contains('Create recipient group')
+      .click({ force: true });
+    cy.get('[data-test-subj="create-recipient-group-form-name-input"]').type(
+      'Test recipient group'
+    );
+    cy.get(
+      '[data-test-subj="create-recipient-group-form-description-input"]'
+    ).type('Recipient group created while creating email channel.');
+    cy.get('[data-test-subj="comboBoxInput"]')
+      .last()
+      .type('custom.email@test.com{enter}');
+    cy.wait(delay);
+    cy.get(
+      '[data-test-subj="create-recipient-group-modal-create-button"]'
+    ).click();
+    cy.contains('successfully created.').should('exist');
+
+    cy.get('[data-test-subj="create-channel-create-button"]').click();
+    cy.contains('successfully created.').should('exist');
+  });
+
+  it('creates a email channel with ses sender', () => {
+    cy.get('[placeholder="Enter channel name"]').type('Test email channel with ses');
+    cy.get('.euiCheckbox__input[id="reports"]').click({ force: true });
+
+    cy.get('.euiSuperSelectControl').contains('Slack').click({ force: true });
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text')
+      .contains('Email')
+      .click({ force: true });
+    cy.wait(delay);
+    
+    cy.get('input.euiRadio__input#ses_account').click({ force: true });
+    cy.wait(delay);
+
+    cy.get('.euiButton__text')
+      .contains('Create SES sender')
+      .click({ force: true });
+    cy.get('[data-test-subj="create-ses-sender-form-name-input"]').type(
+      'test-ses-sender'
+    );
+    cy.get('[data-test-subj="create-ses-sender-form-email-input"]').type(
+      'test@email.com'
+    );
+    cy.get('[data-test-subj="create-ses-sender-form-role-arn-input"]').type(
+      'arn:aws:iam::012345678912:role/NotificationsSESRole'
+    );
+    cy.get('[data-test-subj="create-ses-sender-form-aws-region-input"]').type(
+      'us-east-1'
+    );
+    cy.get(
+      '[data-test-subj="create-ses-sender-modal-create-button"]'
+    ).click();
+    cy.contains('successfully created.').should('exist');
+
+    // custom data-test-subj does not work on combo box
+    cy.get('[data-test-subj="comboBoxInput"]').eq(1).click({ force: true });
+    cy.contains('Test recipient group').click();
+    cy.wait(delay);
+
+    cy.get('[data-test-subj="create-channel-create-button"]').click();
+    cy.contains('successfully created.').should('exist');
+  });
+
+  it('creates a webhook channel', () => {
+    cy.get('[placeholder="Enter channel name"]').type('Test webhook channel');
+    cy.get('.euiCheckbox__input[id="reports"]').click({ force: true });
+
+    cy.get('.euiSuperSelectControl').contains('Slack').click({ force: true });
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text')
+      .contains('Custom webhook')
+      .click({ force: true });
+    cy.wait(delay);
+
+    cy.get('[data-test-subj="custom-webhook-url-input"]').type(
+      'https://custom-webhook-test-url.com:8888/test-path?params1=value1&params2=value2&params3=value3&params4=value4&params5=values5&params6=values6&params7=values7'
+    );
+
+    cy.get('[data-test-subj="create-channel-create-button"]').click();
+    cy.contains('successfully created.').should('exist');
+  });
+
+  it('creates a sns channel', () => {
+    cy.get('[placeholder="Enter channel name"]').type('test-sns-channel');
+    cy.get('.euiCheckbox__input[id="reports"]').click({ force: true });
+
+    cy.get('.euiSuperSelectControl').contains('Slack').click({ force: true });
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text')
+      .contains('Amazon SNS')
+      .click({ force: true });
+    cy.wait(delay);
+
+    cy.get('[data-test-subj="sns-settings-topic-arn-input"]').type(
+      'arn:aws:sns:us-west-2:123456789012:notifications-test'
+    );
+    cy.get('[data-test-subj="sns-settings-role-arn-input"]').type(
+      'arn:aws:iam::012345678901:role/NotificationsSNSRole'
+    );
+
+    cy.get('[data-test-subj="create-channel-create-button"]').click();
+    cy.contains('successfully created.').should('exist');
+  });
+});
+
+describe('Test channels table', () => {
+  beforeEach(() => {
+    cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#channels`);
+    cy.wait(delay * 3);
+  });
+
+  it('displays channels', async () => {
+    cy.contains('Test slack channel').should('exist');
+    cy.contains('Test email channel').should('exist');
+    cy.contains('Test chime channel').should('exist');
+    cy.contains('Test webhook channel').should('exist');
+  });
+
+  it('mutes channels', async () => {
+    cy.get('.euiCheckbox__input[aria-label="Select this row"]').eq(0).click(); // chime channel
+    cy.get('.euiButton__text').contains('Actions').click({ force: true });
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text').contains('Mute').click({ force: true });
+    cy.wait(delay);
+    cy.get('[data-test-subj="mute-channel-modal-mute-button"]').click({
+      force: true,
+    });
+    cy.wait(delay);
+    cy.contains('successfully muted.').should('exist');
+    cy.contains('Muted').should('exist');
+  });
+
+  it('filters channels', async () => {
+    cy.get('input[placeholder="Search"]').type('chime{enter}');
+    cy.wait(delay);
+    cy.contains('Test chime channel').should('exist');
+    cy.contains('Test slack channel').should('not.exist');
+    cy.contains('Test email channel').should('not.exist');
+    cy.contains('Test webhook channel').should('not.exist');
+
+    cy.get('.euiButtonEmpty__text').contains('Source').click({ force: true });
+    cy.get('.euiFilterSelectItem__content')
+      .contains('ISM')
+      .click({ force: true });
+    cy.wait(delay);
+    cy.contains('No channels to display').should('exist');
+  });
+});
+
+describe('Test channel details', () => {
+  beforeEach(() => {
+    cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#channels`);
+    cy.contains('Test webhook channel').click();
+  });
+
+  it('displays channel details', async () => {
+    cy.contains('custom-webhook-test-url.com').should('exist');
+    cy.contains('test-path').should('exist');
+    cy.contains('8888').should('exist');
+    cy.contains('2 more').click();
+    cy.contains('Query parameters (7)').should('exist');
+    cy.contains('params7').should('exist');
+  });
+
+  it('mutes and unmutes channels', async () => {
+    cy.contains('Mute channel').click({ force: true });
+    cy.get('[data-test-subj="mute-channel-modal-mute-button"]').click({
+      force: true,
+    });
+    cy.contains('successfully muted.').should('exist');
+    cy.contains('Muted').should('exist');
+
+    cy.contains('Unmute channel').click({ force: true });
+    cy.contains('successfully unmuted.').should('exist');
+    cy.contains('Active').should('exist');
+  });
+  
+  it('edits channels', () => {
+    cy.contains('Actions').click({ force: true });
+    cy.contains('Edit').click({ force: true });
+    cy.contains('Edit channel').should('exist');
+    cy.get('.euiText').contains('Custom webhook').should('exist');
+    cy.get('.euiCheckbox__input[id="alerting"]').click({ force: true });
+    cy.wait(delay);
+    cy.contains('Save').click({ force: true });
+
+    cy.contains('successfully updated.').should('exist');
+    cy.contains('Alerting').should('exist');
+  })
+
+  it('deletes channels', async () => {
+    cy.contains('Actions').click({ force: true });
+    cy.contains('Delete').click({ force: true });
+    cy.get('input[placeholder="delete"]').type('delete');
+    cy.get('[data-test-subj="delete-channel-modal-delete-button"]').click({force: true})
+    cy.contains('successfully deleted.').should('exist');
+    cy.contains('Test slack channel').should('exist');
+  })
+});

--- a/cypress/integration/plugins/notifications-dashboards/dashboard.spec.js
+++ b/cypress/integration/plugins/notifications-dashboards/dashboard.spec.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="cypress" />
+
+import { delay, NOTIFICATIONS_PLUGIN_NAME } from '../../../utils/plugins/notifications-dashboards/constants';
+
+describe('Test dashboard', () => {
+  beforeEach(() => {
+    cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#notifications`);
+    cy.wait(delay * 3);
+  });
+  
+  it('shows notifications flyout', async () => {
+    cy.contains('[alerting]').click()
+    cy.contains('Channels sent').should('exist');
+    cy.contains('temp-Test slack channel').should('exist');
+  })
+})

--- a/cypress/integration/plugins/notifications-dashboards/email_groups.spec.js
+++ b/cypress/integration/plugins/notifications-dashboards/email_groups.spec.js
@@ -1,0 +1,219 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="cypress" />
+
+import { delay, NOTIFICATIONS_PLUGIN_NAME } from '../../../utils/plugins/notifications-dashboards/constants';
+
+describe('Test create email senders', () => {
+  beforeEach(() => {
+    cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#email-senders`);
+    cy.wait(delay * 3);
+  });
+
+  it('creates ssl sender', () => {
+    cy.get('.euiButton__text')
+      .contains('Create SMTP sender')
+      .click({ force: true });
+    cy.get('[data-test-subj="create-sender-form-name-input"]').type(
+      'test-ssl-sender'
+    );
+    cy.get('.euiButton__text').contains('Create').click({ force: true });
+    cy.contains('Some fields are invalid.').should('exist');
+
+    cy.get('[data-test-subj="create-sender-form-email-input"]').type(
+      'test@email.com'
+    );
+    cy.get('[data-test-subj="create-sender-form-host-input"]').type(
+      'test-host.com'
+    );
+    cy.get('[data-test-subj="create-sender-form-port-input"]').type('123');
+    cy.get('.euiButton__text').contains('Create').click({ force: true });
+    cy.contains('successfully created.').should('exist');
+    cy.contains('test-ssl-sender').should('exist');
+  });
+
+  it('creates tls sender', () => {
+    cy.get('.euiButton__text')
+      .contains('Create SMTP sender')
+      .click({ force: true });
+    cy.get('[data-test-subj="create-sender-form-name-input"]').type(
+      'test-tls-sender'
+    );
+    cy.get('[data-test-subj="create-sender-form-email-input"]').type(
+      'test@email.com'
+    );
+    cy.get('[data-test-subj="create-sender-form-host-input"]').type(
+      'test-host.com'
+    );
+    cy.get('[data-test-subj="create-sender-form-port-input"]').type('123');
+    cy.get('[data-test-subj="create-sender-form-encryption-input"]').click({
+      force: true,
+    });
+    cy.wait(delay);
+    cy.get('.euiContextMenuItem__text').contains('TLS').click({ force: true });
+    cy.wait(delay);
+
+    cy.get('.euiButton__text').contains('Create').click({ force: true });
+    cy.contains('successfully created.').should('exist');
+    cy.contains('test-ssl-sender').should('exist');
+  });
+
+  it('creates SES sender', () => {
+    cy.get('.euiButton__text')
+      .contains('Create SES sender')
+      .click({ force: true });
+    cy.get('[data-test-subj="create-ses-sender-form-name-input"]').type(
+      'test-ses-sender'
+    );
+    cy.get('[data-test-subj="create-ses-sender-form-email-input"]').type(
+      'test@email.com'
+    );
+    cy.get('[data-test-subj="create-ses-sender-form-role-arn-input"]').type(
+      'arn:aws:iam::012345678912:role/NotificationsSESRole'
+    );
+    cy.get('[data-test-subj="create-ses-sender-form-aws-region-input"]').type(
+      'us-east-1'
+    );
+
+    cy.get('.euiButton__text').contains('Create').click({ force: true });
+    cy.contains('successfully created.').should('exist');
+    cy.contains('test-ses-sender').should('exist');
+  });
+});
+
+describe('Test edit senders', () => {
+  beforeEach(() => {
+    cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#email-senders`);
+    cy.wait(delay * 3);
+  });
+
+  it('edits sender email address', () => {
+    cy.get('.euiCheckbox__input[aria-label="Select this row"]').eq(0).click(); // ssl sender
+    cy.get('[data-test-subj="senders-table-edit-button"]').click();
+    cy.get('[data-test-subj="create-sender-form-email-input"]').type(
+      '{selectall}{backspace}edited.test@email.com'
+    );
+    cy.wait(delay);
+
+    cy.get('.euiButton__text').contains('Save').click({ force: true });
+    cy.contains('successfully updated.').should('exist');
+  });
+
+  it('edits ses sender region', () => {
+    cy.get('.euiCheckbox__input[aria-label="Select this row"]').eq(2).click(); // ses sender
+    cy.get('[data-test-subj="ses-senders-table-edit-button"]').click();
+    cy.get('[data-test-subj="create-ses-sender-form-aws-region-input"]').type(
+      '{selectall}{backspace}us-west-2'
+    );
+    cy.wait(delay);
+
+    cy.get('.euiButton__text').contains('Save').click({ force: true });
+    cy.contains('successfully updated.').should('exist');
+  });
+});
+
+describe('Test delete senders', () => {
+  beforeEach(() => {
+    cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#email-senders`);
+    cy.wait(delay * 3);
+  });
+
+  it('deletes smtp senders', () => {
+    cy.get('.euiCheckbox__input[aria-label="Select this row"]').eq(0).click(); // ssl sender
+    cy.get('[data-test-subj="senders-table-delete-button"]').click();
+    cy.get('input[placeholder="delete"]').type('delete');
+    cy.wait(delay);
+    cy.get('[data-test-subj="delete-sender-modal-delete-button"]').click();
+    cy.contains('successfully deleted.').should('exist');
+  });
+
+  it('deletes ses senders', () => {
+    cy.get('.euiCheckbox__input[aria-label="Select this row"]').last().click(); // ses sender
+    cy.get('[data-test-subj="ses-senders-table-delete-button"]').click();
+    cy.get('input[placeholder="delete"]').type('delete');
+    cy.wait(delay);
+    cy.get('[data-test-subj="delete-sender-modal-delete-button"]').click();
+    cy.contains('successfully deleted.').should('exist');
+
+    cy.contains('No SES senders to display').should('exist');
+  });
+});
+
+describe('Test create, edit and delete recipient group', () => {
+  beforeEach(() => {
+    cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#email-recipient-groups`);
+    cy.wait(delay * 3);
+  });
+
+  it('creates recipient group', () => {
+    cy.get('.euiButton__text')
+      .contains('Create recipient group')
+      .click({ force: true });
+    cy.get('[data-test-subj="create-recipient-group-form-name-input"]').type(
+      'Test recipient group'
+    );
+    cy.get('.euiButton__text').contains('Create').click({ force: true });
+    cy.contains('Some fields are invalid.').should('exist');
+
+    cy.get(
+      '[data-test-subj="create-recipient-group-form-description-input"]'
+    ).type('Test group description');
+    cy.get('[data-test-subj="comboBoxInput"]').type(
+      'custom.email.1@test.com{enter}'
+    );
+    cy.get('[data-test-subj="comboBoxInput"]').type(
+      'custom.email.2@test.com{enter}'
+    );
+    cy.get('[data-test-subj="comboBoxInput"]').type(
+      'custom.email.3@test.com{enter}'
+    );
+    cy.get('[data-test-subj="comboBoxInput"]').type(
+      'custom.email.4@test.com{enter}'
+    );
+    cy.get('[data-test-subj="comboBoxInput"]').type(
+      'custom.email.5@test.com{enter}'
+    );
+    cy.get('[data-test-subj="comboBoxInput"]').type(
+      'custom.email.6@test.com{enter}'
+    );
+    cy.wait(delay);
+
+    cy.get('.euiButton__text').contains('Create').click({ force: true });
+    cy.contains('successfully created.').should('exist');
+    cy.contains('Test recipient group').should('exist');
+    cy.wait(delay);
+  });
+
+  it('edits recipient group description', () => {
+    cy.get('.euiCheckbox__input[aria-label="Select this row"]').last().click({ force: true }); // recipient group
+    cy.get('[data-test-subj="recipient-groups-table-edit-button"]').click({ force: true });
+    cy.get(
+      '[data-test-subj="create-recipient-group-form-description-input"]'
+    ).type('{selectall}{backspace}Updated group description');
+    cy.wait(delay);
+
+    cy.get('.euiButton__text').contains('Save').click({ force: true });
+    cy.contains('successfully updated.').should('exist');
+  });
+
+  it('opens email addresses popup', () => {
+    cy.get('.euiLink').contains('1 more').click({ force: true });
+    cy.contains('custom.email.6@test.com').should('exist');
+  });
+
+  it('deletes recipient groups', () => {
+    cy.get('[data-test-subj="checkboxSelectAll"]').last().click();
+    cy.get('[data-test-subj="recipient-groups-table-delete-button"]').click();
+    cy.get('input[placeholder="delete"]').type('delete');
+    cy.wait(delay);
+    cy.get(
+      '[data-test-subj="delete-recipient-group-modal-delete-button"]'
+    ).click({ force: true });
+    cy.contains('successfully deleted.').should('exist');
+
+    cy.contains('No recipient groups to display').should('exist');
+  });
+});

--- a/cypress/utils/constants.js
+++ b/cypress/utils/constants.js
@@ -11,3 +11,4 @@ export * from './plugins/observability-dashboards/constants';
 export * from './plugins/reports-dashboards/constants';
 export * from './plugins/query-workbench-dashboards/constants';
 export * from './plugins/security/constants';
+export * from './plugins/notifications-dashboards/constants';

--- a/cypress/utils/plugins/notifications-dashboards/constants.js
+++ b/cypress/utils/plugins/notifications-dashboards/constants.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const NOTIFICATIONS_PLUGIN_NAME = 'notifications-dashboards';
+export const delay = 1000;

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -26,6 +26,7 @@ function generate_test_list() {
     DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/query-workbench-dashboards/*"
     DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/reports-dashboards/*"
     DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/security/*"
+    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/notifications-dashboards/*"
 
     echo "$DEFAULT_TEST_FILES"
 }
@@ -41,6 +42,7 @@ function generate_test_list_from_build_manifest() {
     grep -q 'queryWorkbenchDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/query-workbench-dashboards/*" || true
     grep -q 'reportsDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/reports-dashboards/*" || true
     grep -q 'securityDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/security/*" || true
+    grep -q 'notificationsDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/notifications-dashboards/*" || true
 
     echo "$MANIFEST_TEST_FILES"
 }


### PR DESCRIPTION
### Description

New plugin. Just copy and pasted the existing tests from this repo:

https://github.com/opensearch-project/notifications/tree/main/dashboards-notifications

I am not positive about the flakiness this introduces but will handle it in subsequent tests.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/184

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
