### PR TITLE
add test case for model deployment details loading indicator

### DIFF
--- a/cypress/utils/plugins/ml-commons-dashboards/constants.js
+++ b/cypress/utils/plugins/ml-commons-dashboards/constants.js
@@ -25,3 +25,9 @@ export const MLC_API = {
   MODEL_UPLOAD: `${MLC_API_BASE}/models/_upload`,
   TASK_BASE: `${MLC_API_BASE}/tasks`,
 };
+
+const BASE_MLC_DASHBOARD_API = BASE_PATH + '/api/ml-commons';
+
+export const MLC_DASHBOARD_API = {
+  DEPLOYED_MODEL_PROFILE: `${BASE_MLC_DASHBOARD_API}/profile/deployed-model/:modelID`,
+};


### PR DESCRIPTION
### Description

There is an UI bug in ml-commons-dashboards 2.6.0, here is [the issue](https://github.com/opensearch-project/ml-commons-dashboards/issues/145). This bug will be fixed in ml-commons-dashboards 2.7.0. This PR add a new case to cover  this bug to ensure the same issue won't be raised anymore.

I've run the new functional test in my local, here is the results:
<img width="1378" alt="image" src="https://user-images.githubusercontent.com/4034161/229748472-44fa2366-012c-443a-8bf8-a82e0dfbe666.png">


### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
