### PR TITLE
fix: model upload failed with model group level access control

### DIFF
--- a/cypress/integration/plugins/ml-commons-dashboards/overview_spec.js
+++ b/cypress/integration/plugins/ml-commons-dashboards/overview_spec.js
@@ -15,22 +15,32 @@ if (Cypress.env('ML_COMMONS_DASHBOARDS_ENABLED')) {
       // Disable only_run_on_ml_node to avoid model upload error in case of cluster no ml nodes
       cy.disableOnlyRunOnMLNode();
       cy.disableNativeMemoryCircuitBreaker();
+      cy.enableRegisterModelViaURL();
       cy.wait(1000);
 
-      cy.uploadModelByUrl({
-        name: uploadModelName,
-        version: '1.0.0',
-        model_format: 'TORCH_SCRIPT',
-        model_task_type: 'text_embedding',
-        model_config: {
-          model_type: 'bert',
-          embedding_dimension: 768,
-          framework_type: 'sentence_transformers',
-          all_config:
-            '{"architectures":["BertModel"],"max_position_embeddings":512,"model_type":"bert","num_attention_heads":12,"num_hidden_layers":6}',
-        },
-        url: 'https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/traced_small_model.zip?raw=true',
+      cy.registerModelGroup({
+        name: 'model-group',
+        model_access_mode: 'public',
       })
+        .then(({ model_group_id }) =>
+          cy.uploadModelByUrl({
+            name: uploadModelName,
+            version: '1.0.0',
+            model_format: 'TORCH_SCRIPT',
+            model_task_type: 'text_embedding',
+            model_group_id,
+            model_content_hash_value:
+              'e13b74006290a9d0f58c1376f9629d4ebc05a0f9385f40db837452b167ae9021',
+            model_config: {
+              model_type: 'bert',
+              embedding_dimension: 768,
+              framework_type: 'sentence_transformers',
+              all_config:
+                '{"architectures":["BertModel"],"max_position_embeddings":512,"model_type":"bert","num_attention_heads":12,"num_hidden_layers":6}',
+            },
+            url: 'https://github.com/opensearch-project/ml-commons/blob/2.x/ml-algorithms/src/test/resources/org/opensearch/ml/engine/algorithms/text_embedding/traced_small_model.zip?raw=true',
+          })
+        )
         .then(({ task_id: taskId }) =>
           cy.cyclingCheckTask({
             taskId,

--- a/cypress/utils/plugins/ml-commons-dashboards/commands.js
+++ b/cypress/utils/plugins/ml-commons-dashboards/commands.js
@@ -40,6 +40,16 @@ Cypress.Commands.add('uploadModelByUrl', (body) =>
     .then(({ body }) => body)
 );
 
+Cypress.Commands.add('registerModelGroup', (body) =>
+  cy
+    .request({
+      method: 'POST',
+      url: MLC_API.MODEL_GROUP_REGISTER,
+      body,
+    })
+    .then(({ body }) => body)
+);
+
 Cypress.Commands.add('deleteMLCommonsModel', (modelId) =>
   cy.request('DELETE', `${MLC_API.MODEL_BASE}/${modelId}`)
 );
@@ -83,6 +93,14 @@ Cypress.Commands.add('disableNativeMemoryCircuitBreaker', () => {
   cy.request('PUT', `${Cypress.env('openSearchUrl')}/_cluster/settings`, {
     transient: {
       'plugins.ml_commons.native_memory_threshold': 100,
+    },
+  });
+});
+
+Cypress.Commands.add('enableRegisterModelViaURL', () => {
+  cy.request('PUT', `${Cypress.env('openSearchUrl')}/_cluster/settings`, {
+    transient: {
+      'plugins.ml_commons.allow_registering_model_via_url': true,
     },
   });
 });

--- a/cypress/utils/plugins/ml-commons-dashboards/constants.js
+++ b/cypress/utils/plugins/ml-commons-dashboards/constants.js
@@ -23,6 +23,7 @@ export const MLC_API_BASE = `${BACKEND_BASE_PATH}/_plugins/_ml`;
 export const MLC_API = {
   MODEL_BASE: `${MLC_API_BASE}/models`,
   MODEL_UPLOAD: `${MLC_API_BASE}/models/_upload`,
+  MODEL_GROUP_REGISTER: `${MLC_API_BASE}/model_groups/_register`,
   TASK_BASE: `${MLC_API_BASE}/tasks`,
 };
 


### PR DESCRIPTION
### Description

The ml-commons 2.8 will bring model group level access control feature. The new feature will break old model upload process.  This PR enable model register upload by URL and create model group before model upload. Then model can be uploaded and deployed. 
This PR **should be backport to `2.x`** branch and already passed in the local environment.

Test video: https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/4034161/6044acbe-9be6-48fb-94df-2d3551cd506c

Test screenshot: ![image](https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/4034161/397d2309-8159-4ed0-a7a6-4d248617a34f)


### Issues Resolved




### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
