### PR TITLE
Fix the flaky test case for security permission

### DIFF
--- a/cypress/integration/plugins/security/permissions_spec.js
+++ b/cypress/integration/plugins/security/permissions_spec.js
@@ -73,7 +73,14 @@ if (Cypress.env('SECURITY_ENABLED')) {
     });
 
     it('should create new action group successfully by selecting `Create from blank`', () => {
-      cy.visit(SEC_UI_PERMISSIONS_PATH);
+      cy.mockPermissionsAction(
+        SEC_PERMISSIONS_FIXTURES_PATH +
+          '/actiongroups_post_new_creation_response.json',
+        () => {
+          cy.visit(SEC_UI_PERMISSIONS_PATH);
+        }
+      );
+
       cy.contains('button', 'Create action group')
         .first()
         .click({ force: true });
@@ -93,13 +100,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
         actionGroupName
       );
 
-      cy.mockPermissionsAction(
-        SEC_PERMISSIONS_FIXTURES_PATH +
-          '/actiongroups_post_new_creation_response.json',
-        () => {
-          cy.get('button[id="submit"]').first().click({ force: true });
-        }
-      );
+      cy.get('button[id="submit"]').first().click({ force: true });
 
       cy.url().should((url) => {
         expect(url).to.contain('/permissions');


### PR DESCRIPTION
### Description
Fix the flaky test case for security permission

### Issues Resolved
*Resolve https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/284

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
