### PR TITLE
[Improvement] fix issue with tenancy and test finder

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/01-create.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/01-create.spec.js
@@ -215,7 +215,9 @@ describe('Cypress', () => {
 });
 
 function visitCreateReportDefinitionPage() {
-  cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
+  cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
+    waitForGetTenant: true,
+  });
   cy.location('pathname', { timeout: 60000 }).should(
     'include',
     '/reports-dashboards'

--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -7,7 +7,9 @@ import { BASE_PATH } from '../../../utils/constants';
 
 describe('Cypress', () => {
   it('Visit edit page, update name and description', () => {
-    cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
+    cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
+      waitForGetTenant: true,
+    });
     cy.location('pathname', { timeout: 60000 }).should(
       'include',
       '/reports-dashboards'

--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -32,7 +32,7 @@ Cypress.Commands.overwrite('visit', (orig, url, options) => {
       };
     }
     newOptions.qs = { security_tenant: 'private' };
-    if (!waitForGetTenant) {
+    if (waitForGetTenant) {
       cy.intercept('GET', '/api/v1/multitenancy/tenant').as('getTenant');
       orig(url, newOptions);
       supressNoRequestOccurred();

--- a/cypress/utils/plugins/reports-dashboards/constants.js
+++ b/cypress/utils/plugins/reports-dashboards/constants.js
@@ -6,7 +6,9 @@
 import { BASE_PATH } from '../../../utils/constants';
 
 export function visitReportingLandingPage() {
-  cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
+  cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
+    waitForGetTenant: true,
+  });
   cy.location('pathname', { timeout: 60000 }).should(
     'include',
     '/reports-dashboards'

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -3,7 +3,7 @@
 set -e
 
 OSD_BUILD_MANIFEST='../local-test-cluster/opensearch-dashboards-*/manifest.yml'
-OSD_TEST_PATH='cypress/integration/core-opensearch-dashboards'
+OSD_TEST_PATH='cypress/integration/core-opensearch-dashboards/opensearch-dashboards'
 OSD_PLUGIN_TEST_PATH='cypress/integration/plugins'
 
 # Map component name in opensearch-build repo INPUT_MANIFEST with folder name for tests in functional repo
@@ -63,7 +63,7 @@ function get_test_list() {
             fi
 
         elif [ "$TEST_TYPE" = "manifest" ]; then
-            if grep -q $component_name; then
+            if grep -q $component_name $OSD_BUILD_MANIFEST; then
                 TEST_FILES_LOCAL+="$TEST_PATH_LOCAL/$test_folder/$TEST_FILES_EXT_LOCAL,"
             fi
         fi


### PR DESCRIPTION
### Description

Incorrectly merged the verification where I check if option to wait
for switching of tenant worked. Switched it back to the expected
scenario if the test passed the command it will wait.

Also, the test finder for manifest was missing the manifest path so
added that while also ensuring the minify OSD tests weren't ran
when verifying the distribution because those will fail as expected.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
