### PR TITLE
[Dashboard De-Angular] Let dashboard finish loading after adding a new vis

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
@@ -95,6 +95,8 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
       cy.getElementByTestId('savedObjectTitle').type(visTitle);
       cy.getElementByTestId('confirmSaveSavedObjectButton').click();
 
+      // Wait for page to load
+      cy.waitForLoader();
       // Check to see if the new vis is present in the dashboard
       cy.getElementByTestId(
         `embeddablePanelHeading-${toTestId(visTitle, '')}`


### PR DESCRIPTION
### Description
Add one line `cy.waitForLoader();` in the vis-builder/dashboard test. 

Previously, after we create a new vis builder from a dashboard, we immediately test if the vis builder exists in that dashboard without letting the dashboard page finish loading. 


