### PR TITLE
Enables visbuilder tests by default

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -17,7 +17,7 @@
     "password": "admin",
     "ENDPOINT_WITH_PROXY": false,
     "MANAGED_SERVICE_ENDPOINT": false,
-    "VISBUILDER_ENABLED": false,
+    "VISBUILDER_ENABLED": true,
     "DATASOURCE_MANAGEMENT_ENABLED": false
   }
 }


### PR DESCRIPTION
Signed-off-by: Ashwin Pc <ashwinpc@amazon.com>

### Description

Enables visbuilder tests by default

### Issues Resolved



### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
