### PR TITLE
[Site][2.5] update test result explorer site with new test links

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -47,10 +47,10 @@
       </tr>
       <tr>
         <td>
-          <input type="text" id="version" value="2.0.0">
+          <input type="text" id="version" value="2.5.0">
         </td>
         <td>
-          <input type="text" id="buildNumber" value="3936">
+          <input type="text" id="buildNumber" value="5367">
         </td>
       </tr>
     </table>
@@ -65,6 +65,7 @@
         <td>
           <select id="platform">
             <option value="linux">Linux</option>
+            <option value="windows">Windows</option>
           </select>
         </td>
         <td>
@@ -83,16 +84,16 @@
           <input type="checkbox" id="security">
         </td>
       </tr>
-    </table>
-    <table id="advancedInputsTable">
       <tr>
         <th>Test Number</th>
       </tr>
       <tr>
         <td>
-          <input type="text" id="testNumber" value="1">
+          <input type="text" id="testNumber" value="2993">
         </td>
       </tr>
+    </table>
+    <table id="advancedInputsTable">
       <tr>
         <th>Test Job Name</th>
       </tr>
@@ -121,6 +122,9 @@
       </li>
       <li>
         <a id="osLink"></a>
+      </li>
+      <li>
+        <a id="jenkinsLink"></a>
       </li>
     </ul>
     <h2>Plugins:</h2>
@@ -154,8 +158,14 @@
           <button id="reportsDashboardsButton" onclick="getPluginLinks('reports-dashboards')">
             reportsDashboards
           </button>
+          <button id="searchRelevanceDashboardsButton" onclick="getPluginLinks('search-relevance-dashboards')">
+            searchRelevanceDashboards
+          </button>
           <button id="securityDashboardsButton" onclick="getPluginLinks('security')">
             securityDashboards
+          </button>
+          <button id="securityAnalyticsDashboardsButton" onclick="getPluginLinks('security-analytics-dashboards-plugin')">
+            securityAnalyticsDashboards
           </button>
       </tr>
     </table>

--- a/site/js/dashboard.js
+++ b/site/js/dashboard.js
@@ -4,9 +4,9 @@
  */
 
 const defaults = {
-  version: '2.0.1',
-  buildNumber: '3958',
-  testNumber: '1',
+  version: '2.5.0',
+  buildNumber: '5367',
+  testNumber: '2993',
   testJobName: 'integ-test-opensearch-dashboards',
   platform: 'linux',
   arch: 'x64',
@@ -45,7 +45,11 @@ const plugins = {
   'custom-import-map-dashboards': {
     name: 'customImportMapDashboards',
     default: {
-      videos: ['import_vector_map_tab.spec.js'],
+      videos: [
+        'documentsLayer.spec.js',
+        'import_vector_map_tab.spec.js',
+        `opensearchMapLayer.spec.js`,
+      ],
     },
   },
   'gantt-chart-dashboards': {
@@ -101,6 +105,12 @@ const plugins = {
       ],
     },
   },
+  'search-relevance-dashboards': {
+    name: 'searchRelevanceDashboards',
+    default: {
+      videos: ['1_query_compare.spec.js'],
+    },
+  },
   security: {
     name: 'securityDashboards',
     default: {
@@ -113,6 +123,12 @@ const plugins = {
         'roles_spec.js',
         'tenants_spec.js',
       ],
+    },
+  },
+  'security-analytics-dashboards-plugin': {
+    name: 'securityAnalyticsDashboards',
+    default: {
+      videos: ['rules_spec.js'],
     },
   },
 };
@@ -199,6 +215,14 @@ function getTestResults() {
   var osLink = document.getElementById('osLink');
   osLink.textContent = osUrl;
   osLink.href = osUrl;
+
+  const jenkinsUrl =
+    'https://build.ci.opensearch.org/job/' +
+    `${testJobName}/` +
+    `${testNumber}`;
+  var jenkinsLink = document.getElementById('jenkinsLink');
+  jenkinsLink.textContent = jenkinsUrl;
+  jenkinsLink.href = jenkinsUrl;
 
   document.getElementById('testResultsDiv').style.display = 'block';
   document.getElementById('testResults').src =

--- a/site/styles.css
+++ b/site/styles.css
@@ -19,6 +19,11 @@ body {
     text-align: left;
 }
 
+#inputsDiv table td select {
+    width: 100%;
+}
+
+
 #inputsDiv table #securityTd {
     text-align: center;
 }
@@ -130,6 +135,7 @@ body {
 
 #testResultsDiv {
     display: none;
+    margin-top: 8px;
 }
 
 #testResults {


### PR DESCRIPTION
### Description

Update pages site with new test links for the latest release of 2.5.0.

Added windows option to platforms.

Moved test number from advanced settings to regular settings because test number is no longer static for each test run.

Update default values.

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
