### PR TITLE
[Backport 2.x] Add support for linux e2e template to run no-sec tests (#367 #383)

### DIFF
--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
@@ -1,0 +1,44 @@
+name: Bundle Snapshot based E2E Cypress tests workflow for core Dashboards (Windows)
+on:
+  pull_request:
+    branches:
+      - main
+      - dev-*
+  push:
+    branches:
+      - main
+      - dev-*
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.filter.outputs.tests }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            tests:
+              - 'cypress/**/core-opensearch-dashboards/**'
+
+  tests-with-security:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template-windows.yml
+    with:
+      test-name: Core Dashboards using Bundle Snapshot
+      test-command: env CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-with-security --browser chrome --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
+      # not useful now as the windows e2e template currently do not allow serving parameters
+      #osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
+
+  tests-without-security:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template-windows.yml
+    with:
+      test-name: Core Dashboards using Bundle Snapshot
+      test-command: env CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-without-security --browser chrome --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
+      # not useful now as the windows e2e template currently do not allow serving parameters
+      #osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
+      security-enabled: false

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -22,7 +22,7 @@ jobs:
             tests:
               - 'cypress/**/core-opensearch-dashboards/**'
 
-  tests:
+  tests-with-security:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
@@ -30,3 +30,13 @@ jobs:
       test-name: Core Dashboards using Bundle Snapshot
       test-command: env CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
       osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
+
+  tests-without-security:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Core Dashboards using Bundle Snapshot
+      test-command: env CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-without-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
+      osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
+      security-enabled: false

--- a/.github/workflows/release-e2e-workflow-template-windows.yml
+++ b/.github/workflows/release-e2e-workflow-template-windows.yml
@@ -1,0 +1,138 @@
+name: Release tests workflow in Bundled OpenSearch Dashboards (Windows)
+on:
+  workflow_call:
+    inputs:
+      test-name:
+        required: true
+        type: string
+      test-command:
+        required: true
+        type: string
+      security-enabled:
+        required: false
+        type: string
+jobs:
+  tests:
+    name: Run Cypress E2E tests for ${{ inputs.test-name }} (Windows)
+    runs-on: windows-latest
+    env:
+      # prevents extra Cypress installation progress messages
+      CI: 1
+      # avoid warnings like "tput: No value for $TERM and no -T specified"
+      TERM: xterm
+    steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Checkout cypress-test
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}
+          path: cypress-test
+      - name: Get package version
+        working-directory: cypress-test
+        run: |
+          echo "VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+          echo "PLATFORM=windows" >> $GITHUB_ENV
+          # Temp measure to resolve script not running on windows
+        shell: bash
+      - name: Get security setups
+        run: |
+          SECURITY_ENABLED=${{ inputs.security-enabled }}
+          if [ "$SECURITY_ENABLED" != 'false' ]; then
+              echo "SECURITY_ENABLED=true" >> $GITHUB_ENV
+          else
+              echo "SECURITY_ENABLED=false" >> $GITHUB_ENV
+          fi
+        shell: bash
+      - name: Get and run OpenSearch
+        run: |
+          curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/${{ env.PLATFORM }}/x64/zip/dist/opensearch/opensearch-${{ env.VERSION }}-${{ env.PLATFORM }}-x64.zip
+          unzip -q opensearch-${{ env.VERSION }}-windows-x64.zip
+          cd opensearch-${{ env.VERSION }}/
+          if [ "$SECURITY_ENABLED" = 'false' ]; then
+              echo "Remove OpenSearch Security"
+              echo "plugins.security.disabled: true" >> config/opensearch.yml
+              nohup ./opensearch-windows-install.bat &
+              timeout 900 bash -c 'while [[ "$(curl -o /dev/null -w ''%{http_code}'' http://localhost:9200)" != "200" ]]; do echo sleeping 5; sleep 5; done'
+              curl -s http://localhost:9200/_cluster/health?pretty
+          else
+              echo "Keep OpenSearch Security"
+              nohup ./opensearch-windows-install.bat &
+              timeout 900 bash -c 'while [[ "$(curl -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do echo sleeping 5; sleep 5; done'
+              curl -sk https://localhost:9200/_cluster/health?pretty -u admin:admin
+          fi
+          netstat -anP tcp | grep LISTEN | grep 9200 || netstat -ntlp | grep 9200
+        shell: bash
+      - name: Get and run OpenSearch-Dashboards
+        run: |
+          curl -SLO https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/${{ env.PLATFORM }}/x64/zip/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-${{ env.PLATFORM }}-x64.zip
+          unzip -q opensearch-dashboards-${{ env.VERSION }}-windows-x64.zip
+        shell: bash
+      - name: Get node and yarn versions
+        run: |
+          echo "node_version=$(jq -r '.engines.node' ./opensearch-dashboards-${{ env.VERSION }}/package.json)" >> $GITHUB_ENV
+        shell: bash
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+      - name: Run OpenSearch-Dashboards server
+        run: |
+          netstat -anP tcp | grep LISTEN | grep 9200 || netstat -ntlp | grep 9200
+          cd opensearch-dashboards-${{ env.VERSION }}
+          # Temporary solution to add vis_builder and data_source enabled parameters
+          echo "vis_builder.enabled: true" >> config/opensearch_dashboards.yml
+          echo "data_source.enabled: true" >> config/opensearch_dashboards.yml
+          # echo "data_source.encryption.wrappingKeyName: 'changeme'" >> config/opensearch_dashboards.yml
+          # echo "data_source.encryption.wrappingKeyNamespace: 'changeme'" >> config/opensearch_dashboards.yml
+          # echo "data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]" >> config/opensearch_dashboards.yml
+          # Not useful now as error shows when trying to force a background run with parameters on Windows
+          # bin/opensearch-dashboards.bat serve ${{ inputs.osd-serve-args }} &
+          if [ "$SECURITY_ENABLED" = 'false' ]; then
+              echo "Remove Dashboards Security"
+              ./bin/opensearch-dashboards-plugin.bat remove securityDashboards
+              sed -i /^opensearch_security/d config/opensearch_dashboards.yml
+              sed -i 's/https/http/' config/opensearch_dashboards.yml
+              bin/opensearch-dashboards.bat &
+              timeout 300 bash -c 'while [[ "$(curl http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do echo sleeping 5; sleep 5; done'
+              curl -s http://localhost:5601/api/status | jq
+          else
+              echo "Keep Dashboards Security"
+              bin/opensearch-dashboards.bat &
+              timeout 300 bash -c 'while [[ "$(curl -k http://localhost:5601/api/status -u admin:admin | jq -r '.status.overall.state')" != "green" ]]; do echo sleeping 5; sleep 5; done'
+              curl -sk localhost:5601/api/status -u admin:admin | jq
+          fi
+          netstat -anP tcp | grep LISTEN | grep 5601 || netstat -ntlp | grep 5601
+        shell: bash
+      - name: Get Cypress version
+        run: |
+          cd ./cypress-test
+          npm install
+        shell: bash
+      - name: Cypress tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: cypress-test
+          command: ${{ inputs.test-command }}
+          wait-on: 'http://localhost:5601'
+      # Screenshots are only captured on failure, will change this once we do visual regression tests
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress-test/cypress/screenshots
+      # Test run video was always captured, so this action uses "always()" condition
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: cypress-videos
+          path: cypress-test/cypress/videos
+      # Test reports was always captured, so this action uses "always()" condition
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: cypress-results
+          path: cypress-test/cypress/results

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -11,6 +11,9 @@ on:
       osd-serve-args:
         required: false
         type: string
+      security-enabled:
+        required: false
+        type: string
 jobs:
   tests:
     name: Run Cypress E2E tests for ${{ inputs.test-name }}
@@ -34,13 +37,31 @@ jobs:
         working-directory: cypress-test
         run: |
           echo "VERSION=$(yarn --silent pkg-version)" >> $GITHUB_ENV
+      - name: Get security setups
+        run: |
+          SECURITY_ENABLED=${{ inputs.security-enabled }}
+          if [ "$SECURITY_ENABLED" != 'false' ]; then
+              echo "SECURITY_ENABLED=true" >> $GITHUB_ENV
+          else
+              echo "SECURITY_ENABLED=false" >> $GITHUB_ENV
+          fi
       - name: Get and run OpenSearch
         run: |
           wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.VERSION }}/latest/linux/x64/tar/dist/opensearch/opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           tar -xzf opensearch-${{ env.VERSION }}-linux-x64.tar.gz
           cd opensearch-${{ env.VERSION }}/
-          ./opensearch-tar-install.sh &
-          timeout 900 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+          if [ "$SECURITY_ENABLED" = 'false' ]; then
+              echo "Remove OpenSearch Security"
+              echo "plugins.security.disabled: true" >> config/opensearch.yml
+              ./opensearch-tar-install.sh &
+              timeout 900 bash -c 'while [[ "$(curl -o /dev/null -w ''%{http_code}'' http://localhost:9200)" != "200" ]]; do sleep 5; done'
+              curl http://localhost:9200
+          else
+              echo "Keep OpenSearch Security"
+              ./opensearch-tar-install.sh &
+              timeout 900 bash -c 'while [[ "$(curl -o /dev/null -w ''%{http_code}'' -u admin:admin -k https://localhost:9200)" != "200" ]]; do sleep 5; done'
+              curl https://localhost:9200 -u admin:admin --insecure
+          fi
       - name: Get OpenSearch-Dashboards
         run: |
           wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/${{ env.VERSION }}/latest/linux/x64/tar/dist/opensearch-dashboards/opensearch-dashboards-${{ env.VERSION }}-linux-x64.tar.gz
@@ -57,8 +78,20 @@ jobs:
       - name: Run OpenSearch-Dashboards server
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
-          bin/opensearch-dashboards serve ${{ inputs.osd-serve-args }} &
-          timeout 300 bash -c 'while [[ "$(curl -s -u admin:admin -k localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          if [ "$SECURITY_ENABLED" = 'false' ]; then
+              echo "Remove Dashboards Security"
+              ./bin/opensearch-dashboards-plugin remove securityDashboards
+              sed -i /^opensearch_security/d config/opensearch_dashboards.yml
+              sed -i 's/https/http/' config/opensearch_dashboards.yml
+              bin/opensearch-dashboards serve ${{ inputs.osd-serve-args }} &
+              timeout 300 bash -c 'while [[ "$(curl http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+              curl http://localhost:5601/api/status
+          else
+              echo "Keep Dashboards Security"
+              bin/opensearch-dashboards serve ${{ inputs.osd-serve-args }} &
+              timeout 300 bash -c 'while [[ "$(curl -u admin:admin -k http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+              curl http://localhost:5601/api/status -u admin:admin --insecure
+          fi
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -3,7 +3,7 @@
 set -e
 
 OSD_BUILD_MANIFEST='../local-test-cluster/opensearch-dashboards-*/manifest.yml'
-OSD_TEST_PATH='cypress/integration/core-opensearch-dashboards/opensearch-dashboards'
+OSD_TEST_PATH='cypress/integration/core-opensearch-dashboards'
 OSD_PLUGIN_TEST_PATH='cypress/integration/plugins'
 
 # Map component name in opensearch-build repo INPUT_MANIFEST with folder name for tests in functional repo
@@ -47,7 +47,7 @@ function get_test_list() {
 
         if [ "$component_name" = "OpenSearch-Dashboards" ]; then
             TEST_PATH_LOCAL=$OSD_TEST_PATH
-            TEST_FILES_EXT_LOCAL="*.js"
+            TEST_FILES_EXT_LOCAL="**/*.js"
         else
             TEST_PATH_LOCAL=$OSD_PLUGIN_TEST_PATH
             TEST_FILES_EXT_LOCAL="*"


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description

[Backport 2.x] Add support for linux e2e template to run no-sec tests

### Issues Resolved
#367
#383

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
