### PR TITLE
Add release.yml file to enable release note automation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - amazon-auto
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+        - feature
+    - title: Security fix
+      labels:
+        - cve
+        - security vulnerability
+    - title: Bug Fix
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Signed-off-by: Zilong Xia <zilongx@amazon.com>

### Description

* Add `release.yml` file to `Functional Test` project to enable the auto generation of release note.

* Testing Release created in fork repo as 
![image](https://user-images.githubusercontent.com/99905560/197667726-bb524825-b317-4796-b7d1-0035af7d1475.png)


### Issues Resolved

Resolves https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/346

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
