### PR TITLE
Fix flaky clicks on AD historical tests

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/historical_analysis_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/historical_analysis_spec.js
@@ -135,6 +135,7 @@ describe('Historical results page', () => {
         force: true,
       });
       cy.get(`[aria-label="Next time window"]`).click();
+      cy.wait(5000);
       cy.contains('Refresh').click({ force: true });
       verifyNoAnomaliesInCharts();
 
@@ -146,6 +147,7 @@ describe('Historical results page', () => {
         }
 
         cy.get(`[aria-label="Previous time window"]`).click();
+        cy.wait(5000);
         cy.contains('Refresh').click({ force: true });
         verifyAnomaliesInCharts();
       });
@@ -160,6 +162,7 @@ describe('Historical results page', () => {
         }
       });
 
+      cy.wait(5000);
       cy.contains('Refresh').click({ force: true });
       cy.wait(2000);
       cy.contains('Daily max').click();


### PR DESCRIPTION
Signed-off-by: Tyler Ohlsen <ohltyler@amazon.com>

### Description

Adds wait times before some of the click actions on some of the buttons for the historical detection tests in the anomaly detection plugin test suite.

We have seen flaky failures where some of the buttons are not clicked when expected, leading to confusing errors later on due to the page getting into an unexpected state. This is because the actions taken right before the click are making API calls and reloading part of the page, so the click doesn't happen. To fix this, we add wait times before trying to click. Also adding `force` params to some of the click actions for consistency across the tests and to prevent future potentially flaky failures.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
