### PR TITLE
add postinstall script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "cypress:release-ad-only": "yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/anomaly-detection-dashboards-plugin/*'",
     "cypress:release-ism-only": "yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/index-management-dashboards-plugin/*'",
     "lint": "eslint . --ext .js",
-    "pkg-version": "./scripts/getpkgversion.sh"
+    "pkg-version": "./scripts/getpkgversion.sh",
+    "postinstall": "husky install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Signed-off-by: CCongWang <wangcong@umich.edu>

### Description

* Add `postinstall` script in package.json, so that people don't need to manually install hooks

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/201#discussion_r860252631

### Testing

1. Delete `node_modules`
2. Run `npm install`, should see that`husky install`runs and text `husky - Git hooks installed`
```
> husky install

husky - Git hooks installed
```
3. Commit code change, should see precommit hook runs
```
ubuntu@ip-172-31-55-176:~/github/opensearch-dashboards-functional-test$ git commit -s -m "add postinstall script in package.json"
yarn run v1.22.10
$ eslint . --ext .js
Done in 2.49s.
```

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
