### PR TITLE
[CI] skip non-supported distributions and fix path

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -79,6 +79,9 @@ then
   PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
 
+EXECUTE_TESTS=$(is_distribution_supported)
+[ $EXECUTE_TESTS = 'false' ] && echo "Distribution type not supported. Only TARs are supported. Skipping tests." && exit 0
+
 npm install
 
 TEST_FILES=$(get_test_list)

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -7,13 +7,22 @@ OSD_TEST_PATH='cypress/integration/core-opensearch-dashboards'
 OSD_PLUGIN_TEST_PATH='cypress/integration/plugins'
 
 # Checks if build manifest in parent directory of current directory under local-test-cluster/opensearch-dashboards-*
+# and if it's a distribution that we can support test runs on. If it exists and is a supported distribution then it
+# will run the tests, or if it the manifest doesn't exist we assume it's a local run and still run tests.
+function is_distribution_supported() {
+    is_supported='true'
+    [ -f $OSD_BUILD_MANIFEST ] && [ $(grep -q -L 'distribution: tar' $OSD_BUILD_MANIFEST) ] && is_supported='false'
+    echo "$is_supported"
+}
+
+# Checks if build manifest in parent directory of current directory under local-test-cluster/opensearch-dashboards-*
 # When the test script executed in the CI, it scales up OpenSearch Dashboards under local-test-cluster with a 
 # manifest that contains the existing components.
 #
 # If the build manifest exists in the expected path then we can read the components to execute component tests if the
 # component exists. If the build manifest does not exist then we can just use a default list of tests.
 function get_test_list() {
-    [ -f $OSD_MANIFEST_PATH ] && generate_test_list_from_build_manifest || generate_test_list
+    [ -f $OSD_BUILD_MANIFEST ] && generate_test_list_from_build_manifest || generate_test_list
 }
 
 function generate_test_list() {


### PR DESCRIPTION
### Description

Skip running tests if distributions is not TAR.

Also, path was not found. Guess in the CI it was running all
versions.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
