### PR TITLE
Allow ftrepo to accept custom browser path running integTest

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -85,6 +85,12 @@ then
   PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 fi
 
+# User can send custom browser path through env variable
+if [ -z "$BROWSER_PATH" ]
+then
+  BROWSER_PATH="chromium"
+fi
+
 . ./test_finder.sh
 
 npm install
@@ -92,6 +98,7 @@ npm install
 TEST_FILES=`get_test_list $TEST_COMPONENTS`
 echo -e "Test Files List:"
 echo $TEST_FILES | tr ',' '\n'
+echo "BROWSER_PATH: $BROWSER_PATH"
 
 ## WARNING: THIS LOGIC NEEDS TO BE THE LAST IN THIS FILE! ##
 # Cypress returns back the test failure count in the error code
@@ -102,8 +109,8 @@ echo $TEST_FILES | tr ',' '\n'
 if [ $SECURITY_ENABLED = "true" ]
 then
    echo "run security enabled tests"
-   yarn cypress:run-with-security --browser chromium --spec "$TEST_FILES"
+   yarn cypress:run-with-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
 else
    echo "run security disabled tests"
-   yarn cypress:run-without-security --browser chromium --spec "$TEST_FILES"
+   yarn cypress:run-without-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
 fi


### PR DESCRIPTION
### Description

Allow ftrepo to accept custom browser path running integTest

### Issues Resolved

opensearch-project/opensearch-build#3434
opensearch-project/opensearch-ci#293

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
