### PR TITLE
Increment version to 2.10 as part of release process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-dashboards-functional-test",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Maintains functional tests for OpenSearch Dashboards and Dashboards plugins",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Description

Increment the version on the parent branch (2.x) to the next development iteration (2.10) after 2.9 branch cut.

Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4486