### PR TITLE
Chore: updates datepicker command for change in oui 1.1

### DIFF
--- a/cypress/utils/dashboards/commands.js
+++ b/cypress/utils/dashboards/commands.js
@@ -48,11 +48,6 @@ Cypress.Commands.add('setTopNavDate', (start, end, submit = true) => {
   // Click date picker
   cy.getElementByTestId('superDatePickerShowDatesButton', opts).click(opts);
 
-  // Click start date
-  cy.getElementByTestId('superDatePickerstartDatePopoverButton', opts).click(
-    opts
-  );
-
   // Click absolute tab
   cy.getElementByTestId('superDatePickerAbsoluteTab', opts).click(opts);
 


### PR DESCRIPTION
### Description

OUI 1.1makes a change that removes the need to click the start date button after clicking show dates. doing so will actually close the popup and fail the test. The change fixes that.

### Issues Resolved



### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
