### PR TITLE
Updates flaky test to not fail in security dashboards

### DIFF
--- a/cypress/integration/plugins/security/permissions_spec.js
+++ b/cypress/integration/plugins/security/permissions_spec.js
@@ -104,6 +104,7 @@ if(Cypress.env("SECURITY_ENABLED")) {
       cy.contains('button', 'Create action group').first().click({ force: true });
       cy.get('button[id="create-from-selection"]').should('have.attr', 'disabled');
   
+      cy.wait(500);
       // check the first action-group by using pattern matching to find the checkbox with id ending in `-checkbox`
       cy.get('[id$=-checkbox]').first().check();
       cy.wait(500);


### PR DESCRIPTION
### Description
Resolves a flaky test that was failing due to multiple clicks in a very short time.

### Issues Resolved

https://amzn-aws.slack.com/archives/C02006YQC9X/p1650390694582289?thread_ts=1650389923.574799&cid=C02006YQC9X

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
