### PR TITLE
[Site] update results path based on recent updates for concurrency

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -12,7 +12,8 @@
 
 <body onload="setDefaultValues()">
   <div class="topNav">
-    <span>OpenSearch Dashboards Test Results Explorer</span>
+    <img src="https://opensearch.org/assets/brand/SVG/Logo/opensearch_dashboards_logo_darkmode.svg"/>
+    <span>Functional Test Results Explorer</span>
     <a href="https://github.com/opensearch-project/opensearch-dashboards-functional-test">
       Github
     </a>

--- a/site/index.html
+++ b/site/index.html
@@ -96,10 +96,14 @@
     <table id="advancedInputsTable">
       <tr>
         <th>Test Job Name</th>
+        <th>Legacy Tests Results</th>
       </tr>
       <tr>
         <td>
           <input style="width:50vw" type="text" id="testJobName" value="integ-test-opensearch-dashboards">
+        </td>
+        <td id="legacyTd">
+          <input type="checkbox" id="legacyResults">
         </td>
       </tr>
     </table>

--- a/site/js/dashboard.js
+++ b/site/js/dashboard.js
@@ -264,7 +264,8 @@ function enableLegacyTestsResults() {
 function hideLegacyTestsResults() {
   document.getElementById('testResultsDiv').style.display = 'none';
   var testResultsLink = document.getElementById('testResultLink');
-  testResultsLink.textContent = 'How to View Test Results';
+  testResultsLink.textContent = 'How to view test results for plugins';
+  testResultsLink.href = 'assets/plugin_test_results_help.gif';
 }
 
 // eslint-disable-next-line no-unused-vars
@@ -320,9 +321,8 @@ function getPluginLinks(plugin) {
     pluginTestResultLink.href = testResultsUrl;
     document.getElementById('pluginLink').appendChild(pluginTestResultLink);
 
-    const breakElement = document.createElement('br');
-    breakElement.style = 'margin-bottom: 12px;';
-    document.getElementById('pluginLink').appendChild(breakElement);
+    const ruleElement = document.createElement('hr');
+    document.getElementById('pluginLink').appendChild(ruleElement);
   }
 
   var pluginLink = document.createElement('a');

--- a/site/styles.css
+++ b/site/styles.css
@@ -152,10 +152,16 @@ body {
     overflow: hidden;
 }
 
+.topNav img {
+    float: left;
+    height: 28px;
+    width: auto;
+    padding: 12px 6px;
+}
 .topNav span {
     float: left;
     color: white;
-    padding: 14px 16px;
+    padding: 16px 8px;
     font-size: 1rem;
     cursor: default;
 }
@@ -163,7 +169,7 @@ body {
 .topNav a {
     float: right;
     color: white;
-    padding: 14px 16px;
+    padding: 16px 16px;
     text-align: center;
     text-decoration: underline;
     font-size: 1rem;

--- a/site/styles.css
+++ b/site/styles.css
@@ -32,6 +32,10 @@ body {
     display: none;
 }
 
+#inputsDiv #advancedInputsTable #legacyTd {
+    text-align: center;
+}
+
 #submitButton {
     margin-top: 8px;
     width: 150px;
@@ -99,7 +103,7 @@ body {
     left: 50%;
     top: 50%; 
     margin-left: -375px;
-    margin-top: -225px;
+    margin-top: -275px;
     background-color: white;
     border-radius: 6px;
     box-shadow: rgba(27, 31, 35, 0.04) 0 1px 0, rgba(255, 255, 255, 0.25) 0 3px 0 inset;


### PR DESCRIPTION
### Description

For site, previous test results will exist within the FTRepo but since the usage of concurrency for plugin tests, the path to the results is different.

Updating site to be able to handle both situations.

Added a gif how to use this feature.

### Issues Resolved
n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
