### PR TITLE
[ENHANCEMENT] Improving Dashboards Search Relevance Tests

### DIFF
--- a/cypress/integration/plugins/search-relevance-dashboards/1_query_compare.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/1_query_compare.spec.js
@@ -18,6 +18,7 @@ import { BASE_PATH } from '../../../utils/base_constants';
 describe('Compare queries', () => {
   before(() => {
     const miscUtils = new MiscUtils(cy);
+    cy.deleteAllIndices();
     miscUtils.addSampleData();
   });
 


### PR DESCRIPTION
### Description

Improving Cypress tests for `Dashboards Search Relevance` to defend against uncleared sample data. If sample data from other tests are not cleared after they finished, the `search-relevance` tests fail, as during `2.6.0` release.

Test run with sample data that is not cleared:
![image](https://user-images.githubusercontent.com/47805161/224219918-e1e808fe-9d79-41e3-9ee2-293e7c1f3b0a.png)

Test run after adding `cy.deleteAllIndices()`:
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/47805161/224220444-35a4d62d-6cec-4855-8368-e2d2c2bc63e4.png">

### Issues Resolved

[#159](https://github.com/opensearch-project/dashboards-search-relevance/issues/159)

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
