### PR TITLE
[Site] add test explore page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <title>OSD Functional Test Repo</title>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="styles.css">
+  <script src="js/dashboard.js"></script>
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <link rel="icon" type="image/x-icon" href="https://avatars.githubusercontent.com/u/12060704?v=4">
+</head>
+
+<body>
+  <div class="topNav">
+    <span>OpenSearch Dashboards Test Results Explorer</span>
+    <a href="https://github.com/opensearch-project/opensearch-dashboards-functional-test">
+      Github
+    </a>
+    <a href="https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/new?assignees=&labels=enhancement%2C+untriaged&template=FEATURE_REQUEST_TEMPLATE.md&title=%5BFEATURE%5D">
+      Plugin Not Here?
+    </a>
+  </div> 
+  <div id="advancedConfigDiv">
+    <table>
+      <tr>
+        <th>
+          Advanced Configurations
+        </th>
+      </tr>
+      <tr>
+        <td id="advancedConfigTd">
+          <input type="checkbox" id="advancedConfig" onclick="enableAdvancedConfig()">
+        </td>
+      </tr>
+    </table>
+  </div>
+  <div id="descriptionDiv">
+    Welcome to the test results explorer! Please enter the version and build number to view results.
+    <br><br>
+    <i>NOTE: You might need to add an extension to view the results in UTF-8. Otherwise, download directly.</i>
+  </div>
+  <div id="inputsDiv">
+    <table>
+      <tr>
+        <th>Version</th>
+        <th>Build Number</th>
+      </tr>
+      <tr>
+        <td>
+          <input type="text" id="version" value="2.0.0">
+        </td>
+        <td>
+          <input type="text" id="buildNumber" value="3936">
+        </td>
+      </tr>
+    </table>
+    <table>
+      <tr>
+        <th>Platform</th>
+        <th>Arch</th>
+        <th>Type</th>
+        <th>With Security</th>
+      </tr>
+      <tr>
+        <td>
+          <select id="platform">
+            <option value="linux">Linux</option>
+          </select>
+        </td>
+        <td>
+          <select id="arch">
+            <option value="x64">x64</option>
+            <option value="arm64">arm64</option>
+          </select>
+        </td>
+        <td>
+          <select id="type">
+            <option value="tar">tar</option>
+            <option value="rpm">rpm</option>
+          </select>
+        </td>
+        <td id="securityTd">
+          <input type="checkbox" id="security">
+        </td>
+      </tr>
+    </table>
+    <table id="advancedInputsTable">
+      <tr>
+        <th>Test Number</th>
+      </tr>
+      <tr>
+        <td>
+          <input type="text" id="testNumber" value="1">
+        </td>
+      </tr>
+      <tr>
+        <th>Test Job Name</th>
+      </tr>
+      <tr>
+        <td>
+          <input style="width:50vw" type="text" id="testJobName" value="integ-test-opensearch-dashboards">
+        </td>
+      </tr>
+    </table>
+    <button id="submitButton" onclick="getTestResults()">Submit</button>
+  </div>
+  <div id="testResultsLinksDiv">
+    <h2>Useful Links:</h2>
+    <ul>
+      <li>
+        <a id="testResultLink"></a>
+      </li>
+      <li>
+        <a id="manifestLink"></a>
+      </li>
+      <li>
+        <a id="osdLink"></a>
+      </li>
+      <li>
+        <a id="osLink"></a>
+      </li>
+    </ul>
+    <h2>Plugins:</h2>
+    <table>
+      <tr>
+        <td id="pluginButtonsTd">
+          <button id="alertingDashboardsButton" onclick="getPluginLinks('alerting-dashboards-plugin')">
+            alertingDashboards
+          </button>
+          <button id="anomalyDetectionDashboardsButton" onclick="getPluginLinks('anomaly-detection-dashboards-plugin')">
+            anomalyDetectionDashboards
+          </button>
+          <button id="ganttChartDashboardsButton" onclick="getPluginLinks('gantt-chart-dashboards')">
+            ganttChartDashboards
+          </button>
+          <button id="indexManagementDashboardsButton" onclick="getPluginLinks('index-management-dashboards-plugin')">
+            indexManagementDashboards
+          </button>
+          <button id="notificationsDashboardsButton" onclick="getPluginLinks('notifications-dashboards')">
+            notificationsDashboards
+          </button>
+          <button id="observabilityDashboardsButton" onclick="getPluginLinks('observability-dashboards')">
+            observabilityDashboards
+          </button>
+          <button id="queryWorkbenchDashboardsButton" onclick="getPluginLinks('query-workbench-dashboards')">
+            queryWorkbenchDashboards
+          </button>
+          <button id="reportsDashboardsButton" onclick="getPluginLinks('reports-dashboards')">
+            reportsDashboards
+          </button>
+          <button id="securityDashboardsButton" onclick="getPluginLinks('security')">
+            securityDashboards
+          </button>
+      </tr>
+    </table>
+  </div>
+  <div id="pluginLinksDiv">
+    <button onclick="closePluginLinks()">Close</button>
+    <h2 id="pluginName"></h2>
+    <span><i>NOTE: If you are getting errors accessing these links, please verify the plugin is within the build manifest (within the useful links section).</i></span>
+    <br>
+    <span>If your plugin is not in the build manifest, please verify it has been added to:</span>
+    <span id="githubManifestLink"></span>
+    <br><br>
+    <span id="pluginLink"></span>
+    <ul id="pluginLinksList"></ul>
+  </div>
+  <div id="testResultsDiv">
+    <h2>Test Results:</h2>
+    <iframe id="testResults"><meta charset="utf-8"></iframe>
+  </div>
+</body>
+
+</html>

--- a/site/js/dashboard.js
+++ b/site/js/dashboard.js
@@ -1,0 +1,234 @@
+// Copyright OpenSearch Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+const plugins = {
+  'alerting-dashboards-plugin': {
+    name: 'alertingDashboards',
+    videos: [
+      'acknowledge_alerts_modal_spec.js',
+      'alert_spec.js',
+      'alerts_dashboard_flyout_spec.js',
+      'bucket_level_monitor_spec.js',
+      'cluster_metrics_monitor_spec.js',
+      'query_level_monitor_spec.js',
+    ],
+  },
+  'anomaly-detection-dashboards-plugin': {
+    name: 'anomalyDetectionDashboards',
+    videos: [
+      'create_detector_spec.js',
+      'dashboard_spec.js',
+      'detector_configuration_spec.js',
+      'detector_list_spec.js',
+      'historical_analysis_spec.js',
+      'overview_spec.js',
+      'real_time_results_spec.js',
+      'sample_detector_spec.js',
+    ],
+  },
+  'gantt-chart-dashboards': {
+    name: 'ganttChartDashboards',
+    videos: ['gantt_ui.spec.js'],
+  },
+  'index-management-dashboards-plugin': {
+    name: 'indexManagementDashboards',
+    videos: [
+      'indices_spec.js',
+      'managed_indices_spec.js',
+      'policies_spec.js',
+      'rollups_spec.js',
+      'transforms_spec.js',
+    ],
+  },
+  'notifications-dashboards': {
+    name: 'notificationsDashboards',
+    videos: ['1_email_senders_and_groups.spec.js', '2_channels.spec.js'],
+  },
+  'observability-dashboards': {
+    name: 'observabilityDashboards',
+    videos: [
+      '0_before.spec.js',
+      '1_trace_analytics_dashboard.spec.js',
+      '2_trace_analytics_services.spec.js',
+      '3_trace_analytics_traces.spec.js',
+      '4_panels.spec.js',
+      '5_event_analytics.spec.js',
+      '6_notebooks.spec.js',
+      '7_app_analytics.spec.js',
+      '8_after.spec.js',
+    ],
+  },
+  'query-workbench-dashboards': {
+    name: 'queryWorkbenchDashboards',
+    videos: ['ui.spec.js'],
+  },
+  'reports-dashboards': {
+    name: 'reportsDashboards',
+    videos: [
+      '01-create.spec.js',
+      '02-edit.spec.js',
+      '03-details.spec.js',
+      '04-download.spec.js',
+    ],
+  },
+  security: {
+    name: 'securityDashboards',
+    videos: [
+      'audit_log_spec.js',
+      'auth_spec.js',
+      'get_started_spec.js',
+      'internalusers_spec.js',
+      'permissions_spec.js',
+      'roles_spec.js',
+      'tenants_spec.js',
+    ],
+  },
+};
+
+// eslint-disable-next-line no-unused-vars
+function getTestResults() {
+  const version = document.getElementById('version').value;
+  const testJobName = document.getElementById('testJobName').value;
+  const buildNumber = document.getElementById('buildNumber').value;
+  const testNumber = document.getElementById('testNumber').value;
+  const platform = document.getElementById('platform').value;
+  const arch = document.getElementById('arch').value;
+  const type = document.getElementById('type').value;
+  const securityEnabled = document.getElementById('security').checked;
+  const testResultsUrl =
+    'https://ci.opensearch.org/ci/dbc/' +
+    `${testJobName}/` +
+    `${version}/` +
+    `${buildNumber}/` +
+    `${platform}/` +
+    `${arch}/` +
+    `${type}/` +
+    `test-results/${testNumber}/integ-test/functionalTestDashboards/` +
+    `${securityEnabled ? 'with-security' : 'without-security'}/` +
+    'test-results/stdout.txt';
+
+  document.getElementById('testResultsLinksDiv').style.display = 'block';
+
+  document.getElementById('securityDashboardsButton').hidden = !securityEnabled;
+  var testResultsLink = document.getElementById('testResultLink');
+  testResultsLink.textContent = testResultsUrl;
+  testResultsLink.href = testResultsUrl;
+
+  const osdUrl =
+    'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/' +
+    `${version}/` +
+    `${buildNumber}/` +
+    `${platform}/` +
+    `${arch}/` +
+    `${type}/` +
+    'dist/opensearch-dashboards/' +
+    `opensearch-dashboards-${version}-${platform}-${arch}` +
+    `${type === 'tar' ? '.tar.gz' : '.rpm'}`;
+  var osdLink = document.getElementById('osdLink');
+  osdLink.textContent = osdUrl;
+  osdLink.href = osdUrl;
+
+  const manifestUrl =
+    'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/' +
+    `${version}/` +
+    `${buildNumber}/` +
+    `${platform}/` +
+    `${arch}/` +
+    `${type}/` +
+    'dist/opensearch-dashboards/manifest.yml';
+  var manifestLink = document.getElementById('manifestLink');
+  manifestLink.textContent = manifestUrl;
+  manifestLink.href = manifestUrl;
+
+  const osUrl =
+    'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/' +
+    `${version}/` +
+    'latest/' +
+    `${platform}/` +
+    `${arch}/` +
+    `${type}/` +
+    'dist/opensearch/' +
+    `opensearch-${version}-${platform}-${arch}` +
+    `${type === 'tar' ? '.tar.gz' : '.rpm'}`;
+  var osLink = document.getElementById('osLink');
+  osLink.textContent = osUrl;
+  osLink.href = osUrl;
+
+  document.getElementById('testResultsDiv').style.display = 'block';
+  document.getElementById('testResults').src =
+    decodeURIComponent(testResultsUrl);
+}
+
+// eslint-disable-next-line no-unused-vars
+function enableAdvancedConfig() {
+  document.getElementById('advancedInputsTable').style.display =
+    document.getElementById('advancedConfig').checked ? 'block' : 'none';
+}
+
+// eslint-disable-next-line no-unused-vars
+function getPluginLinks(plugin) {
+  document.getElementById('pluginLinksList').innerHTML = '';
+  document.getElementById('githubManifestLink').innerHTML = '';
+  document.getElementById('pluginLink').innerHTML = '';
+  document.getElementById('pluginLinksDiv').style.display = 'block';
+  document.getElementById('pluginName').innerHTML = plugin;
+  const version = document.getElementById('version').value;
+  const testJobName = document.getElementById('testJobName').value;
+  const buildNumber = document.getElementById('buildNumber').value;
+  const testNumber = document.getElementById('testNumber').value;
+  const platform = document.getElementById('platform').value;
+  const arch = document.getElementById('arch').value;
+  const type = document.getElementById('type').value;
+  const securityEnabled = document.getElementById('security').checked;
+
+  var pluginLinksList = document.getElementById('pluginLinksList');
+  const pluginObject = plugins[plugin];
+
+  const pluginUrl =
+    'https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/' +
+    `${version}/` +
+    `${buildNumber}/` +
+    `${platform}/` +
+    `${arch}/` +
+    `${type}/` +
+    'builds/opensearch-dashboards/plugins/' +
+    `${pluginObject.name}-${version}.zip`;
+
+  var githubManifestLink = document.createElement('a');
+  githubManifestLink.textContent = 'Manifest';
+  githubManifestLink.href = `https://github.com/opensearch-project/opensearch-build/blob/main/manifests/${version}/opensearch-dashboards-${version}.yml`;
+  document.getElementById('githubManifestLink').appendChild(githubManifestLink);
+
+  var pluginLink = document.createElement('a');
+  pluginLink.textContent = pluginUrl;
+  pluginLink.href = pluginUrl;
+  document.getElementById('pluginLink').appendChild(pluginLink);
+
+  const videosBaseUrl =
+    'https://ci.opensearch.org/ci/dbc/' +
+    `${testJobName}/` +
+    `${version}/` +
+    `${buildNumber}/` +
+    `${platform}/` +
+    `${arch}/` +
+    `${type}/` +
+    `test-results/${testNumber}/integ-test/functionalTestDashboards/` +
+    `${securityEnabled ? 'with-security' : 'without-security'}/` +
+    'test-results/cypress-videos/plugins/' +
+    `${plugin}`;
+  const videos = pluginObject.videos;
+  for (const video of videos) {
+    var link = document.createElement('a');
+    link.textContent = `${videosBaseUrl}/${video}.mp4`;
+    link.href = `${videosBaseUrl}/${video}.mp4`;
+    var li = document.createElement('li');
+    li.appendChild(link);
+    pluginLinksList.appendChild(li);
+  }
+}
+
+// eslint-disable-next-line no-unused-vars
+function closePluginLinks() {
+  document.getElementById('pluginLinksDiv').style.display = 'none';
+  document.getElementById('pluginLinksList').innerHTML = '';
+}

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,0 +1,167 @@
+body {
+    font: normal 12px Arial;
+}
+
+#descriptionDiv {
+    margin: 8px 2px;
+}
+
+#advancedConfigDiv {
+    float: right;
+    margin-top: 10px;
+}
+
+#advancedConfigDiv table #advancedConfigTd {
+    text-align: right;
+}
+
+#inputsDiv table th {
+    text-align: left;
+}
+
+#inputsDiv table #securityTd {
+    text-align: center;
+}
+
+#inputsDiv #advancedInputsTable {
+    display: none;
+}
+
+#submitButton {
+    margin-top: 8px;
+    width: 150px;
+    background-color: #3c8cdc;
+    border: 1px solid rgba(27, 31, 35, 0.15);
+    border-radius: 6px;
+    box-shadow: rgba(27, 31, 35, 0.04) 0 1px 0, rgba(255, 255, 255, 0.25) 0 1px 0 inset;
+    box-sizing: border-box;
+    cursor: pointer;
+    color: white;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 20px;
+    list-style: none;
+    padding: 6px 16px;
+    user-select: none;
+}
+  
+#submitButton:hover {
+    background-color: #8dacea;
+    text-decoration: none;
+    transition-duration: 0.1s;
+}
+
+#testResultsLinksDiv {
+    width: 100%;
+    height: 30vh;
+    display: none;
+}
+
+#pluginButtonsTd button {
+    margin-top: 8px;
+    background-color: #3c8cdc;
+    border: 1px solid rgba(27, 31, 35, 0.15);
+    border-radius: 6px;
+    box-shadow: rgba(27, 31, 35, 0.04) 0 1px 0, rgba(255, 255, 255, 0.25) 0 1px 0 inset;
+    box-sizing: border-box;
+    cursor: pointer;
+    color: white;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 20px;
+    list-style: none;
+    padding: 6px 16px;
+    user-select: none;
+}
+  
+#pluginLinkButton:hover {
+    background-color: #8dacea;
+    text-decoration: none;
+    transition-duration: 0.1s;
+}
+
+#pluginLinksDiv {
+    padding: 8px;
+    display: none;
+    width: 750px;
+    height: 550px;
+    position: absolute;
+    left: 50%;
+    top: 50%; 
+    margin-left: -375px;
+    margin-top: -245px;
+    background-color: white;
+    border-radius: 6px;
+    box-shadow: rgba(27, 31, 35, 0.04) 0 1px 0, rgba(255, 255, 255, 0.25) 0 3px 0 inset;
+    border: 2px solid rgba(27, 31, 35, 0.15);
+}
+
+#pluginLinksDiv button {
+    float: left;
+    margin-top: 8px;
+    margin-left: 8px;
+    background-color: white;
+    border: 2px solid gray;
+    border-radius: 6px;
+    box-sizing: border-box;
+    cursor: pointer;
+    color: gray;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 20px;
+    list-style: none;
+    padding: 6px 14px;
+    user-select: none;
+}
+
+#pluginLinksDiv #pluginName {
+    text-align: center;
+    margin-top: 50px;
+}
+
+#pluginLinksDiv #pluginLinksList {
+    margin-top: 8px;
+}
+
+#testResultsDiv {
+    display: none;
+}
+
+#testResults {
+    width: 100%;
+    height: 52vh;
+}
+
+.topNav {
+    background-color: #333;
+    overflow: hidden;
+}
+
+.topNav span {
+    float: left;
+    color: white;
+    padding: 14px 16px;
+    font-size: 1rem;
+    cursor: default;
+}
+
+.topNav a {
+    float: right;
+    color: white;
+    padding: 14px 16px;
+    text-align: center;
+    text-decoration: underline;
+    font-size: 1rem;
+}
+
+.topNav a:hover {
+    background-color: #ddd;
+    color: black;
+}
+
+/* Add a color to the active/current link */
+.topNav a.active {
+    background-color: blue;
+    color: white;
+}
+


### PR DESCRIPTION
### Description

Basic HTML and JS to explore known tests.
There can be improvements made but just initial stuff and hardcoded.
values to help plugin developers find their results.

If this is merged, and `Sites` are enabled for this repo then it should be accessible
via `https://opensearch-project.github.io/opensearch-dashboards-functional-test/site/`

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/217

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
