### PR TITLE
Change form:false for AD request

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_detector_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_detector_spec.js
@@ -19,7 +19,7 @@ context('Create detector workflow', () => {
     cy.fixture(AD_FIXTURE_BASE_PATH + 'sample_test_data.txt').then((data) => {
       cy.request({
         method: 'POST',
-        form: true,
+        form: false,
         url: 'api/console/proxy',
         headers: {
           'content-type': 'application/json;charset=UTF-8',


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Changes the AD request to `form:false` in the request parameters, when loading in some sample data. From the [cypress documentation](https://docs.cypress.io/api/commands/request#Arguments), setting to `form:true` means the body should be url-encoded, and overwrites the `Content-Type` header to `application/x-www-form-urlencoded`. What we actually want is `application/json` which we have already specified in the request itself. By setting to `false` it removes any confusion and cleans up the code to make it run as expected.

Note that the previous code still worked, but was changing the request header to `Content-Type: application/x-www-form-urlencoded` under the hood which was causing confusion and could lead to certain bugs, especially if the request body was changed such that it couldn't be url-encoded.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
