### PR TITLE
update Github action trigger to be all branches

### DIFF
--- a/.github/workflows/alerting-release-e2e-workflow.yml
+++ b/.github/workflows/alerting-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: Alerting Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/anomaly-detection-release-e2e-workflow.yml
+++ b/.github/workflows/anomaly-detection-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: Anomaly Detection Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/custom-import-map-dashboards-release-e2e-workflow.yml
+++ b/.github/workflows/custom-import-map-dashboards-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: customImportMapDashboards Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
@@ -1,13 +1,9 @@
 name: Bundle Snapshot based E2E Cypress tests workflow for core Dashboards (Windows)
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
   push:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 
 jobs:
   changes:

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -1,13 +1,9 @@
 name: Bundle Snapshot based E2E Cypress tests workflow for core Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
   push:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 
 jobs:
   changes:

--- a/.github/workflows/gantt-chart-release-e2e-workflow.yml
+++ b/.github/workflows/gantt-chart-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: Gantt Chart Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/index-management-release-e2e-workflow.yml
+++ b/.github/workflows/index-management-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: Index Management Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_checker.yml
+++ b/.github/workflows/lint_checker.yml
@@ -4,9 +4,7 @@
 name: Lint Checker
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   tests:
     name: Lint Checker

--- a/.github/workflows/notifications-release-e2e-workflow.yml
+++ b/.github/workflows/notifications-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: Notifications Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/observability-release-e2e-workflow.yml
+++ b/.github/workflows/observability-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: Observability Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/query-workbench-release-e2e-workflow.yml
+++ b/.github/workflows/query-workbench-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: Query Workbench Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/reports-release-e2e-workflow.yml
+++ b/.github/workflows/reports-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: Reports Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/search-relevance-release-e2e-workflow.yml
+++ b/.github/workflows/search-relevance-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: Search Relevance Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/security-release-e2e-workflow.yml
+++ b/.github/workflows/security-release-e2e-workflow.yml
@@ -1,9 +1,7 @@
 name: Security Release tests workflow in Bundled OpenSearch Dashboards
 on:
   pull_request:
-    branches:
-      - main
-      - dev-*
+    branches: [ '**' ]
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: Tianle Huang <tianleh@amazon.com>

### Description

@ohltyler noticed that workflows are not running for branches e.g 2.x. Thus we are changing to match all branches.

### Issues Resolved



### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
