### PR TITLE
Disable only_run_on_ml_node to avoid model upload error

### DIFF
--- a/cypress/integration/plugins/ml-commons-dashboards/overview_spec.js
+++ b/cypress/integration/plugins/ml-commons-dashboards/overview_spec.js
@@ -11,6 +11,10 @@ describe('MLC Overview page', () => {
     .getTime()
     .toString(34)}`;
   before(() => {
+    // Disable only_run_on_ml_node to avoid model upload error in case of cluster no ml nodes
+    cy.disableOnlyRunOnMLNode();
+    cy.wait(1000);
+
     cy.uploadModelByUrl({
       name: uploadModelName,
       version: '1.0.0',

--- a/cypress/utils/plugins/ml-commons-dashboards/commands.js
+++ b/cypress/utils/plugins/ml-commons-dashboards/commands.js
@@ -70,3 +70,11 @@ Cypress.Commands.add('getMLCommonsTask', (taskId) => {
     })
     .then(({ body }) => body);
 });
+
+Cypress.Commands.add('disableOnlyRunOnMLNode', () => {
+  cy.request('PUT', `${Cypress.env('openSearchUrl')}/_cluster/settings`, {
+    transient: {
+      'plugins.ml_commons.only_run_on_ml_node': false,
+    },
+  });
+});


### PR DESCRIPTION
### Description

The ml-commons-dashboards functional test will failed if there is no ml nodes in opensearch cluster. The error will like this:
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/4034161/220516611-50f6bc96-4c79-48e6-af8c-304caae52909.png">

Disable only_run_on_ml_node to avoid this error in model upload phase.
<img width="1375" alt="image" src="https://user-images.githubusercontent.com/4034161/220516268-973d2096-f05f-4a6c-847c-bb7a0886f64d.png">

I removed all the ml node in my local and re-run this functional test. It works fine.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
