### PR TITLE
Adding test for opensearch_security.multitenancy.enabled disabled

### DIFF
--- a/cypress/integration/plugins/security-dashboards-plugin/inaccessible_tenancy_features.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/inaccessible_tenancy_features.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TENANTS_MANAGE_PATH } from '../../../utils/dashboards/constants';
+
+if (Cypress.env('SECURITY_ENABLED')) {
+  describe('Multi Tenancy Tests: ', () => {
+    before(() => {
+      cy.server();
+    });
+    it('Test Dashboards tenancy features should not be accessible ', () => {
+      // This test is to ensure tenancy related features are not accessible when opensearch_security.multitenancy.enabled is disabled in the opensearchdashboard.yaml
+      cy.visit(TENANTS_MANAGE_PATH);
+      cy.waitForLoader();
+
+      cy.contains('You have not enabled multi tenancy').should('exist');
+
+      // Switch tenants button should not exist when multi-tenancy is disabled.
+      cy.get('#user-icon-btn').click();
+      cy.contains('button', 'Switch tenants').should('not.exist');
+    });
+  });
+}


### PR DESCRIPTION
### Description

We are adding a new cypress test to check if Dashboards tenancy features are disabled when `opensearch_security.multitenancy.enabled` is disabled in the `opensearchdashboard.yaml` file.

### Issues Resolved

Cypress tests for PR: https://github.com/opensearch-project/security-dashboards-plugin/pull/1419

### Check List

- [✅ ] Commits are signed per the DCO using --signoff

Testing video: 

https://user-images.githubusercontent.com/99718513/236475661-31cd89cf-6121-422a-b71f-cc0a7236b1be.mp4

Testing by running cypress test from Security-Dashboards plugin;
https://github.com/opensearch-project/security-dashboards-plugin/actions/runs/4894295743/jobs/8738346716

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
