### PR TITLE
[VisBuilder] Fixes tests for vis type persistence change

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
@@ -56,9 +56,10 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
       // Add Vis Builder Visualisation to dashboard
       cy.getElementByTestId('dashboardEditMode').click();
       cy.getElementByTestId('dashboardAddPanelButton').click();
-      cy.getElementByTestId('savedObjectFinderSearchInput').type(
-        `${VB_LINE_VIS_TITLE}{enter}`
-      );
+      cy.getElementByTestId('savedObjectFinderFilterButton').click();
+      cy.getElementByTestId(
+        'savedObjectFinderFilter-visualization-visbuilder'
+      ).click();
       cy.getElementByTestId(
         `savedObjectTitle${toTestId(VB_LINE_VIS_TITLE)}`
       ).click();

--- a/cypress/utils/dashboards/vis_builder/commands.js
+++ b/cypress/utils/dashboards/vis_builder/commands.js
@@ -21,7 +21,7 @@ Cypress.Commands.add('vbSelectDataSource', (dataSource) => {
     .click(opts);
 });
 
-Cypress.Commands.add('vbSelectVisType', (type) => {
+Cypress.Commands.add('vbSelectVisType', (type, confirm = false) => {
   const opts = { log: false };
 
   Cypress.log({
@@ -32,7 +32,9 @@ Cypress.Commands.add('vbSelectVisType', (type) => {
 
   cy.getElementByTestId('chartPicker', opts).click(opts);
   cy.get('[data-test-subj^=visType-', opts).contains(type, opts).click(opts);
-  cy.getElementByTestId('confirmModalConfirmButton', opts).click(opts);
+  if (confirm) {
+    cy.getElementByTestId('confirmModalConfirmButton', opts).click(opts);
+  }
 });
 
 Cypress.Commands.add('vbEditAgg', (fields = []) => {

--- a/cypress/utils/dashboards/vis_builder/constants.js
+++ b/cypress/utils/dashboards/vis_builder/constants.js
@@ -5,7 +5,7 @@
 
 import { BASE_PATH } from '../../base_constants';
 
-export const VB_DEBOUNCE = 200; // Debounce time for VisBuilder fields in ms
+export const VB_DEBOUNCE = 300; // Debounce time for VisBuilder fields in ms
 
 export const VB_INDEX_DATA = 'vis-builder.data.txt';
 export const VB_INDEX_DOC_COUNT = '10,000';


### PR DESCRIPTION
### Description

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/3715 changes how the visualization types change. We no longer show the confirm modal. This updates the tests to reflect that. This will fail in CI until the other change is merged

### Issues Resolved


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
