### PR TITLE
[Table Visualizations] Update test

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
@@ -50,14 +50,14 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
       cy.getElementByTestId('field-categories.keyword-showDetails').drag(
         '[data-test-subj="dropBoxAddField-split_row"]'
       );
-      testSplitTables('', 4);
+      testSplitTables(4);
       removeBucket('dropBoxField-split_row-0');
 
       // vis builder should render splitted tables in columns
       cy.getElementByTestId('field-categories.keyword-showDetails').drag(
         '[data-test-subj="dropBoxAddField-split_column"]'
       );
-      testSplitTables('visTable__groupInColumns', 4);
+      testSplitTables(4);
     });
 
     after(() => {
@@ -85,9 +85,9 @@ export const removeBucket = (bucket) => {
   });
 };
 
-export const testSplitTables = (dir, num) => {
+export const testSplitTables = (num) => {
   cy.getElementByTestId('visTable')
-    .should('have.class', `visTable ${dir}`.trim())
+    .should('have.class', `visTable`)
     .find('[class="visTable__group"]')
     .should(($tables) => {
       // should have found specified number of tables


### PR DESCRIPTION
### Description

This PR updates tests, so that it no longer needs to test direction, because the direction logic was moved to the OUI components, instead of custom `visTable__groupInColumns` class that is used currently. Without this, the tests will fail when [the PR that removes `visTable__groupInColumns`](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4272) will be merged, as this class will no longer exist.
https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/6823c8202eb8aca8ec1ef1dee41c9e25f65622ab/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js#L60 

### Issues Resolved

Solves https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/730

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
