### PR TITLE
Wait for tenancy call if security enabled and bump version

### DIFF
--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:admin -k localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:admin -k localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/cypress/utils/plugins/anomaly-detection-dashboards-plugin/helpers.js
+++ b/cypress/utils/plugins/anomaly-detection-dashboards-plugin/helpers.js
@@ -11,7 +11,7 @@ export const selectTopItemFromFilter = (
     .find('[data-test-subj=comboBoxToggleListButton]')
     .click({ force: true });
   cy.get('.euiFilterSelectItem').first().click();
-  cy.wait(1000)
+  cy.wait(1000);
   // If multiple options can be selected, the combo box doesn't close after selecting an option.
   // We manually close in this case, so the unselected items aren't visible on the page.
   // This way, we can test whether or not filtering has worked as expected.

--- a/cypress/utils/plugins/observability-dashboards/constants.js
+++ b/cypress/utils/plugins/observability-dashboards/constants.js
@@ -230,7 +230,10 @@ export const moveToHomePage = () => {
 };
 
 export const moveToCreatePage = () => {
-  cy.visit(`${BASE_PATH}/app/observability-dashboards#/application_analytics/`);
+  cy.visit(
+    `${BASE_PATH}/app/observability-dashboards#/application_analytics/`,
+    { waitForGetTenant: true }
+  );
   cy.wait(delayTime * 2);
   cy.get('.euiButton__text').contains('Create application').click();
   supressResizeObserverIssue();
@@ -239,7 +242,10 @@ export const moveToCreatePage = () => {
 };
 
 export const moveToApplication = (name) => {
-  cy.visit(`${BASE_PATH}/app/observability-dashboards#/application_analytics/`);
+  cy.visit(
+    `${BASE_PATH}/app/observability-dashboards#/application_analytics/`,
+    { waitForGetTenant: true }
+  );
   supressResizeObserverIssue();
   cy.wait(delayTime * 7);
   cy.contains(name, { timeout: 120000 }).click();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-dashboards-functional-test",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-dashboards-functional-test",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0",
   "description": "Maintains functional tests for OpenSearch Dashboards and Dashboards plugins",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

Bumping to version 2.0.0, fix linter problem.

Also, preventing the test runner from navigating to a new
page when security plugin is enabled. The reason why is
because depending on how long the test takes to run, there
is an API call to refresh the permissions that take a little
bit longer than what tests are expecting. So if the test runner
makes the call to switch tenants but navigates to a new page
before that call is finished another call might run into a
permissions error. This ensures that if that call is made
then the test runner waits before navigating to the destination.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/231

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
