### PR TITLE
Remove context menu download reporting tests in notebooks

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -138,20 +138,6 @@ describe('Test reporting integration if plugin installed', () => {
     });
   });
 
-  it('Create in-context PDF report from notebook', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.wait(delayTime);
-    cy.get('button.euiContextMenuItem:nth-child(1)').contains('Download PDF').click();
-    cy.get('#downloadInProgressLoadingModal').should('exist');
-  });
-
-  it('Create in-context PNG report from notebook', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.wait(delayTime);
-    cy.get('button.euiContextMenuItem:nth-child(2)').contains('Download PNG').click();
-    cy.get('#downloadInProgressLoadingModal').should('exist');
-  });
-
   it('Create on-demand report definition from context menu', () => {
     cy.get('#reportingActionsButton').click();
     cy.wait(delayTime);


### PR DESCRIPTION
### Description

We don't support notebooks context menu reports below 2.5 or 2.6 after chromium removal, users will need to create a report in the reporting plugin explicitly for notebooks. This PR removes the old tests in 1.3 branch. They should be removed by #530 but it contained other changes and couldn't be backported

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/585

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
