### PR TITLE
[BACKPORT 2.x] Add functional test for ml-commons-dashboards overview page (#538)

### DIFF
--- a/.github/workflows/ml-commons-release-e2e-workflow.yml
+++ b/.github/workflows/ml-commons-release-e2e-workflow.yml
@@ -1,0 +1,24 @@
+name: ML Commons Release tests workflow in Bundled OpenSearch Dashboards
+on:
+  pull_request:
+    branches: ['**']
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.filter.outputs.tests }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            tests:
+              - 'cypress/**/ml-commons-dashboards/**'
+
+  tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: ML Commons
+      test-command: yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/ml-commons-dashboards/*'

--- a/cypress/integration/plugins/ml-commons-dashboards/overview_spec.js
+++ b/cypress/integration/plugins/ml-commons-dashboards/overview_spec.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { MLC_URL } from '../../../utils/constants';
+
+describe('MLC Overview page', () => {
+  let uploadedModelId;
+  let uploadedModelLoadedError;
+  const uploadModelName = `traced_small_model-${new Date()
+    .getTime()
+    .toString(34)}`;
+  before(() => {
+    cy.uploadModelByUrl({
+      name: uploadModelName,
+      version: '1.0.0',
+      model_format: 'TORCH_SCRIPT',
+      model_task_type: 'text_embedding',
+      model_config: {
+        model_type: 'bert',
+        embedding_dimension: 768,
+        framework_type: 'sentence_transformers',
+        all_config:
+          '{"architectures":["BertModel"],"max_position_embeddings":512,"model_type":"bert","num_attention_heads":12,"num_hidden_layers":6}',
+      },
+      url: 'https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/traced_small_model.zip?raw=true',
+    })
+      .then(({ task_id: taskId }) =>
+        cy.cyclingCheckTask({
+          taskId,
+        })
+      )
+      .then(({ model_id: modelId }) => {
+        uploadedModelId = modelId;
+        return cy.loadMLCommonsModel(modelId);
+      })
+      .then(({ task_id: taskId }) =>
+        cy.cyclingCheckTask({
+          taskId,
+          rejectOnError: false,
+        })
+      )
+      .then(({ error }) => {
+        if (error) {
+          uploadedModelLoadedError = error;
+        }
+      });
+  });
+
+  after(() => {
+    if (uploadedModelId) {
+      cy.unloadMLCommonsModel(uploadedModelId);
+      cy.deleteMLCommonsModel(uploadedModelId);
+    }
+  });
+
+  it('should return to monitoring page when visit root', () => {
+    cy.visit(MLC_URL.ROOT);
+    cy.url().should('include', MLC_URL.OVERVIEW);
+  });
+
+  it('should display page header and deployed model name, status and id', () => {
+    cy.visit(MLC_URL.OVERVIEW);
+
+    cy.contains('h1', 'Overview');
+    cy.contains('h2', 'Deployed models');
+
+    cy.get('[aria-label="Search by name or ID"]').type(uploadModelName);
+
+    cy.contains(uploadedModelId)
+      .closest('tr')
+      .contains(uploadedModelLoadedError ? 'Not responding' : 'Responding')
+      .closest('tr')
+      .contains(uploadModelName);
+
+    cy.contains('h1', 'Overview');
+    cy.contains('h2', 'Deployed models');
+  });
+
+  it('should open preview panel after view detail button click', () => {
+    cy.visit(MLC_URL.OVERVIEW);
+
+    cy.get('[aria-label="Search by name or ID"]').type(uploadModelName);
+
+    cy.contains(uploadedModelId)
+      .closest('tr')
+      .find('[aria-label="view detail"]')
+      .click();
+
+    cy.contains('.euiFlyoutHeader > h3', uploadModelName);
+    cy.contains('.euiFlyoutBody', uploadedModelId);
+  });
+});

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -28,6 +28,7 @@ import '../utils/plugins/security/commands';
 import '../utils/plugins/security-dashboards-plugin/commands';
 import '../utils/plugins/alerting-dashboards-plugin/commands';
 import '../utils/plugins/security-analytics-dashboards-plugin/commands';
+import '../utils/plugins/ml-commons-dashboards/commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/cypress/utils/constants.js
+++ b/cypress/utils/constants.js
@@ -15,3 +15,4 @@ export * from './plugins/security/constants';
 export * from './plugins/notifications-dashboards/constants';
 export * from './plugins/security-dashboards-plugin/constants';
 export * from './plugins/security-analytics-dashboards-plugin/constants';
+export * from './plugins/ml-commons-dashboards/constants';

--- a/cypress/utils/plugins/ml-commons-dashboards/commands.js
+++ b/cypress/utils/plugins/ml-commons-dashboards/commands.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { MLC_API } from './constants';
+
+Cypress.Commands.add('cyclingCheckTask', ({ taskId, rejectOnError = true }) =>
+  cy.wrap(
+    new Cypress.Promise((resolve, reject) => {
+      const checkTask = () => {
+        cy.getMLCommonsTask(taskId).then((payload) => {
+          if (payload.error) {
+            if (rejectOnError) {
+              reject(new Error(payload.error));
+              return;
+            }
+            resolve(payload);
+            return;
+          }
+          if (payload.state === 'COMPLETED') {
+            resolve(payload);
+            return;
+          }
+          cy.wait(1000);
+          checkTask();
+        });
+      };
+      checkTask();
+    })
+  )
+);
+
+Cypress.Commands.add('uploadModelByUrl', (body) =>
+  cy
+    .request({
+      method: 'POST',
+      url: MLC_API.MODEL_UPLOAD,
+      body,
+    })
+    .then(({ body }) => body)
+);
+
+Cypress.Commands.add('deleteMLCommonsModel', (modelId) =>
+  cy.request('DELETE', `${MLC_API.MODEL_BASE}/${modelId}`)
+);
+
+Cypress.Commands.add('loadMLCommonsModel', (modelId) =>
+  cy
+    .request({
+      method: 'POST',
+      url: `${MLC_API.MODEL_BASE}/${modelId}/_load`,
+    })
+    .then(({ body }) => body)
+);
+
+Cypress.Commands.add('unloadMLCommonsModel', (modelId) =>
+  cy
+    .request({
+      method: 'POST',
+      url: `${MLC_API.MODEL_BASE}/${modelId}/_unload`,
+    })
+    .then(({ body }) => body)
+);
+
+Cypress.Commands.add('getMLCommonsTask', (taskId) => {
+  return cy
+    .request({
+      method: 'GET',
+      url: `${MLC_API.TASK_BASE}/${taskId}`,
+    })
+    .then(({ body }) => body);
+});

--- a/cypress/utils/plugins/ml-commons-dashboards/constants.js
+++ b/cypress/utils/plugins/ml-commons-dashboards/constants.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BASE_PATH, BACKEND_BASE_PATH } from '../../base_constants';
+
+/**
+ *****************************
+ URL CONSTANTS
+ *****************************
+ */
+
+const BASE_MLC_PATH = BASE_PATH + '/app/ml-commons-dashboards';
+
+export const MLC_URL = {
+  ROOT: BASE_MLC_PATH + '/',
+  OVERVIEW: BASE_MLC_PATH + '/overview',
+};
+
+export const MLC_API_BASE = `${BACKEND_BASE_PATH}/_plugins/_ml`;
+
+export const MLC_API = {
+  MODEL_BASE: `${MLC_API_BASE}/models`,
+  MODEL_UPLOAD: `${MLC_API_BASE}/models/_upload`,
+  TASK_BASE: `${MLC_API_BASE}/tasks`,
+};

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -20,6 +20,7 @@ OSD_COMPONENT_TEST_MAP=( "OpenSearch-Dashboards:opensearch-dashboards"
                          "customImportMapDashboards:custom-import-map-dashboards"
                          "searchRelevanceDashboards:search-relevance-dashboards"
                          "securityAnalyticsDashboards:security-analytics-dashboards-plugin"
+                         "mlCommonsDashboards:ml-commons-dashboards"
                        )
 
 [ -f $OSD_BUILD_MANIFEST ] && TEST_TYPE="manifest" || TEST_TYPE="default"


### PR DESCRIPTION
Signed-off-by: Lin Wang <wonglam@amazon.com>
(cherry picked from commit 94d1f8047821b522b07aed5b0844f2068a835983)

### Description

Manual backport #538 to 2.x

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
