### PR TITLE
Fix workbench find full window button

### DIFF
--- a/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
+++ b/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
@@ -183,7 +183,7 @@ describe('Test SQL UI', () => {
 
     cy.get('.euiButton__text').contains('Run').click({ force: true });
     cy.wait(QUERY_WORKBENCH_DELAY);
-    cy.get('.euiButton__text')
+    cy.get('.euiButton__text', { withinSubject: null })
       .contains('Full screen view')
       .click({ force: true });
 


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description

cypress issue 14566
full window button sometimes cannot be found

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
