### PR TITLE
Lock Cypress version to 9.5.4 so it will not use other versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "prettier": "^2.5.1"
       },
       "devDependencies": {
-        "cypress": "^9.5.4",
+        "cypress": "9.5.4",
         "cypress-multi-reporters": "^1.5.0",
         "eslint": "^7.0.0",
         "eslint-config-prettier": "^8.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -774,9 +774,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.6.0.tgz",
-      "integrity": "sha512-nNwt9eBQmSENamwa8LxvggXksfyzpyYaQ7lNBLgks3XZ6dPE/6BCQFBzeAyAPt/bNXfH3tKPkAyhiAZPYkWoEg==",
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.4.tgz",
+      "integrity": "sha512-6AyJAD8phe7IMvOL4oBsI9puRNOWxZjl8z1lgixJMcgJ85JJmyKeP6uqNA0dI1z14lmJ7Qklf2MOgP/xdAqJ/Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3156,6 +3156,7 @@
     },
     "@opensearch-dashboards-test/opensearch-dashboards-test-library": {
       "version": "git+ssh://git@github.com/opensearch-project/opensearch-dashboards-test-library.git#e1adcf8496a7b006690aca476a2c5df23f2158e8",
+      "integrity": "sha512-nCyejzgd5Ro+T7JPbsyt5YJclOhRNy94+XaBz1Ns7CTqzENjzfbox6wi51ZbA5nH2Ogei21aS1qsggf/7YXXgQ==",
       "from": "@opensearch-dashboards-test/opensearch-dashboards-test-library@opensearch-project/opensearch-dashboards-test-library#main"
     },
     "@types/node": {
@@ -3553,9 +3554,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.6.0.tgz",
-      "integrity": "sha512-nNwt9eBQmSENamwa8LxvggXksfyzpyYaQ7lNBLgks3XZ6dPE/6BCQFBzeAyAPt/bNXfH3tKPkAyhiAZPYkWoEg==",
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.4.tgz",
+      "integrity": "sha512-6AyJAD8phe7IMvOL4oBsI9puRNOWxZjl8z1lgixJMcgJ85JJmyKeP6uqNA0dI1z14lmJ7Qklf2MOgP/xdAqJ/Q==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prettier": "^2.5.1"
   },
   "devDependencies": {
-    "cypress": "^9.5.4",
+    "cypress": "9.5.4",
     "cypress-multi-reporters": "^1.5.0",
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description

Lock Cypress version to 9.5.4 so it will not use other versions:

```

2022-04-30 05:03:10 INFO     [FAILED] Cypress failed to start.
[FAILED] 
[FAILED] This may be due to a missing library or dependency. https://on.cypress.io/required-dependencies
[FAILED] 
[FAILED] Please refer to the error below for more details.
[FAILED] 
[FAILED] ----------
[FAILED] 
[FAILED] /usr/share/opensearch/.cache/Cypress/9.6.0/Cypress/Cypress: /usr/share/opensearch/.cache/Cypress/9.6.0/Cypress/Cypress: cannot execute binary file
[FAILED] 
[FAILED] ----------
[FAILED] 
[FAILED] Platform: linux-x64 (RHEL - )
[FAILED] Cypress Version: 9.6.0
error Command failed with exit code 1.
```

Our docker image only have 9.5.4 version compiled and installed.
On 2022/04/25 Cypress released 9.6.0, which fits `^9.5.4` requirements: https://docs.cypress.io/guides/references/changelog#9-6-0.

This caused 9.6.0 version being used in the run.
And since we do not have 9.6.0 version in docker image, the test failed.

Thus we lock the version here specifically.

Thanks.


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
