### PR TITLE
[AD] fix historical analysis

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/historical_analysis_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/historical_analysis_spec.js
@@ -5,8 +5,8 @@
 
 import { AD_URL } from '../../../utils/constants';
 
-context('Historical results page', () => {
-  function verifyAnomaliesInCharts() {
+describe('Historical results page', () => {
+  const verifyAnomaliesInCharts = () => {
     // Wait for any kicked off historical analysis to finish. Relying on default
     // timeout (60s) to find an element that only shows up when the analysis is finished
     cy.getElementByTestId('detectorStateFinished').should('exist');
@@ -28,7 +28,7 @@ context('Historical results page', () => {
     );
   }
 
-  function verifyNoAnomaliesInCharts() {
+  const verifyNoAnomaliesInCharts = () => {
     // Wait for any kicked off historical analysis to finish. Relying on default
     // timeout (60s) to find an element that only shows up when the analysis is finished
     cy.getElementByTestId('detectorStateFinished').should('exist');
@@ -107,20 +107,31 @@ context('Historical results page', () => {
       cy.contains('Refresh').click();
       verifyNoAnomaliesInCharts();
       
-      cy.getElementByTestId('superDatePickerToggleQuickMenuButton').click();
-      cy.get(`[aria-label="Previous time window"]`).click();
-      cy.contains('Refresh').click();
-      verifyAnomaliesInCharts();
+      cy.get('body').then($body => {
+        if ($body.find('[aria-label="Previous time window"]').length == 0) {
+          cy.getElementByTestId('superDatePickerToggleQuickMenuButton').click();
+        }
+
+        cy.get(`[aria-label="Previous time window"]`).click();
+        cy.contains('Refresh').click();
+        verifyAnomaliesInCharts();
+      });
     });
 
     it('Aggregations render anomalies', () => {
+      cy.get('body').then($body => {
+        if ($body.find('[aria-label="Previous time window"]').length > 0) {
+          cy.getElementByTestId('superDatePickerToggleQuickMenuButton').click();
+        }
+      });
+
       cy.contains('Refresh').click();
       cy.wait(2000);
-      cy.get(`[title="Daily max"]`).click();
+      cy.contains('Daily max').click();
       verifyAnomaliesInCharts();
-      cy.get(`[title="Weekly max"]`).click();
+      cy.contains('Weekly max').click();
       verifyAnomaliesInCharts();
-      cy.get(`[title="Monthly max"]`).click();
+      cy.contains('Monthly max').click();
       verifyAnomaliesInCharts();
     });
 


### PR DESCRIPTION
### Description

For our cypress, the date picker might not have closed when refreshing
so then I just checked if the button exists if not then it's because
the date picker is closed. If it's open it will then the previous time
window will exist.

Issue:
n/a

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
