### PR TITLE
[Backport 2.5] feat: add function test for IM plugin (#443) 

### DIFF
--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")"
+          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")"
       - name: Setup node
         uses: actions/setup-node@v1
         with:

--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -106,25 +106,6 @@ describe('Aliases', () => {
         .end();
 
       cy.get('[data-test-subj="7 more"]').should('exist');
-
-      cy.get('[data-test-subj="moreAction"] button')
-        .click()
-        .get('[data-test-subj="deleteAction"]')
-        .click();
-      // The confirm button should be disabled
-      cy.get('[data-test-subj="deleteConfirmButton"]').should('be.disabled');
-      // type delete
-      cy.wait(500).get('[data-test-subj="deleteInput"]').type('delete');
-      cy.get('[data-test-subj="deleteConfirmButton"]').should(
-        'not.be.disabled'
-      );
-      // click to delete
-      cy.get('[data-test-subj="deleteConfirmButton"]').click();
-      // the alias should not exist
-      cy.wait(500);
-      cy.get(`#_selection_column_${SAMPLE_ALIAS_PREFIX}-0-checkbox`).should(
-        'not.exist'
-      );
     });
   });
 


### PR DESCRIPTION
* feat: add function test for IM plugin on v2.5

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: remove snapshot_spec

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: remove duplicate commands

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: remove duplicate commands

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: remove some useless test case

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: remove snapshot_spec and duplicate commands (#450)

* feat: remove snapshot spec and update commands

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: make actions to run again

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: change to addIndexAlias & removeIndexAlias

Signed-off-by: suzhou <suzhou@amazon.com>

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: lint

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: fix workflow bug

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: use 2.5.0 version

Signed-off-by: suzhou <suzhou@amazon.com>

* feat: revert version to 3.0.0

Signed-off-by: suzhou <suzhou@amazon.com>

---------

Signed-off-by: suzhou <suzhou@amazon.com>
(cherry picked from commit 95edebceb23308135fa64fb67643d12797846d96)

### Description

[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
