### PR TITLE
Add support for linux e2e template to run no-sec tests

### DIFF
--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
@@ -22,12 +22,23 @@ jobs:
             tests:
               - 'cypress/**/core-opensearch-dashboards/**'
 
-  tests:
+  tests-with-security:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
-    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    uses: ./.github/workflows/release-e2e-workflow-template-windows.yml
     with:
       test-name: Core Dashboards using Bundle Snapshot
-      test-command: env CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
+      test-command: env CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-with-security --browser chrome --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
       # not useful now as the windows e2e template currently do not allow serving parameters
       #osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
+
+  tests-without-security:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template-windows.yml
+    with:
+      test-name: Core Dashboards using Bundle Snapshot
+      test-command: env CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-without-security --browser chrome --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
+      # not useful now as the windows e2e template currently do not allow serving parameters
+      #osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
+      security-enabled: false

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -22,7 +22,7 @@ jobs:
             tests:
               - 'cypress/**/core-opensearch-dashboards/**'
 
-  tests:
+  tests-with-security:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
@@ -30,3 +30,13 @@ jobs:
       test-name: Core Dashboards using Bundle Snapshot
       test-command: env CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
       osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
+
+  tests-without-security:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Core Dashboards using Bundle Snapshot
+      test-command: env CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-without-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
+      osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
+      security-enabled: false

--- a/.github/workflows/release-e2e-workflow-template-windows.yml
+++ b/.github/workflows/release-e2e-workflow-template-windows.yml
@@ -8,9 +8,12 @@ on:
       test-command:
         required: true
         type: string
+      security-enabled:
+        required: false
+        type: string
 jobs:
   tests:
-    name: Run Cypress E2E tests for ${{ inputs.test-name }}
+    name: Run Cypress E2E tests for ${{ inputs.test-name }} (Windows)
     runs-on: windows-latest
     env:
       # prevents extra Cypress installation progress messages
@@ -30,17 +33,36 @@ jobs:
       - name: Get package version
         working-directory: cypress-test
         run: |
-          echo "VERSION=$(yarn --silent pkg-version)" >> $GITHUB_ENV
+          echo "VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
           echo "PLATFORM=windows" >> $GITHUB_ENV
+          # Temp measure to resolve script not running on windows
+        shell: bash
+      - name: Get security setups
+        run: |
+          SECURITY_ENABLED=${{ inputs.security-enabled }}
+          if [ "$SECURITY_ENABLED" != 'false' ]; then
+              echo "SECURITY_ENABLED=true" >> $GITHUB_ENV
+          else
+              echo "SECURITY_ENABLED=false" >> $GITHUB_ENV
+          fi
         shell: bash
       - name: Get and run OpenSearch
         run: |
           curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/${{ env.PLATFORM }}/x64/zip/dist/opensearch/opensearch-${{ env.VERSION }}-${{ env.PLATFORM }}-x64.zip
           unzip -q opensearch-${{ env.VERSION }}-windows-x64.zip
           cd opensearch-${{ env.VERSION }}/
-          nohup ./opensearch-windows-install.bat &
-          timeout 900 bash -c 'while [[ "$(curl -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do echo sleeping 5; sleep 5; done'
-          curl -sk https://localhost:9200/_cluster/health?pretty -u admin:admin
+          if [ "$SECURITY_ENABLED" = 'false' ]; then
+              echo "Remove OpenSearch Security"
+              echo "plugins.security.disabled: true" >> config/opensearch.yml
+              nohup ./opensearch-windows-install.bat &
+              timeout 900 bash -c 'while [[ "$(curl -o /dev/null -w ''%{http_code}'' http://localhost:9200)" != "200" ]]; do echo sleeping 5; sleep 5; done'
+              curl -s http://localhost:9200/_cluster/health?pretty
+          else
+              echo "Keep OpenSearch Security"
+              nohup ./opensearch-windows-install.bat &
+              timeout 900 bash -c 'while [[ "$(curl -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do echo sleeping 5; sleep 5; done'
+              curl -sk https://localhost:9200/_cluster/health?pretty -u admin:admin
+          fi
           netstat -anP tcp | grep LISTEN | grep 9200 || netstat -ntlp | grep 9200
         shell: bash
       - name: Get and run OpenSearch-Dashboards
@@ -64,11 +86,25 @@ jobs:
           # Temporary solution to add vis_builder and data_source enabled parameters
           echo "vis_builder.enabled: true" >> config/opensearch_dashboards.yml
           echo "data_source.enabled: true" >> config/opensearch_dashboards.yml
+          # echo "data_source.encryption.wrappingKeyName: 'changeme'" >> config/opensearch_dashboards.yml
+          # echo "data_source.encryption.wrappingKeyNamespace: 'changeme'" >> config/opensearch_dashboards.yml
+          # echo "data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]" >> config/opensearch_dashboards.yml
           # Not useful now as error shows when trying to force a background run with parameters on Windows
-          bin/opensearch-dashboards.bat serve ${{ inputs.osd-serve-args }} &
-          bin/opensearch-dashboards.bat &
-          timeout 300 bash -c 'while [[ "$(curl http://localhost:5601/api/status -u admin:admin | jq -r '.status.overall.state')" != "green" ]]; do echo sleeping 5; sleep 5; done'
-          curl -sk localhost:5601/api/status -u admin:admin | jq
+          # bin/opensearch-dashboards.bat serve ${{ inputs.osd-serve-args }} &
+          if [ "$SECURITY_ENABLED" = 'false' ]; then
+              echo "Remove Dashboards Security"
+              ./bin/opensearch-dashboards-plugin.bat remove securityDashboards
+              sed -i /^opensearch_security/d config/opensearch_dashboards.yml
+              sed -i 's/https/http/' config/opensearch_dashboards.yml
+              bin/opensearch-dashboards.bat &
+              timeout 300 bash -c 'while [[ "$(curl http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do echo sleeping 5; sleep 5; done'
+              curl -s http://localhost:5601/api/status | jq
+          else
+              echo "Keep Dashboards Security"
+              bin/opensearch-dashboards.bat &
+              timeout 300 bash -c 'while [[ "$(curl -k http://localhost:5601/api/status -u admin:admin | jq -r '.status.overall.state')" != "green" ]]; do echo sleeping 5; sleep 5; done'
+              curl -sk localhost:5601/api/status -u admin:admin | jq
+          fi
           netstat -anP tcp | grep LISTEN | grep 5601 || netstat -ntlp | grep 5601
         shell: bash
       - name: Get Cypress version

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -11,6 +11,9 @@ on:
       osd-serve-args:
         required: false
         type: string
+      security-enabled:
+        required: false
+        type: string
 jobs:
   tests:
     name: Run Cypress E2E tests for ${{ inputs.test-name }}
@@ -34,13 +37,31 @@ jobs:
         working-directory: cypress-test
         run: |
           echo "VERSION=$(yarn --silent pkg-version)" >> $GITHUB_ENV
+      - name: Get security setups
+        run: |
+          SECURITY_ENABLED=${{ inputs.security-enabled }}
+          if [ "$SECURITY_ENABLED" != 'false' ]; then
+              echo "SECURITY_ENABLED=true" >> $GITHUB_ENV
+          else
+              echo "SECURITY_ENABLED=false" >> $GITHUB_ENV
+          fi
       - name: Get and run OpenSearch
         run: |
           wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/tar/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/
-          ./opensearch-tar-install.sh &
-          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+          if [ "$SECURITY_ENABLED" = 'false' ]; then
+              echo "Remove OpenSearch Security"
+              echo "plugins.security.disabled: true" >> config/opensearch.yml
+              ./opensearch-tar-install.sh &
+              timeout 900 bash -c 'while [[ "$(curl -o /dev/null -w ''%{http_code}'' http://localhost:9200)" != "200" ]]; do sleep 5; done'
+              curl http://localhost:9200
+          else
+              echo "Keep OpenSearch Security"
+              ./opensearch-tar-install.sh &
+              timeout 900 bash -c 'while [[ "$(curl -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+              curl https://localhost:9200 -u admin:admin --insecure
+          fi
       - name: Get OpenSearch-Dashboards
         run: |
           wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/tar/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
@@ -57,8 +78,20 @@ jobs:
       - name: Run OpenSearch-Dashboards server
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
-          bin/opensearch-dashboards serve ${{ inputs.osd-serve-args }} &
-          timeout 300 bash -c 'while [[ "$(curl -s -u admin:admin -k localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          if [ "$SECURITY_ENABLED" = 'false' ]; then
+              echo "Remove Dashboards Security"
+              ./bin/opensearch-dashboards-plugin remove securityDashboards
+              sed -i /^opensearch_security/d config/opensearch_dashboards.yml
+              sed -i 's/https/http/' config/opensearch_dashboards.yml
+              bin/opensearch-dashboards serve ${{ inputs.osd-serve-args }} &
+              timeout 300 bash -c 'while [[ "$(curl http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+              curl http://localhost:5601/api/status
+          else
+              echo "Keep Dashboards Security"
+              bin/opensearch-dashboards serve ${{ inputs.osd-serve-args }} &
+              timeout 300 bash -c 'while [[ "$(curl -u admin:admin -k http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+              curl http://localhost:5601/api/status -u admin:admin --insecure
+          fi
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/dashboard_sanity_test_spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/dashboard_sanity_test_spec.js
@@ -5,5 +5,4 @@
 
 import { dashboardSanityTests } from '../../common/dashboard_sample_data_spec.js';
 
-
 dashboardSanityTests();


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description

Add support for linux e2e template to run no-sec tests

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/2649

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
