### PR TITLE
Clean up create detector AD test

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_detector_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_detector_spec.js
@@ -11,11 +11,11 @@ context('Create detector workflow', () => {
   const TEST_DETECTOR_DESCRIPTION = 'Some test detector description.';
   const TEST_FEATURE_NAME = 'test-feature';
   const TEST_TIMESTAMP_NAME = 'timestamp'; // coming from single_index_response.json fixture
-  const TEST_INDEX_NAME = 'ad-cypress-test-index';
+  const TEST_INDEX_NAME = 'sample-ad-index';
 
   // Index some sample data first
   before(() => {
-    cy.deleteAllIndices()
+    cy.deleteAllIndices();
     cy.fixture(AD_FIXTURE_BASE_PATH + 'sample_test_data.txt').then((data) => {
       cy.request({
         method: 'POST',
@@ -36,7 +36,7 @@ context('Create detector workflow', () => {
 
   // Clean up created resources
   after(() => {
-    cy.deleteAllIndices()
+    cy.deleteAllIndices();
   });
 
   it('Full creation - based on real index', () => {
@@ -79,6 +79,10 @@ context('Create detector workflow', () => {
     cy.getElementByTestId('timestampNameCell').contains(TEST_TIMESTAMP_NAME);
     cy.getElementByTestId('featureTable').contains(TEST_FEATURE_NAME);
     cy.getElementByTestId('createDetectorButton').click();
+
+    // Wait 5s for the detector to be created and started. By default,
+    // real-time detection will start.
+    cy.wait(5000);
 
     // Lands on the config page by default. Delete the detector to clean up.
     cy.getElementByTestId('actionsButton').click();


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Cleans up 2 things in the AD create detector test:
1. Renames the sample index to `sample-ad-index` so it gets deleted in the `cy.deleteAllIndices()` cmd. Before, this was left as a dangling index because the pattern in [deleteAllIndices](https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/main/cypress/utils/commands.js#L92) didn't catch the old name of `ad-cypress-test-index`.
2. Adds 5s wait time after creation before attempting to delete. This was flaky and would occasionally fail when trying to delete too fast, before the creation and detector start requests had finished executing.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
