### PR TITLE
Fix Anomaly Detection System Indices Deletion in Cypress Tests

### DIFF
--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -128,7 +128,6 @@ Cypress.Commands.add('deleteADSystemIndices', () => {
   }).then((response) => {
     if (response.status === 200) {
       for (let hit of response.body.hits.hits) {
-        console.log(hit);
         cy.request(
           'POST',
           `${Cypress.env(

--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -108,7 +108,45 @@ Cypress.Commands.add('deleteAllIndices', () => {
 
 Cypress.Commands.add('deleteADSystemIndices', () => {
   cy.log('Deleting AD system indices');
-  cy.request('DELETE', `${Cypress.env('openSearchUrl')}/.opendistro-anomaly*`);
+  const url = `${Cypress.env(
+    'openSearchUrl'
+  )}/_plugins/_anomaly_detection/detectors/results`;
+  cy.request({
+    method: 'DELETE',
+    url: url,
+    failOnStatusCode: false,
+    body: { query: { match_all: {} } },
+  });
+
+  cy.request({
+    method: 'POST',
+    url: `${Cypress.env(
+      'openSearchUrl'
+    )}/_plugins/_anomaly_detection/detectors/_search`,
+    failOnStatusCode: false,
+    body: { query: { match_all: {} } },
+  }).then((response) => {
+    if (response.status === 200) {
+      for (let hit of response.body.hits.hits) {
+        console.log(hit);
+        cy.request(
+          'POST',
+          `${Cypress.env(
+            'openSearchUrl'
+          )}/_plugins/_anomaly_detection/detectors/${hit._id}/_stop`
+        ).then((response) => {
+          if (response.status === 200) {
+            cy.request(
+              'DELETE',
+              `${Cypress.env(
+                'openSearchUrl'
+              )}/_plugins/_anomaly_detection/detectors/${hit._id}`
+            );
+          }
+        });
+      }
+    }
+  });
 });
 
 Cypress.Commands.add('getIndexSettings', (index) => {


### PR DESCRIPTION
### Description

This commit addresses an issue where the deletion of Anomaly Detection (AD) system indices was failing in Cypress tests due to lack of super admin privileges. Instead of attempting to delete the indices as super admin, which isn't feasible in the Cypress environment, we now employ an API-based approach to delete the content of these AD indices.

Testing Performed:
1. Executed all tests in a security-enabled cluster confirming the successful deletion of AD system indices content.

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/714

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
