### PR TITLE
Adds basic integration test for customImportMap plugin

### DIFF
--- a/.github/workflows/custom-import-map-dashboards-release-e2e-workflow.yml
+++ b/.github/workflows/custom-import-map-dashboards-release-e2e-workflow.yml
@@ -1,0 +1,26 @@
+name: customImportMapDashboards Release tests workflow in Bundled OpenSearch Dashboards
+on:
+  pull_request:
+    branches:
+      - main
+      - dev-*
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.filter.outputs.tests }}
+    steps:
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          tests:
+            - 'cypress/**/custom-import-map-dashboards/**'
+
+  tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Observability
+      test-command: yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/custom-import-map-dashboards/*'

--- a/cypress/integration/plugins/custom-import-map-dashboards/import_vector_map_tab.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/import_vector_map_tab.spec.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="cypress" />
+
+import { BASE_PATH } from '../../../utils/constants';
+import {
+    MiscUtils,
+  } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+
+const miscUtils = new MiscUtils(cy);
+describe('Verify the presence of import custom map tab in region map plugin', () => {
+  before(() => {
+    cy.deleteAllIndices();
+    miscUtils.addSampleData();
+
+    cy.visit(`${BASE_PATH}/app/visualize#/`);
+
+    // Click on "Create Visualization" tab
+    cy.contains('Create visualization').click({ force: true });
+
+    // Click on "Region Map" icon
+    cy.contains('Region Map').click({ force: true });
+
+    // Select index source - [Flights] Flight Log
+    cy.contains('[Flights] Flight Log').click({ force: true });
+  });
+
+  it('checks import custom map tab is present', () => {
+    // Click on "Import Vector Map" tab, which is part of customImportMap plugin
+    cy.contains('Import Vector Map').click({ force: true });
+  })
+
+  after(() => {
+    miscUtils.removeSampleData();
+  })
+});

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -17,6 +17,7 @@ OSD_COMPONENT_TEST_MAP=( "OpenSearch-Dashboards:opensearch-dashboards"
                          "reportsDashboards:reports-dashboards"
                          "securityDashboards:security"
                          "notificationsDashboards:notifications-dashboards"
+                         "customImportMapDashboards:custom-import-map-dashboards"
                        )
 
 [ -f $OSD_BUILD_MANIFEST ] && TEST_TYPE="manifest" || TEST_TYPE="default"


### PR DESCRIPTION
Signed-off-by: Shivam Dhar <dhshivam@amazon.com>

### Description

- [X] Checks if "Import Vector Map" tab is present (added to region map plugin via customImportMap)


Video without security ->

https://user-images.githubusercontent.com/9303427/182781721-cdf45498-eae4-48cf-9771-8f3b2e7291d8.mp4

Test results -

`yarn cypress:run-without-security --spec "cypress/integration/plugins/customImportMap/*.js"`

```
yarn run v1.22.18
$ env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=false --spec 'cypress/integration/plugins/customImportMap/*.js'
The experimentalNetworkStubbing configuration option was removed in Cypress version 6.0.0.

It is no longer necessary for using cy.intercept(). You can safely remove this option from your config.
Couldn't determine Mocha version

====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        9.5.4                                                                          │
  │ Browser:        Electron 94 (headless)                                                         │
  │ Node Version:   v17.6.0 (/Users/dhshivam/.nvm/versions/node/v17.6.0/bin/node)                  │
  │ Specs:          1 found (plugins/customImportMap/0_before.spec.js)                             │
  │ Searched:       cypress/integration/plugins/customImportMap/*.js                               │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  plugins/customImportMap/0_before.spec.js                                        (1 of 1)
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Couldn't determine Mocha version


  Before

    ✓ setup completed (36860ms)


  1 passing (37s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     36 seconds                                                                       │
  │ Spec Ran:     plugins/customImportMap/0_before.spec.js                                         │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/dhshivam/Documents/GitHub/opensearch-dashboards-func    (5 seconds)
                          tional-test/cypress/videos/plugins/customImportMap/0_before               
                          .spec.js.mp4                                                              


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/customImportMap/0_before.sp      00:36        1        1        -        -        - │
  │    ec.js                                                                                       │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:36        1        1        -        -        -  

✨  Done in 59.37s.
```

Video with security enabled ->



https://user-images.githubusercontent.com/9303427/182931739-74286652-7758-4110-bba4-a5d6f620a1f4.mp4

Test results - 

`yarn cypress:run-with-security --spec "cypress/integration/plugins/customImportMap/*.js"`

```
yarn run v1.22.18
$ env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200 --spec 'cypress/integration/plugins/customImportMap/*.js'
The experimentalNetworkStubbing configuration option was removed in Cypress version 6.0.0.

It is no longer necessary for using cy.intercept(). You can safely remove this option from your config.
Couldn't determine Mocha version

====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        9.5.4                                                                          │
  │ Browser:        Electron 94 (headless)                                                         │
  │ Node Version:   v17.6.0 (/Users/dhshivam/.nvm/versions/node/v17.6.0/bin/node)                  │
  │ Specs:          1 found (plugins/customImportMap/0_before.spec.js)                             │
  │ Searched:       cypress/integration/plugins/customImportMap/*.js                               │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  plugins/customImportMap/0_before.spec.js                                        (1 of 1)
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Couldn't determine Mocha version


  Verify the presence of import custom map tab in region map plugin
    ✓ checks import custom map tab is present (74526ms)


  1 passing (1m)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     1 minute, 18 seconds                                                             │
  │ Spec Ran:     plugins/customImportMap/0_before.spec.js                                         │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/dhshivam/Documents/GitHub/opensearch-dashboards-func   (12 seconds)
                          tional-test/cypress/videos/plugins/customImportMap/0_before               
                          .spec.js.mp4                                                              

    Compression progress:  100%

====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/customImportMap/0_before.sp      01:18        1        1        -        -        - │
  │    ec.js                                                                                       │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        01:18        1        1        -        -        -  

✨  Done in 112.30s.
```


### Issues Resolved

https://github.com/opensearch-project/dashboards-maps/issues/26


### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
