### PR TITLE
Add an optional parameter -o to integtest.sh 

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-. ./test_finder.sh
-
 function usage() {
     echo ""
     echo "This script is used to run integration tests for plugin installed on a remote OpenSearch/Dashboards cluster."
@@ -20,11 +18,12 @@ function usage() {
     echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
     echo -e "-t TEST_COMPONENTS\t(OpenSearch-Dashboards reportsDashboards etc.), optional, specify test components, separate with space, else test everything."
     echo -e "-v VERSION\t, no defaults, indicates the OpenSearch version to test."
+    echo -e "-o OPTION\t, no defaults, determine the TEST_TYPE value among(default, manifest) in test_finder.sh, optional."
     echo -e "-h\tPrint this message."
     echo "--------------------------------------------------------------------------"
 }
 
-while getopts ":hb:p:s:c:t:v:" arg; do
+while getopts ":hb:p:s:c:t:v:o:" arg; do
     case $arg in
         h)
             usage
@@ -47,6 +46,9 @@ while getopts ":hb:p:s:c:t:v:" arg; do
             ;;
         v)
             VERSION=$OPTARG
+            ;;
+        o)
+            OPTION=$OPTARG
             ;;
         :)
             echo "-${OPTARG} requires an argument"
@@ -82,6 +84,8 @@ then
   USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
   PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
+
+. ./test_finder.sh
 
 npm install
 

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -5,6 +5,7 @@ set -e
 OSD_BUILD_MANIFEST='../local-test-cluster/opensearch-dashboards-*/manifest.yml'
 OSD_TEST_PATH='cypress/integration/core-opensearch-dashboards'
 OSD_PLUGIN_TEST_PATH='cypress/integration/plugins'
+TEST_TYPE=$OPTION
 
 # Map component name in opensearch-build repo INPUT_MANIFEST with folder name for tests in functional repo
 OSD_COMPONENT_TEST_MAP=( "OpenSearch-Dashboards:opensearch-dashboards"
@@ -23,7 +24,10 @@ OSD_COMPONENT_TEST_MAP=( "OpenSearch-Dashboards:opensearch-dashboards"
                          "securityAnalyticsDashboards:security-analytics-dashboards-plugin"
                        )
 
-[ -f $OSD_BUILD_MANIFEST ] && TEST_TYPE="manifest" || TEST_TYPE="default"
+if [ -z $TEST_TYPE ]; then
+    [ -f $OSD_BUILD_MANIFEST ] && TEST_TYPE="manifest" || TEST_TYPE="default"
+fi
+
 [ ! `echo $SHELL | grep 'bash'` ] && echo "You must run this script with bash as other shells like zsh will fail the script, exit in 10" && sleep 10 && exit 1
 
 # Checks if build manifest in parent directory of current directory under local-test-cluster/opensearch-dashboards-*


### PR DESCRIPTION
SignedOff by : divyaasm@amazon.com

### Description

A new optional argument OPTION [-o ] is added to integtest.sh

### Issues Resolved

Fix to the issue [#3316](https://github.com/opensearch-project/opensearch-build/pull/3316)

Call to ./integtest.sh from integ-workflow can now use additional `-o default` parameter when -t is passed which executes the tests individually instead of altogether. This is optional and does not change the behaviour if -o is not passed.

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
