### PR TITLE
Use library from release tag instead of git reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,8 +182,8 @@
       "dev": true
     },
     "@opensearch-dashboards-test/opensearch-dashboards-test-library": {
-      "version": "git+https://github.com/opensearch-project/opensearch-dashboards-test-library.git#bae148619679abdc1eb2865da25929ca4180c1ce",
-      "from": "git+https://github.com/opensearch-project/opensearch-dashboards-test-library.git#main"
+      "version": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.4.tar.gz",
+      "integrity": "sha512-IGxw7GVFRyKgjVs+ubTDynrOEvqlI7gTua+Lf2LbDL9g+f6qQ64gnCyMQWeu3mr+w38r+rvN6Uq0AGCcbQ9mlA=="
     },
     "@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/opensearch-project/opensearch-dashboards-functional-test",
   "dependencies": {
     "@cypress/skip-test": "^2.6.1",
-    "@opensearch-dashboards-test/opensearch-dashboards-test-library": "git+https://github.com/opensearch-project/opensearch-dashboards-test-library.git#main",
+    "@opensearch-dashboards-test/opensearch-dashboards-test-library": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.4.tar.gz",
     "brace": "^0.11.1",
     "prettier": "^2.5.1"
   },


### PR DESCRIPTION
### Description

The module installed from the OSD test library seems to update or not based on caching issues

### Related proposal

https://github.com/opensearch-project/opensearch-dashboards-test-library/issues/36

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
