### PR TITLE
[Site] add import maps button and more query string

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -108,6 +108,9 @@
     <h2>Useful Links:</h2>
     <ul>
       <li>
+        Link to this page: <a id="resultPageLink"></a>
+      </li>
+      <li>
         <a id="testResultLink"></a>
       </li>
       <li>
@@ -129,6 +132,9 @@
           </button>
           <button id="anomalyDetectionDashboardsButton" onclick="getPluginLinks('anomaly-detection-dashboards-plugin')">
             anomalyDetectionDashboards
+          </button>
+          <button id="customImportMapDashboardsButton" onclick="getPluginLinks('custom-import-map-dashboards')">
+            customImportMapDashboards
           </button>
           <button id="ganttChartDashboardsButton" onclick="getPluginLinks('gantt-chart-dashboards')">
             ganttChartDashboards

--- a/site/js/dashboard.js
+++ b/site/js/dashboard.js
@@ -6,6 +6,9 @@ const defaults = {
   buildNumber: '3958',
   testNumber: '1',
   testJobName: 'integ-test-opensearch-dashboards',
+  platform: 'linux',
+  arch: 'x64',
+  type: 'tar',
 };
 
 const plugins = {
@@ -35,6 +38,12 @@ const plugins = {
         'real_time_results_spec.js',
         'sample_detector_spec.js',
       ],
+    },
+  },
+  'custom-import-map-dashboards': {
+    name: 'customImportMapDashboards',
+    default: {
+      videos: ['import_vector_map_tab.spec.js'],
     },
   },
   'gantt-chart-dashboards': {
@@ -131,6 +140,20 @@ function getTestResults() {
   document.getElementById('testResultsLinksDiv').style.display = 'block';
 
   document.getElementById('securityDashboardsButton').hidden = !securityEnabled;
+
+  const resultPageUrl =
+    'https://opensearch-project.github.io/opensearch-dashboards-functional-test/site/?' +
+    `version=${version}&` +
+    `build_number=${buildNumber}&` +
+    `test_number=${testNumber}&` +
+    `platform=${platform}&` +
+    `arch=${arch}&` +
+    `type=${type}`;
+
+  var resultPageLink = document.getElementById('resultPageLink');
+  resultPageLink.textContent = resultPageUrl;
+  resultPageLink.href = resultPageUrl;
+
   var testResultsLink = document.getElementById('testResultLink');
   testResultsLink.textContent = testResultsUrl;
   testResultsLink.href = testResultsUrl;
@@ -279,4 +302,13 @@ function setDefaultValues() {
   document.getElementById('testNumber').value = params.get('test_number')
     ? params.get('test_number')
     : defaults.testNumber;
+  document.getElementById('platform').value = params.get('platform')
+    ? params.get('platform')
+    : defaults.platform;
+  document.getElementById('arch').value = params.get('arch')
+    ? params.get('arch')
+    : defaults.arch;
+  document.getElementById('type').value = params.get('type')
+    ? params.get('type')
+    : defaults.type;
 }


### PR DESCRIPTION
### Description

Enables access to easily see the import custom maps. Also added more query strings to easily set and build a link to the test results page to be easily copied and shared.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
