### PR TITLE
Backport changes from main to 1.3 branch related to OSD Integtests

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-. ./test_finder.sh
-
 function usage() {
     echo ""
     echo "This script is used to run integration tests for plugin installed on a remote OpenSearch/Dashboards cluster."
@@ -18,12 +16,14 @@ function usage() {
     echo -e "-p BIND_PORT\t, defaults to 9200 or 5601 depends on OpenSearch or Dashboards, can be changed to any port for the cluster location."
     echo -e "-s SECURITY_ENABLED\t(true | false), defaults to true. Specify the OpenSearch/Dashboards have security enabled or not."
     echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
+    echo -e "-t TEST_COMPONENTS\t(OpenSearch-Dashboards reportsDashboards etc.), optional, specify test components, separate with space, else test everything."
     echo -e "-v VERSION\t, no defaults, indicates the OpenSearch version to test."
+    echo -e "-o OPTION\t, no defaults, determine the TEST_TYPE value among(default, manifest) in test_finder.sh, optional."
     echo -e "-h\tPrint this message."
     echo "--------------------------------------------------------------------------"
 }
 
-while getopts ":hb:p:s:c:v:" arg; do
+while getopts ":hb:p:s:c:t:v:o:" arg; do
     case $arg in
         h)
             usage
@@ -41,8 +41,14 @@ while getopts ":hb:p:s:c:v:" arg; do
         c)
             CREDENTIAL=$OPTARG
             ;;
+        t)
+            TEST_COMPONENTS=$OPTARG
+            ;;
         v)
             VERSION=$OPTARG
+            ;;
+        o)
+            OPTION=$OPTARG
             ;;
         :)
             echo "-${OPTARG} requires an argument"
@@ -79,10 +85,13 @@ then
   PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
 
+. ./test_finder.sh
+
 npm install
 
-
-TEST_FILES=$(get_test_list)
+TEST_FILES=`get_test_list $TEST_COMPONENTS`
+echo -e "Test Files List:"
+echo $TEST_FILES | tr ',' '\n'
 
 ## WARNING: THIS LOGIC NEEDS TO BE THE LAST IN THIS FILE! ##
 # Cypress returns back the test failure count in the error code

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -5,42 +5,73 @@ set -e
 OSD_BUILD_MANIFEST='../local-test-cluster/opensearch-dashboards-*/manifest.yml'
 OSD_TEST_PATH='cypress/integration/core-opensearch-dashboards'
 OSD_PLUGIN_TEST_PATH='cypress/integration/plugins'
+TEST_TYPE=$OPTION
+
+# Map component name in opensearch-build repo INPUT_MANIFEST with folder name for tests in functional repo
+OSD_COMPONENT_TEST_MAP=( "OpenSearch-Dashboards:opensearch-dashboards"
+                         "alertingDashboards:alerting-dashboards-plugin"
+                         "anomalyDetectionDashboards:anomaly-detection-dashboards-plugin"
+                         "ganttChartDashboards:gantt-chart-dashboards"
+                         "indexManagementDashboards:index-management-dashboards-plugin"
+                         "observabilityDashboards:observability-dashboards"
+                         "queryWorkbenchDashboards:query-workbench-dashboards"
+                         "reportsDashboards:reports-dashboards"
+                         "securityDashboards:security"
+                       )
+
+if [ -z $TEST_TYPE ]; then
+    [ -f $OSD_BUILD_MANIFEST ] && TEST_TYPE="manifest" || TEST_TYPE="default"
+fi
+
+[ ! `echo $SHELL | grep 'bash'` ] && echo "You must run this script with bash as other shells like zsh will fail the script, exit in 10" && sleep 10 && exit 1
 
 # Checks if build manifest in parent directory of current directory under local-test-cluster/opensearch-dashboards-*
-# When the test script executed in the CI, it scales up OpenSearch Dashboards under local-test-cluster with a 
+# When the test script executed in the CI, it scales up OpenSearch Dashboards under local-test-cluster with a
 # manifest that contains the existing components.
 #
 # If the build manifest exists in the expected path then we can read the components to execute component tests if the
 # component exists. If the build manifest does not exist then we can just use a default list of tests.
+#
+# Usages: get_test_list - Get all test list in the repository by default. If manifest exists, then only components in manifests will be added in test list
+#         get_test_list <component1> <component2> ... - Get test list based on user defined components. Ex: get_test_list OpenSearch-Dashboards reportsDashboards
+
 function get_test_list() {
-    [ -f $OSD_BUILD_MANIFEST ] && generate_test_list_from_build_manifest || generate_test_list
-}
+    local TEST_FILES_LOCAL=""
+    local TEST_FILES_EXT_LOCAL=""
+    local TEST_PATH_LOCAL=""
+    local TEST_COMPONENTS_LOCAL="$@"
 
-function generate_test_list() {
-    DEFAULT_TEST_FILES="$OSD_TEST_PATH/opensearch-dashboards/*.js"
-    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/alerting-dashboards-plugin/*"
-    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/anomaly-detection-dashboards-plugin/*"
-    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/gantt-chart-dashboards/*"
-    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/index-management-dashboards-plugin/*"
-    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/observability-dashboards/*"
-    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/query-workbench-dashboards/*"
-    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/reports-dashboards/*"
-    DEFAULT_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/security/*"
+    for map_entry in "${OSD_COMPONENT_TEST_MAP[@]}"; do
+        component_name=${map_entry%%:*}
+        test_folder=${map_entry#*:}
 
-    echo "$DEFAULT_TEST_FILES"
-}
+        if [ "$component_name" = "OpenSearch-Dashboards" ]; then
+            TEST_PATH_LOCAL=$OSD_TEST_PATH
+            TEST_FILES_EXT_LOCAL="**/*.js"
+        else
+            TEST_PATH_LOCAL=$OSD_PLUGIN_TEST_PATH
+            TEST_FILES_EXT_LOCAL="*"
+        fi
 
-function generate_test_list_from_build_manifest() {
-    MANIFEST_TEST_FILES="$OSD_TEST_PATH/opensearch-dashboards/*.js"
+        if [ "$TEST_TYPE" = "default" ]; then
+            if [ -z "$TEST_COMPONENTS_LOCAL" ]; then
+                TEST_FILES_LOCAL+="$TEST_PATH_LOCAL/$test_folder/$TEST_FILES_EXT_LOCAL,"
+            else
+                for test_component in $TEST_COMPONENTS_LOCAL; do
+                    if [ "$test_component" = "$component_name" ]; then
+                        TEST_FILES_LOCAL+="$TEST_PATH_LOCAL/$test_folder/$TEST_FILES_EXT_LOCAL,"
+                        break
+                    fi
+                done
+            fi
 
-    grep -q 'alertingDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/alerting-dashboards-plugin/*" || true
-    grep -q 'anomalyDetectionDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/anomaly-detection-dashboards-plugin/*" || true
-    grep -q 'ganttChartDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/gantt-chart-dashboards/*" || true
-    grep -q 'indexManagementDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/index-management-dashboards-plugin/*" || true
-    grep -q 'observabilityDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/observability-dashboards/*" || true
-    grep -q 'queryWorkbenchDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/query-workbench-dashboards/*" || true
-    grep -q 'reportsDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/reports-dashboards/*" || true
-    grep -q 'securityDashboards' $OSD_BUILD_MANIFEST && MANIFEST_TEST_FILES+=",$OSD_PLUGIN_TEST_PATH/security/*" || true
+        elif [ "$TEST_TYPE" = "manifest" ]; then
+            if grep -q $component_name $OSD_BUILD_MANIFEST; then
+                TEST_FILES_LOCAL+="$TEST_PATH_LOCAL/$test_folder/$TEST_FILES_EXT_LOCAL,"
+            fi
+        fi
 
-    echo "$MANIFEST_TEST_FILES"
+    done
+
+    echo "${TEST_FILES_LOCAL%,}"
 }


### PR DESCRIPTION
### Description

Backport the changes from main branch to 1.3 branch to support the parallel run of OSD integtests. Currently the changes are applied only to 2.x branch. Need to adapt the changes for [1.3.10](https://github.com/opensearch-project/opensearch-build/issues/3331) release 

 
Changes to the files integtest.sh and test_finder.sh include from :
https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/234
https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/236
https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/367
https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/644


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
