### PR TITLE
Remove experimentalNetworkStubbing Option from Cypress.json

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -16,6 +16,5 @@
     "password": "admin",
     "ENDPOINT_WITH_PROXY": false,
     "MANAGED_SERVICE_ENDPOINT": false
-  },
-  "experimentalNetworkStubbing": true
+  }
 }


### PR DESCRIPTION
### Description

```experimentalNetworkStubbing``` option was removed and made the default behaviour from version 6.0.0.

Ref: https://docs.cypress.io/guides/references/changelog#6-0-0

### Issues Resolved

Resolves #309 

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
