### PR TITLE
Onboarding security analytics dashboards plugin.

### DIFF
--- a/.github/workflows/security-analytics-release-e2e-workflow.yml
+++ b/.github/workflows/security-analytics-release-e2e-workflow.yml
@@ -1,0 +1,26 @@
+name: Security Analytics Release tests workflow in Bundled OpenSearch Dashboards
+on:
+  pull_request:
+    branches:
+      - main
+      - dev-*
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.filter.outputs.tests }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            tests:
+              - 'cypress/**/security-analytics-dashboards-plugin/**'
+
+  tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Security Analytics
+      test-command: yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/security-analytics-dashboards-plugin/*'

--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/rules_spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/rules_spec.js
@@ -1,0 +1,200 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PLUGIN_NAME, TWENTY_SECONDS_TIMEOUT } from '../../../utils/plugins/security-analytics-dashboards-plugin/constants'
+
+const SAMPLE_RULE = {
+  name: 'Cypress test rule',
+  logType: 'windows',
+  description: 'This is a rule used to test the rule creation workflow. Not for production use.',
+  detection:
+    'selection:\n  Provider_Name: Service Control Manager\nEventID: 7045\nServiceName: ZzNetSvc\n{backspace}{backspace}condition: selection',
+  detectionLine: [
+    'selection:',
+    'Provider_Name: Service Control Manager',
+    'EventID: 7045',
+    'ServiceName: ZzNetSvc',
+    'condition: selection',
+  ],
+  severity: 'critical',
+  tags: ['attack.persistence', 'attack.privilege_escalation', 'attack.t1543.003'],
+  references: 'https://nohello.com',
+  falsePositive: 'unknown',
+  author: 'Cypress Test Runner',
+  status: 'experimental',
+};
+
+describe('Rules', () => {
+  before(() => {
+    // Deleting pre-existing test rules
+    cy.deleteRule(SAMPLE_RULE.name);
+  });
+  beforeEach(() => {
+    // Visit Rules page
+    cy.visit(`${Cypress.env('opensearch_dashboards')}/app/${PLUGIN_NAME}#/rules`);
+  });
+
+  describe('Can be created', () => {
+    it('manually using UI', () => {
+      // Click "create new rule" button
+      cy.get('[data-test-subj="create_rule_button"]', TWENTY_SECONDS_TIMEOUT).click({
+        force: true,
+      });
+
+      // Enter the name
+      cy.get('[data-test-subj="rule_name_field"]', TWENTY_SECONDS_TIMEOUT).type(SAMPLE_RULE.name);
+
+      // Enter the log type
+      cy.get('[data-test-subj="rule_type_dropdown"]', TWENTY_SECONDS_TIMEOUT).select(
+        SAMPLE_RULE.logType
+      );
+
+      // Enter the description
+      cy.get('[data-test-subj="rule_description_field"]', TWENTY_SECONDS_TIMEOUT).type(
+        SAMPLE_RULE.description
+      );
+
+      // Enter the detection
+      cy.get('[data-test-subj="rule_detection_field"]', TWENTY_SECONDS_TIMEOUT).type(
+        SAMPLE_RULE.detection
+      );
+
+      // Enter the severity
+      cy.get('[data-test-subj="rule_severity_dropdown"]', TWENTY_SECONDS_TIMEOUT).select(
+        SAMPLE_RULE.severity
+      );
+
+      // Enter the tags
+      SAMPLE_RULE.tags.forEach((tag) =>
+        cy
+          .get('[data-test-subj="rule_tags_dropdown"]', TWENTY_SECONDS_TIMEOUT)
+          .type(`${tag}{enter}{esc}`)
+      );
+
+      // Enter the reference
+      cy.get('[data-test-subj="rule_references_field_0"]', TWENTY_SECONDS_TIMEOUT).type(
+        SAMPLE_RULE.references
+      );
+
+      // Enter the false positive cases
+      cy.get('[data-test-subj="rule_false_positive_cases_field_0"]', TWENTY_SECONDS_TIMEOUT).type(
+        SAMPLE_RULE.falsePositive
+      );
+
+      // Enter the author
+      cy.get('[data-test-subj="rule_author_field"]', TWENTY_SECONDS_TIMEOUT).type(
+        SAMPLE_RULE.author
+      );
+
+      // Enter the log type
+      cy.get('[data-test-subj="rule_status_dropdown"]', TWENTY_SECONDS_TIMEOUT).select(
+        SAMPLE_RULE.status
+      );
+
+      // Click "create" button
+      cy.get('[data-test-subj="create_rule_button"]', TWENTY_SECONDS_TIMEOUT).click({
+        force: true,
+      });
+
+      // Wait for the page to finish loading
+      cy.wait(5000);
+      cy.contains('No items found', TWENTY_SECONDS_TIMEOUT).should('not.exist');
+
+      // Search for the rule
+      cy.get(`input[type="search"]`, TWENTY_SECONDS_TIMEOUT)
+        // .focus()
+        .type(`${SAMPLE_RULE.name}{enter}`);
+
+      // Click the rule link to open the details flyout
+      cy.get(`[data-test-subj="rule_link_${SAMPLE_RULE.name}"]`, TWENTY_SECONDS_TIMEOUT).click();
+
+      // Confirm the flyout contains the expected values
+      cy.get(`[data-test-subj="rule_flyout_${SAMPLE_RULE.name}"]`, TWENTY_SECONDS_TIMEOUT)
+        .click({ force: true })
+        .within(() => {
+          // Validate name
+          cy.get('[data-test-subj="rule_flyout_rule_name"]', TWENTY_SECONDS_TIMEOUT).contains(
+            SAMPLE_RULE.name,
+            TWENTY_SECONDS_TIMEOUT
+          );
+
+          // Validate log type
+          cy.get('[data-test-subj="rule_flyout_rule_log_type"]', TWENTY_SECONDS_TIMEOUT).contains(
+            SAMPLE_RULE.logType,
+            TWENTY_SECONDS_TIMEOUT
+          );
+
+          // Validate description
+          cy.get(
+            '[data-test-subj="rule_flyout_rule_description"]',
+            TWENTY_SECONDS_TIMEOUT
+          ).contains(SAMPLE_RULE.description, TWENTY_SECONDS_TIMEOUT);
+
+          // Validate author
+          cy.get('[data-test-subj="rule_flyout_rule_author"]', TWENTY_SECONDS_TIMEOUT).contains(
+            SAMPLE_RULE.author,
+            TWENTY_SECONDS_TIMEOUT
+          );
+
+          // Validate source is "custom"
+          cy.get('[data-test-subj="rule_flyout_rule_source"]', TWENTY_SECONDS_TIMEOUT).contains(
+            'Custom',
+            TWENTY_SECONDS_TIMEOUT
+          );
+
+          // Validate severity
+          cy.get('[data-test-subj="rule_flyout_rule_severity"]', TWENTY_SECONDS_TIMEOUT).contains(
+            SAMPLE_RULE.severity,
+            TWENTY_SECONDS_TIMEOUT
+          );
+
+          // Validate tags
+          SAMPLE_RULE.tags.forEach((tag) =>
+            cy
+              .get('[data-test-subj="rule_flyout_rule_tags"]', TWENTY_SECONDS_TIMEOUT)
+              .contains(tag, TWENTY_SECONDS_TIMEOUT)
+          );
+
+          // Validate references
+          cy.get('[data-test-subj="rule_flyout_rule_references"]', TWENTY_SECONDS_TIMEOUT).contains(
+            SAMPLE_RULE.references,
+            TWENTY_SECONDS_TIMEOUT
+          );
+
+          // Validate false positives
+          cy.get(
+            '[data-test-subj="rule_flyout_rule_false_positives"]',
+            TWENTY_SECONDS_TIMEOUT
+          ).contains(SAMPLE_RULE.falsePositive, TWENTY_SECONDS_TIMEOUT);
+
+          // Validate status
+          cy.get('[data-test-subj="rule_flyout_rule_status"]', TWENTY_SECONDS_TIMEOUT).contains(
+            SAMPLE_RULE.status,
+            TWENTY_SECONDS_TIMEOUT
+          );
+
+          // Validate detection
+          SAMPLE_RULE.detectionLine.forEach((line) =>
+            cy
+              .get('[data-test-subj="rule_flyout_rule_detection"]', TWENTY_SECONDS_TIMEOUT)
+              .contains(line, TWENTY_SECONDS_TIMEOUT)
+          );
+
+          // Close the flyout
+          cy.get('[data-test-subj="euiFlyoutCloseButton"]', TWENTY_SECONDS_TIMEOUT).click({
+            force: true,
+          });
+        });
+
+      // Confirm flyout closed
+      cy.contains(`[data-test-subj="rule_flyout_${SAMPLE_RULE.name}"]`).should('not.exist');
+    });
+  });
+
+  after(() => {
+    // Deleting test rules
+    cy.deleteRule(SAMPLE_RULE.name);
+  });
+});

--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/rules_spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/rules_spec.js
@@ -4,6 +4,7 @@
  */
 
 import { PLUGIN_NAME, TWENTY_SECONDS_TIMEOUT } from '../../../utils/plugins/security-analytics-dashboards-plugin/constants'
+import {BASE_PATH} from "../../../utils/base_constants";
 
 const SAMPLE_RULE = {
   name: 'Cypress test rule',
@@ -33,7 +34,7 @@ describe('Rules', () => {
   });
   beforeEach(() => {
     // Visit Rules page
-    cy.visit(`${Cypress.env('opensearch_dashboards')}/app/${PLUGIN_NAME}#/rules`);
+    cy.visit(`${BASE_PATH}/app/${PLUGIN_NAME}#/rules`);
   });
 
   describe('Can be created', () => {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -27,6 +27,7 @@ import '../utils/plugins/anomaly-detection-dashboards-plugin/commands';
 import '../utils/plugins/security/commands';
 import '../utils/plugins/security-dashboards-plugin/commands';
 import '../utils/plugins/alerting-dashboards-plugin/commands';
+import '../utils/plugins/security-analytics-dashboards-plugin/commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress/utils/constants.js
+++ b/cypress/utils/constants.js
@@ -14,3 +14,4 @@ export * from './plugins/query-workbench-dashboards/constants';
 export * from './plugins/security/constants';
 export * from './plugins/notifications-dashboards/constants';
 export * from './plugins/security-dashboards-plugin/constants';
+export * from './plugins/security-analytics-dashboards-plugin/constants'

--- a/cypress/utils/plugins/security-analytics-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/security-analytics-dashboards-plugin/commands.js
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const { ADMIN_AUTH, INDICES, NODE_API, PLUGIN_NAME } = require('./constants');
+
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  // Add the basic auth header when security enabled in the Opensearch cluster
+  // https://github.com/cypress-io/cypress/issues/1288
+  if (Cypress.env('security_enabled')) {
+    const ADMIN_AUTH = {
+      username: Cypress.env('username'),
+      password: Cypress.env('password'),
+    };
+    if (options) {
+      options.auth = ADMIN_AUTH;
+    } else {
+      options = { auth: ADMIN_AUTH };
+    }
+    // Add query parameters - select the default OSD tenant
+    options.qs = { security_tenant: 'private' };
+    return originalFn(url, options);
+  } else {
+    return originalFn(url, options);
+  }
+});
+
+// Be able to add default options to cy.request(), https://github.com/cypress-io/cypress/issues/726
+Cypress.Commands.overwrite('request', (originalFn, ...args) => {
+  let defaults = {};
+  // Add the basic authentication header when security enabled in the Opensearch cluster
+  const ADMIN_AUTH = {
+    username: Cypress.env('username'),
+    password: Cypress.env('password'),
+  };
+  if (Cypress.env('security_enabled')) {
+    defaults.auth = ADMIN_AUTH;
+  }
+
+  let options = {};
+  if (typeof args[0] === 'object' && args[0] !== null) {
+    options = Object.assign({}, args[0]);
+  } else if (args.length === 1) {
+    [options.url] = args;
+  } else if (args.length === 2) {
+    [options.method, options.url] = args;
+  } else if (args.length === 3) {
+    [options.method, options.url, options.body] = args;
+  }
+
+  return originalFn(Object.assign({}, defaults, options));
+});
+
+Cypress.Commands.add('deleteAllIndices', () => {
+  cy.request('DELETE', `${Cypress.env('opensearch')}/index*,sample*,opensearch_dashboards*,test*`);
+});
+
+Cypress.Commands.add('createDetector', (detectorJSON) => {
+  cy.request('POST', `${Cypress.env('opensearch')}${NODE_API.DETECTORS_BASE}`, detectorJSON);
+});
+
+Cypress.Commands.add('updateDetector', (detectorId, detectorJSON) => {
+  cy.request(
+    'PUT',
+    `${Cypress.env('opensearch')}/${NODE_API.DETECTORS_BASE}/${detectorId}`,
+    detectorJSON
+  );
+});
+
+Cypress.Commands.add('createRule', (ruleJSON) => {
+  cy.request('POST', `${Cypress.env('opensearch')}${NODE_API.RULES_BASE}`, ruleJSON);
+});
+
+Cypress.Commands.add('updateRule', (ruleId, ruleJSON) => {
+  cy.request('PUT', `${Cypress.env('opensearch')}/${NODE_API.RULES_BASE}/${ruleId}`, ruleJSON);
+});
+
+Cypress.Commands.add('deleteRule', (ruleName) => {
+  const body = {
+    from: 0,
+    size: 5000,
+    query: {
+      nested: {
+        path: 'rule',
+        query: {
+          bool: {
+            must: [{ match: { 'rule.title': 'Cypress test rule' } }],
+          },
+        },
+      },
+    },
+  };
+  cy.request({
+    method: 'POST',
+    url: `${Cypress.env('opensearch')}${NODE_API.RULES_BASE}/_search?pre_packaged=false`,
+    failOnStatusCode: false,
+    body,
+  }).then((response) => {
+    if (response.status === 200) {
+      for (let hit of response.body.hits.hits) {
+        if (hit._source.title === ruleName)
+          cy.request(
+            'DELETE',
+            `${Cypress.env('opensearch')}${NODE_API.RULES_BASE}/${hit._id}?forced=true`
+          );
+      }
+    }
+  });
+});
+
+Cypress.Commands.add('createIndex', (index, settings = {}) => {
+  cy.request('PUT', `${Cypress.env('opensearch')}/${index}`, settings);
+});
+
+Cypress.Commands.add('createIndexTemplate', (name, template) => {
+  cy.request(
+    'PUT',
+    `${Cypress.env('opensearch')}${NODE_API.INDEX_TEMPLATE_BASE}/${name}`,
+    template
+  );
+});

--- a/cypress/utils/plugins/security-analytics-dashboards-plugin/constants.js
+++ b/cypress/utils/plugins/security-analytics-dashboards-plugin/constants.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const TWENTY_SECONDS_TIMEOUT = { timeout: 20000 };
+
+export const INDICES = {
+  DETECTORS_INDEX: '.opensearch-detectors-config',
+  PRE_PACKAGED_RULES_INDEX: '.opensearch-pre-packaged-rules-config',
+  CUSTOM_RULES_INDEX: '.opensearch-custom-rules-config',
+};
+
+export const PLUGIN_NAME = 'opensearch_security_analytics_dashboards';
+export const BASE_API_PATH = '/_plugins/_security_analytics';
+
+export const NODE_API = {
+  DETECTORS_BASE: `${BASE_API_PATH}/detectors`,
+  SEARCH_DETECTORS: `${BASE_API_PATH}/detectors/_search`,
+  INDICES_BASE: `${BASE_API_PATH}/indices`,
+  GET_FINDINGS: `${BASE_API_PATH}/findings/_search`,
+  DOCUMENT_IDS_QUERY: `${BASE_API_PATH}/document_ids_query`,
+  TIME_RANGE_QUERY: `${BASE_API_PATH}/time_range_query`,
+  MAPPINGS_BASE: `${BASE_API_PATH}/mappings`,
+  MAPPINGS_VIEW: `${BASE_API_PATH}/mappings/view`,
+  GET_ALERTS: `${BASE_API_PATH}/alerts`,
+  RULES_BASE: `${BASE_API_PATH}/rules`,
+  CHANNELS: `${BASE_API_PATH}/_notifications/channels`,
+  ACKNOWLEDGE_ALERTS: `${BASE_API_PATH}/detectors/{detector_id}/_acknowledge/alerts`,
+  INDEX_TEMPLATE_BASE: '/_index_template',
+};

--- a/site/index.html
+++ b/site/index.html
@@ -157,6 +157,9 @@
           <button id="securityDashboardsButton" onclick="getPluginLinks('security')">
             securityDashboards
           </button>
+          <button id="securityAnalyticsDashboardsButton" onclick="getPluginLinks('security-analytics-dashboards-plugin')">
+            securityAnalyticsDashboards
+          </button>
       </tr>
     </table>
   </div>

--- a/site/js/dashboard.js
+++ b/site/js/dashboard.js
@@ -115,6 +115,14 @@ const plugins = {
       ],
     },
   },
+  'security-analytics-dashboards-plugin': {
+    name: 'securityAnalyticsDashboards',
+    default: {
+      videos: [
+        'rules_spec.js',
+      ],
+    },
+  },
 };
 
 // eslint-disable-next-line no-unused-vars

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -19,6 +19,7 @@ OSD_COMPONENT_TEST_MAP=( "OpenSearch-Dashboards:opensearch-dashboards"
                          "notificationsDashboards:notifications-dashboards"
                          "customImportMapDashboards:custom-import-map-dashboards"
                          "searchRelevanceDashboards:search-relevance-dashboards"
+                         "securityAnalyticsDashboards:security-analytics-dashboards-plugin"
                        )
 
 [ -f $OSD_BUILD_MANIFEST ] && TEST_TYPE="manifest" || TEST_TYPE="default"


### PR DESCRIPTION
### Description
Onboarding security analytics dashboards plugin. Security analytics 3.0 isn't available yet (currently, it is set to version 2.4), so the checks are expected to fail for now. This PR https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/380 will onboard security analytics directly to the 2.x branch.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
