### PR TITLE
Add Cypress test for Default Saved Map

### DIFF
--- a/cypress/integration/plugins/custom-import-map-dashboards/add_saved_object.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/add_saved_object.spec.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BASE_PATH } from '../../../utils/constants';
+
+describe('Add flights dataset saved object', () => {
+  before(() => {
+    cy.visit(`${BASE_PATH}/app/maps-dashboards`, {
+      retryOnStatusCodeFailure: true,
+      timeout: 60000,
+    });
+    cy.get('div[data-test-subj="indexPatternEmptyState"]', { timeout: 60000 })
+      .contains(/Add sample data/)
+      .click();
+    cy.get('div[data-test-subj="sampleDataSetCardflights"]', { timeout: 60000 })
+      .contains(/Add data/)
+      .click();
+    cy.wait(60000);
+  });
+
+  after(() => {
+    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory`);
+    cy.get('button[data-test-subj="removeSampleDataSetflights"]')
+      .should('be.visible')
+      .click();
+  });
+
+  it('check if maps saved object of flights dataset can be found and open', () => {
+    cy.visit(`${BASE_PATH}/app/maps-dashboards`);
+    cy.contains(
+      '[Flights] Flights Status on Maps Destination Location'
+    ).click();
+    cy.get('[data-test-subj="layerControlPanel"]').should(
+      'contain',
+      'Flights On Time'
+    );
+  });
+});

--- a/cypress/integration/plugins/custom-import-map-dashboards/add_saved_object.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/add_saved_object.spec.js
@@ -17,7 +17,6 @@ describe('Add flights dataset saved object', () => {
     cy.get('div[data-test-subj="sampleDataSetCardflights"]', { timeout: 60000 })
       .contains(/Add data/)
       .click();
-    cy.wait(60000);
   });
 
   after(() => {


### PR DESCRIPTION
### Description

Add Cypress test to validate adding default saved map for the sample flights dataset in the dashboards-maps plugin.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
