### PR TITLE
[Security] Bump minimatch to 3.1.2 to fix the ReDoS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1974,9 +1974,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"


### PR DESCRIPTION
Signed-off-by: Zilong Xia <zilongx@amazon.com>

### Description

* Resolves the `minimatch ReDoS vulnerability` by bumping `minimatch` up to `3.1.2` 
* Retrieve vulnerability details by running `npm audit`
```
88665a51c9b6:opensearch-dashboards-functional-test zilongx$ npm i --package-lock-only
added 327 packages and audited 327 packages in 0.896s
found 4 high severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details
88665a51c9b6:opensearch-dashboards-functional-test zilongx$ npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
# Run  npm update minimatch --depth 6  to resolve 4 vulnerabilities
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ minimatch ReDoS vulnerability                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimatch                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ eslint [dev]                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ eslint > minimatch                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-f8q6-p94x-37v3            │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ minimatch ReDoS vulnerability                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimatch                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ eslint [dev]                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ eslint > @eslint/eslintrc > minimatch                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-f8q6-p94x-37v3            │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ minimatch ReDoS vulnerability                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimatch                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ cypress [dev]                                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ cypress > tmp > rimraf > glob > minimatch                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-f8q6-p94x-37v3            │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ minimatch ReDoS vulnerability                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimatch                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ eslint [dev]                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ eslint > file-entry-cache > flat-cache > rimraf > glob >     │
│               │ minimatch                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-f8q6-p94x-37v3            │
└───────────────┴──────────────────────────────────────────────────────────────┘


found 4 high severity vulnerabilities in 327 scanned packages
  run `npm audit fix` to fix 4 of them.

```

* Fix the dependency issue by running `npm audit fix`
```
88665a51c9b6:opensearch-dashboards-functional-test zilongx$ npm audit fix

> cypress@9.5.4 postinstall /Volumes/workplace/opensearch-dashboards-functional-test/node_modules/cypress
> node index.js --exec install

Installing Cypress (version: 9.5.4)

✔  Downloaded Cypress
✔  Unzipped Cypress
✔  Finished Installation /Users/zilongx/Library/Caches/Cypress/9.5.4

You can now open Cypress by running: node_modules/.bin/cypress open

https://on.cypress.io/installing-cypress

added 327 packages from 261 contributors in 38.502s

76 packages are looking for funding
  run `npm fund` for details

fixed 4 of 4 vulnerabilities in 327 scanned packages
88665a51c9b6:opensearch-dashboards-functional-test zilongx$ npm audit
                                                                                
                       === npm audit security report ===                        
                                                                                
found 0 vulnerabilities

```

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
