### PR TITLE
[CI] Update test template to not use timeout

### DIFF
--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -75,7 +75,7 @@ jobs:
           working-directory: cypress-test
           command: ${{ inputs.test-command }}
           start: ${{ steps.get_opensearch.RUN_CMD }}, ${{ steps.get_opensearch_dashboards.RUN_CMD }}
-          wait-on: 'http://localhost:9200, http://localhost:5601'
+          wait-on: 'https://localhost:9200, http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -34,17 +34,18 @@ jobs:
         working-directory: cypress-test
         run: |
           echo "VERSION=$(yarn --silent pkg-version)" >> $GITHUB_ENV
-      - name: Get and run OpenSearch
+      - name: Get OpenSearch
+        id: get_opensearch
         run: |
           wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/tar/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
-          cd opensearch-${{ env.VERSION }}/
-          ./opensearch-tar-install.sh &
-          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+          echo "::set-output name=RUN_CMD::$(./../opensearch-${{ env.VERSION }}/opensearch-tar-install.sh)"
       - name: Get OpenSearch-Dashboards
+        id: get_opensearch_dashboards
         run: |
           wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/tar/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
+          echo "::set-output name=RUN_CMD::$(./../opensearch-dashboards-${{ env.VERSION }}/bin/opensearch-dashboards serve ${{ inputs.osd-serve-args }})"
       - name: Get node and yarn versions
         id: versions
         run: |
@@ -54,11 +55,6 @@ jobs:
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
-      - name: Run OpenSearch-Dashboards server
-        run: |
-          cd opensearch-dashboards-${{ env.VERSION }}
-          bin/opensearch-dashboards serve ${{ inputs.osd-serve-args }} &
-          timeout 300 bash -c 'while [[ "$(curl -s -u admin:admin -k localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |
@@ -78,7 +74,8 @@ jobs:
         with:
           working-directory: cypress-test
           command: ${{ inputs.test-command }}
-          wait-on: 'http://localhost:5601'
+          start: ${{ steps.get_opensearch.RUN_CMD }}, ${{ steps.get_opensearch_dashboards.RUN_CMD }}
+          wait-on: 'http://localhost:9200, http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
       - uses: actions/upload-artifact@v1
         if: failure()

--- a/cypress/integration/plugins/alerting-dashboards-plugin/acknowledge_alerts_modal_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/acknowledge_alerts_modal_spec.js
@@ -38,7 +38,7 @@ describe('AcknowledgeAlertsModal', () => {
     cy.contains(QUERY_MONITOR, { timeout: TWENTY_SECONDS });
 
     // Wait 1 minute for the test monitors to trigger alerts, then go to the 'Alerts by trigger' dashboard page to view alerts
-    cy.wait(60000);
+    cy.wait(60001);
   });
 
   beforeEach(() => {


### PR DESCRIPTION
### Description

GitHub workflow was failing because starting of OpenSearch and therefore OpenSearch Dashboards would exit with 124.

For example:
https://github.com/opensearch-project/opensearch-dashboards-functional-test/actions/runs/3237324644/jobs/5304250104

This is due to us using a timeout function and it outputs a non-zero code therefore github actions treats it as a failure code and doesn't run the test.

This fixes to utilize cypress to run the startup commands and tests within a single command.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
