### PR TITLE
Removing form field in gantt-chart, observability and workbench

### DIFF
--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -19,7 +19,6 @@ describe('Dump test data', () => {
     const dumpDataSet = (ndjson, index) =>
       cy.request({
         method: 'POST',
-        form: true,
         url: 'api/console/proxy',
         headers: {
           'content-type': 'application/json;charset=UTF-8',

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -19,6 +19,7 @@ describe('Dump test data', () => {
     const dumpDataSet = (ndjson, index) =>
       cy.request({
         method: 'POST',
+        form: false,
         url: 'api/console/proxy',
         headers: {
           'content-type': 'application/json;charset=UTF-8',

--- a/cypress/integration/plugins/observability-dashboards/0_before.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/0_before.spec.js
@@ -43,6 +43,7 @@ describe('Before', () => {
       cy.request(mapping_url).then((response) => {
         cy.request({
           method: 'POST',
+          form: false,
           url: 'api/console/proxy',
           headers: {
             'content-type': 'application/json;charset=UTF-8',
@@ -59,6 +60,7 @@ describe('Before', () => {
       cy.request(data_url).then((response) => {
         cy.request({
           method: 'POST',
+          form: false,
           url: 'api/console/proxy',
           headers: {
             'content-type': 'application/json;charset=UTF-8',

--- a/cypress/integration/plugins/observability-dashboards/0_before.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/0_before.spec.js
@@ -43,7 +43,6 @@ describe('Before', () => {
       cy.request(mapping_url).then((response) => {
         cy.request({
           method: 'POST',
-          form: true,
           url: 'api/console/proxy',
           headers: {
             'content-type': 'application/json;charset=UTF-8',
@@ -60,7 +59,6 @@ describe('Before', () => {
       cy.request(data_url).then((response) => {
         cy.request({
           method: 'POST',
-          form: true,
           url: 'api/console/proxy',
           headers: {
             'content-type': 'application/json;charset=UTF-8',

--- a/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
+++ b/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
@@ -20,6 +20,7 @@ describe('Dump test data', () => {
       cy.request(url).then((response) => {
         cy.request({
           method: 'POST',
+          form: false,
           url: 'api/console/proxy',
           headers: {
             'content-type': 'application/json;charset=UTF-8',
@@ -195,6 +196,7 @@ describe('Test and verify SQL downloads', () => {
     it(title, () => {
       cy.request({
         method: 'POST',
+        form: false,
         url: url,
         headers: {
           'content-type': 'application/json;charset=UTF-8',

--- a/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
+++ b/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
@@ -20,7 +20,6 @@ describe('Dump test data', () => {
       cy.request(url).then((response) => {
         cy.request({
           method: 'POST',
-          form: true,
           url: 'api/console/proxy',
           headers: {
             'content-type': 'application/json;charset=UTF-8',
@@ -196,7 +195,6 @@ describe('Test and verify SQL downloads', () => {
     it(title, () => {
       cy.request({
         method: 'POST',
-        form: true,
         url: url,
         headers: {
           'content-type': 'application/json;charset=UTF-8',


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

### Description

The functional tests for gantt-chart, observability and workbench were over-riding the default cypress form field in api requests to OpenSearch. This was leading to error as form field override is only necessary when this header is set to `x-www-form-urlencoded` 

Solution: Removed the form field as it is not required in the tests.

### Issues Resolved

#313 
#310  
#311  
#312  

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
