### PR TITLE
remove unnecessary version in Notification workflow

### DIFF
--- a/.github/workflows/notifications-release-e2e-workflow.yml
+++ b/.github/workflows/notifications-release-e2e-workflow.yml
@@ -10,4 +10,3 @@ jobs:
     with:
       test-name: Notifications
       test-command: yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/notifications-dashboards/*'
-      version: 2.0.0-rc1


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

Address the failed Notification workflow https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/206#issuecomment-1113895074

### Issues Resolved

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
