### PR TITLE
Make package.json 2.0.0 so that other checks on 2.0.0 GA can pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-dashboards-functional-test",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0",
   "description": "Maintains functional tests for OpenSearch Dashboards and Dashboards plugins",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description

Make package.json 2.0.0 so that other checks on 2.0.0 GA can pass

### Issues Resolved

Part of opensearch-project/opensearch-build#2086

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
