### PR TITLE
update maintainer list

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,10 +18,13 @@ This document explains who the maintainers are (see below), what they do in this
 
 ## Current Maintainers
 
-| Maintainer               | GitHub ID                               | Affiliation |
-| ------------------------ | --------------------------------------- | ----------- |
-| Henri Yandell            | [hyandell](https://github.com/hyandell) | Amazon      |
-| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)     | Amazon      |
+| Maintainer               | GitHub ID                                        | Affiliation |
+| ------------------------ | ------------------------------------------------ | ----------- |
+| Tianle Huang             | [tianleh](https://github.com/tianleh)            | Amazon      |
+| Kawika Avilla            | [kavilla](https://github.com/kavilla)            | Amazon      |
+| Tyler Ohlsen             | [ohltyler](https://github.com/ohltyler)          | Amazon      |
+| Cong Wang                | [CCongWang](https://github.com/CCongWang)        | Amazon      |
+| David Cui                | [davidcui1225](https://github.com/davidcui1225)  | Amazon      |
 
 ## Maintainer Responsibilities
 


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

Update maintainer list to reflect the actual situation. Will follow the standard [process](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md#becoming-a-maintainer) for future new maintainers.

### Issues Resolved

Resolves https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/212

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
