### PR TITLE
[Backport 1.3] Tweak dir path for osd after untar (#688)

### DIFF
--- a/.github/workflows/cypress-workflow-plugins-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-plugins-bundle-snapshot-based.yml
@@ -38,7 +38,8 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          echo "::set-output name=node_version::$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")"
+          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
+          echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release-signoff-chrome.yml
+++ b/.github/workflows/release-signoff-chrome.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")
+          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@v1

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")
+          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@v1

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")
+          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@v1

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")
+          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@v1

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")
+          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@v1

--- a/.github/workflows/release-signoff-chromium.yml
+++ b/.github/workflows/release-signoff-chromium.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")
+          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@v1

--- a/.github/workflows/release-signoff-electron.yml
+++ b/.github/workflows/release-signoff-electron.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")
+          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@v1

--- a/.github/workflows/release-signoff-firefox.yml
+++ b/.github/workflows/release-signoff-firefox.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get node and yarn versions
         id: versions
         run: |
-          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}-linux-x64/package.json').engines.node).match(/[.0-9]+/)[0]")
+          node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
         uses: actions/setup-node@v1


### PR DESCRIPTION
### Description

[Backport 1.3] Tweak dir path for osd after untar (#688)

### Issues Resolved

#688

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
