### PR TITLE
add peterzhuamazon as maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,13 +1,14 @@
 ## Current Maintainers
 
-| Maintainer               | GitHub ID                                        | Affiliation |
-| ------------------------ | ------------------------------------------------ | ----------- |
-| Tianle Huang             | [tianleh](https://github.com/tianleh)            | Amazon      |
-| Kawika Avilla            | [kavilla](https://github.com/kavilla)            | Amazon      |
-| Tyler Ohlsen             | [ohltyler](https://github.com/ohltyler)          | Amazon      |
-| Cong Wang                | [CCongWang](https://github.com/CCongWang)        | Amazon      |
-| Manideep Pabba           | [mpabba3003](https://github.com/mpabba3003)      | Amazon      |
-| Ashwin P Chandran        | [ashwin-pc](https://github.com/ashwin-pc)        | Amazon      |
+| Maintainer               | GitHub ID                                           | Affiliation |
+| ------------------------ | --------------------------------------------------- | ----------- |
+| Tianle Huang             | [tianleh](https://github.com/tianleh)               | Amazon      |
+| Kawika Avilla            | [kavilla](https://github.com/kavilla)               | Amazon      |
+| Tyler Ohlsen             | [ohltyler](https://github.com/ohltyler)             | Amazon      |
+| Cong Wang                | [CCongWang](https://github.com/CCongWang)           | Amazon      |
+| Manideep Pabba           | [mpabba3003](https://github.com/mpabba3003)         | Amazon      |
+| Ashwin P Chandran        | [ashwin-pc](https://github.com/ashwin-pc)           | Amazon      |
+| Peter Zhu                | [peterzhuamazon](https://github.com/peterzhuamazon) | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

The maintainers have voted https://github.com/peterzhuamazon as maintainer. Also @peterzhuamazon  agreed to join as maintainer.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
