### PR TITLE
Replacing day.js with moment.js -> 1.3 and older 

### DIFF
--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -5,11 +5,8 @@
 
 /// <reference types="cypress" />
 
-import customParseFormat from 'dayjs/plugin/customParseFormat';
-import dayjs from 'dayjs';
 import { BASE_PATH } from '../../../utils/constants';
-
-dayjs.extend(customParseFormat);
+import moment from 'moment';
 
 const delay = 100;
 const GANTT_VIS_NAME =
@@ -181,7 +178,9 @@ describe('Configure panel settings', () => {
       .eq(0)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'MM/DD hh:mm:ss A', true).isValid()).to.be.true;
+        expect(
+          moment(text, 'MM/DD hh:mm:ss A').format('MM/DD hh:mm:ss A')
+        ).equal(text);
       });
 
     cy.get('select').eq(3).select('MM/DD/YY hh:mm A');
@@ -192,7 +191,9 @@ describe('Configure panel settings', () => {
       .eq(0)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'MM/DD/YY hh:mm A', true).isValid()).to.be.true;
+        expect(
+          moment(text, 'MM/DD/YY hh:mm A').format('MM/DD/YY hh:mm A')
+        ).equal(text);
       });
 
     cy.get('select').eq(3).select('HH:mm:ss.SSS');
@@ -203,7 +204,7 @@ describe('Configure panel settings', () => {
       .eq(0)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'HH:mm:ss.SSS', true).isValid()).to.be.true;
+        expect(moment(text, 'HH:mm:ss.SSS').format('HH:mm:ss.SSS')).equal(text);
       });
 
     cy.get('select').eq(3).select('MM/DD HH:mm:ss');
@@ -214,7 +215,9 @@ describe('Configure panel settings', () => {
       .eq(0)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'MM/DD HH:mm:ss', true).isValid()).to.be.true;
+        expect(moment(text, 'MM/DD HH:mm:ss').format('MM/DD HH:mm:ss')).equal(
+          text
+        );
       });
 
     cy.get('select').eq(3).select('MM/DD/YY HH:mm');
@@ -225,7 +228,9 @@ describe('Configure panel settings', () => {
       .eq(0)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'MM/DD/YY HH:mm', true).isValid()).to.be.true;
+        expect(moment(text, 'MM/DD/YY HH:mm').format('MM/DD/YY HH:mm')).equal(
+          text
+        );
       });
   });
 


### PR DESCRIPTION
Signed-off-by: Shenoy Pratik <sgguruda@amazon.com>

### Description

For branches 1.3 and prior, FTR uses cypress 5 which doesn't have default shipped moment.js rather it has moment.js. 
This PR replaces the day.js library usage for older versions. 

### Issues Resolved

```
Error: Webpack Compilation Error
./cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
Module not found: Error: Can't resolve 'dayjs' in '/docker/cypress/integration/plugins/gantt-chart-dashboards'
resolve 'dayjs' in '/docker/cypress/integration/plugins/gantt-chart-dashboards'
```
Related to https://github.com/cypress-io/cypress/issues/8714

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
