### PR TITLE
Disable native memory circuit breaker before model upload

### DIFF
--- a/cypress/integration/plugins/ml-commons-dashboards/overview_spec.js
+++ b/cypress/integration/plugins/ml-commons-dashboards/overview_spec.js
@@ -14,6 +14,7 @@ if (Cypress.env('ML_COMMONS_DASHBOARDS_ENABLED')) {
     before(() => {
       // Disable only_run_on_ml_node to avoid model upload error in case of cluster no ml nodes
       cy.disableOnlyRunOnMLNode();
+      cy.disableNativeMemoryCircuitBreaker();
       cy.wait(1000);
 
       cy.uploadModelByUrl({

--- a/cypress/utils/plugins/ml-commons-dashboards/commands.js
+++ b/cypress/utils/plugins/ml-commons-dashboards/commands.js
@@ -78,3 +78,11 @@ Cypress.Commands.add('disableOnlyRunOnMLNode', () => {
     },
   });
 });
+
+Cypress.Commands.add('disableNativeMemoryCircuitBreaker', () => {
+  cy.request('PUT', `${Cypress.env('openSearchUrl')}/_cluster/settings`, {
+    transient: {
+      'plugins.ml_commons.native_memory_threshold': 100,
+    },
+  });
+});


### PR DESCRIPTION
### Description

Disable native memory circuit breaker to avoid model upload error like [this](https://github.com/opensearch-project/opensearch-dashboards-functional-test/actions/runs/4258333832/jobs/7413535943#step:15:108).
The same code run successfully when cherry-pick to 2.6 branch,  the result link is: https://github.com/wanglam/opensearch-dashboards-functional-test/actions/runs/4261055837/jobs/7414926387#step:15:108

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
