### PR TITLE
Fix internaluser test to adapt the password validation

### DIFF
--- a/cypress/integration/plugins/security/internalusers_spec.js
+++ b/cypress/integration/plugins/security/internalusers_spec.js
@@ -83,7 +83,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.contains('span', 'Create');
 
       const userName = 'test';
-      const password = 'Password12';
+      const password = 'testUserPassword123';
 
       cy.get('input[data-test-subj="name-text"]').type(userName, {
         force: true,


### PR DESCRIPTION
### Description
Fix internaluser test to adapt the password validation feature for security plugin

### Issues Resolved
- Fix 2.8 RC testing
- Relate https://github.com/opensearch-project/security/pull/2557

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
