### PR TITLE
[Vis Builder] [Test] Add functional tests for table vis

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  VB_APP_URL,
+  VB_INDEX_END_TIME,
+  VB_INDEX_ID,
+  VB_INDEX_PATTERN,
+  VB_INDEX_START_TIME,
+  VB_PATH_INDEX_DATA,
+  VB_PATH_SO_DATA,
+} from '../../../../../../utils/constants';
+
+if (Cypress.env('VISBUILDER_ENABLED')) {
+  describe('Vis Builder: Table Chart', () => {
+    before(() => {
+      cy.deleteIndex(VB_INDEX_ID);
+      cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
+      cy.importSavedObjects(VB_PATH_SO_DATA);
+
+      cy.visit(VB_APP_URL);
+
+      // Wait for page to load
+      cy.waitForLoader();
+      cy.vbSelectDataSource(VB_INDEX_PATTERN);
+
+      // Set Top nav
+      cy.setTopNavDate(VB_INDEX_START_TIME, VB_INDEX_END_TIME);
+
+      cy.vbSelectVisType('Table');
+    });
+
+    it('Basic test', () => {
+      // vis builder should render a basic table vis
+      cy.getElementByTestId('field-undefined-showDetails').drag(
+        '[data-test-subj="dropBoxAddField-metric"]'
+      );
+      testMetric('10,000');
+
+      // vis builder should render a table vis with multiple rows
+      cy.getElementByTestId('field-categories.keyword-showDetails').drag(
+        '[data-test-subj="dropBoxAddField-bucket"]'
+      );
+      testSplitRows(['Cat', 'Dog', 'Hawk', 'Rabbit']);
+      removeBucket('dropBoxField-bucket-0');
+
+      // vis builder should render splitted tables in rows
+      cy.getElementByTestId('field-categories.keyword-showDetails').drag(
+        '[data-test-subj="dropBoxAddField-split_row"]'
+      );
+      testSplitTables('', 4);
+      removeBucket('dropBoxField-split_row-0');
+
+      // vis builder should render splitted tables in columns
+      cy.getElementByTestId('field-categories.keyword-showDetails').drag(
+        '[data-test-subj="dropBoxAddField-split_column"]'
+      );
+      testSplitTables('visTable__groupInColumns', 4);
+    });
+
+    after(() => {
+      cy.deleteIndex(VB_INDEX_ID);
+    });
+  });
+}
+
+export const testMetric = (value) => {
+  cy.getElementByTestId('dataGridRowCell')
+    .find('[class="euiDataGridRowCell__truncate"]')
+    .should('contain.text', value);
+};
+
+export const testSplitRows = (valueArray) => {
+  for (var value of valueArray) {
+    testMetric(value);
+  }
+};
+
+// remove a bucket metric
+export const removeBucket = (bucket) => {
+  cy.getElementByTestId(bucket).within((item) => {
+    item.find('[data-test-subj="dropBoxRemoveBtn"]').click();
+  });
+};
+
+export const testSplitTables = (dir, num) => {
+  cy.getElementByTestId('visTable')
+    .should('have.class', `visTable ${dir}`.trim())
+    .find('[class="visTable__group"]')
+    .should(($tables) => {
+      // should have found specified number of tables
+      expect($tables).to.have.length(num);
+    });
+};


### PR DESCRIPTION
### Description

This PR adds basic functional tests for table vis rendered in vis builder. These functional tests are only focusing on how
vis builder renders table vis given diff metric and bucket. The functions related specific to table vis will be tested in table visualization to avoid any duplications.

### Issues Resolved
 https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/388


https://user-images.githubusercontent.com/79961084/200977570-94733e88-8f97-43f4-ad41-dd9ac6f2d632.mov



### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
