### PR TITLE
update security test folder in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ $ yarn cypress run-without-security --spec "cypress/integration/core-opensearch-
 with security:
 
 ```
-$ yarn cypress run-with-security --spec "cypress/integration/core-opensearch-dashboards/vanilla-opensearch-dashboards/*.js"
+$ yarn cypress run-with-security --spec "cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js"
 ```
 
 These tests run in headless mode by default. You can also manually trigger the test via browser UI by running:
@@ -73,7 +73,7 @@ $ yarn cypress open
 And you can override certain [cypress config or environment variable](cypress.json) by applying additional cli arguments, for example to override the baseUrl and openSearchUrl to test a remote OpenSearch endpoint:
 
 ```
-$ yarn cypress run --spec "cypress/integration/core-opensearch-dashboards/vanilla-opensearch-dashboards/*.js" --config "baseUrl=https://<endpoint>/_dashboards" --env "openSearchUrl=https://<endpoint>,SECURITY_ENABLED=true,username=admin,password=xxxxxxxx,ENDPOINT_WITH_PROXY=true"
+$ yarn cypress run --spec "cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js" --config "baseUrl=https://<endpoint>/_dashboards" --env "openSearchUrl=https://<endpoint>,SECURITY_ENABLED=true,username=admin,password=xxxxxxxx,ENDPOINT_WITH_PROXY=true"
 ```
 
 `SECURITY_ENABLED`: if true, the `username` and `password` passing in are used as basic authentication credentials during `cy.visit` and `cy.request`. Also, please notice security enabled endpoint normally uses https protocol, so you may want to pass in different urls.


### PR DESCRIPTION
Signed-off-by: CCongWang <wangcong@umich.edu>

### Description

* Update the test folder when security is enabled in [CONTRIBUTING](https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/main/CONTRIBUTING.md)

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/100

### Testing

1. Run 
```yarn cypress run --spec "cypress/integration/core-opensearch-dashboards/opensearch-dashboards/*.js" --config "baseUrl=https://search-conjwang-1-2-2y5dpzuupluvzhttbx6xwjpcsi.us-east-1.es.amazonaws.com/_dashboards" --env "openSearchUrl=https://search-conjwang-1-2-2y5dpzuupluvzhttbx6xwjpcsi.us-east-1.es.amazonaws.com,SECURITY_ENABLED=true,username=admin,password=Test2022*,ENDPOINT_WITH_PROXY=true"```

2. See all tests passed
```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  core-opensearch-dashboards/opensear      00:59       34       34        -        -        - │
  │    ch-dashboards/dashboard_sanity_test                                                         │
  │    _spec.js                                                                                    │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:59       34       34        -        -        -  

✨  Done in 74.35s.
```

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
