### PR TITLE
[Backport main] feat: sync cypress test from notifications-dashboards (#776)

### DIFF
--- a/cypress/fixtures/plugins/notifications-dashboards/test_chime_channel.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_chime_channel.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "name": "Test chime channel",
+    "description": "A test chime channel",
+    "config_type": "chime",
+    "is_enabled": true,
+    "chime": {
+      "url": "https://sample-chime-webhook"
+    }
+  }
+}

--- a/cypress/fixtures/plugins/notifications-dashboards/test_email_recipient_group.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_email_recipient_group.json
@@ -1,0 +1,30 @@
+{
+  "config": {
+    "name": "Test recipient group",
+    "description": "A test email recipient group",
+    "config_type": "email_group",
+    "is_enabled": true,
+    "email_group": {
+      "recipient_list": [
+        {
+          "recipient": "custom.email.1@test.com"
+        },
+        {
+          "recipient": "custom.email.2@test.com"
+        },
+        {
+          "recipient": "custom.email.3@test.com"
+        },
+        {
+          "recipient": "custom.email.4@test.com"
+        },
+        {
+          "recipient": "custom.email.5@test.com"
+        },
+        {
+          "recipient": "custom.email.6@test.com"
+        }
+      ]
+    }
+  }
+}

--- a/cypress/fixtures/plugins/notifications-dashboards/test_ses_sender.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_ses_sender.json
@@ -1,0 +1,13 @@
+{
+  "config": {
+    "name": "test-ses-sender",
+    "description": "A test SES sender",
+    "config_type": "ses_account",
+    "is_enabled": true,
+    "ses_account": {
+      "region": "us-east-1",
+      "role_arn": "arn:aws:iam::012345678912:role/NotificationsSESRole",
+      "from_address": "test@email.com"
+    }
+  }
+}

--- a/cypress/fixtures/plugins/notifications-dashboards/test_slack_channel.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_slack_channel.json
@@ -1,0 +1,11 @@
+{
+  "config": {
+    "name": "Test slack channel",
+    "description": "A test slack channel",
+    "config_type": "slack",
+    "is_enabled": true,
+    "slack": {
+      "url": "https://sample-slack-webhook"
+    }
+  }
+}

--- a/cypress/fixtures/plugins/notifications-dashboards/test_smtp_email_channel.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_smtp_email_channel.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "name": "Test email channel",
+    "description": "A test SMTP email channel",
+    "config_type": "email",
+    "is_enabled": true,
+    "email": {
+      "email_account_id": "test_smtp_sender_id",
+      "recipient_list": [
+        {
+          "recipient": "custom.email@test.com"
+        }
+      ],
+      "email_group_id_list": []
+    }
+  }
+}

--- a/cypress/fixtures/plugins/notifications-dashboards/test_sns_channel.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_sns_channel.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "name": "test-sns-channel",
+    "description": "A test SNS channel",
+    "config_type": "sns",
+    "is_enabled": true,
+    "sns": {
+      "topic_arn": "arn:aws:sns:us-west-2:123456789012:notifications-test",
+      "role_arn": "arn:aws:iam::012345678901:role/NotificationsSNSRole"
+    }
+  }
+}

--- a/cypress/fixtures/plugins/notifications-dashboards/test_ssl_smtp_sender.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_ssl_smtp_sender.json
@@ -1,0 +1,14 @@
+{
+  "config": {
+    "name": "test-ssl-sender",
+    "description": "A test SSL SMTP sender",
+    "config_type": "smtp_account",
+    "is_enabled": true,
+    "smtp_account": {
+      "host": "test-host.com",
+      "port": 123,
+      "method": "ssl",
+      "from_address": "test@email.com"
+    }
+  }
+}

--- a/cypress/fixtures/plugins/notifications-dashboards/test_tls_smtp_sender.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_tls_smtp_sender.json
@@ -1,0 +1,15 @@
+{
+  "config_id": "test_smtp_sender_id",
+  "config": {
+    "name": "test-tls-sender",
+    "description": "A test TLS SMTP sender",
+    "config_type": "smtp_account",
+    "is_enabled": true,
+    "smtp_account": {
+      "host": "test-host.com",
+      "port": 123,
+      "method": "start_tls",
+      "from_address": "test@email.com"
+    }
+  }
+}

--- a/cypress/fixtures/plugins/notifications-dashboards/test_webhook_channel.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_webhook_channel.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "name": "Test webhook channel",
+    "description": "A test webhook channel",
+    "config_type": "webhook",
+    "is_enabled": true,
+    "webhook": {
+      "url": "https://custom-webhook-test-url.com:8888/test-path?params1=value1&params2=value2&params3=value3&params4=value4&params5=values5&params6=values6&params7=values7"
+    }
+  }
+}
+

--- a/cypress/integration/plugins/notifications-dashboards/1_email_senders_and_groups.spec.js
+++ b/cypress/integration/plugins/notifications-dashboards/1_email_senders_and_groups.spec.js
@@ -11,10 +11,21 @@ import {
   NOTIFICATIONS_PLUGIN_NAME,
 } from '../../../utils/constants';
 
+import testSslSmtpSender from '../../../fixtures/plugins/notifications-dashboards/test_ssl_smtp_sender.json';
+import testTlsSmtpSender from '../../../fixtures/plugins/notifications-dashboards/test_tls_smtp_sender.json';
+import testSesSender from '../../../fixtures/plugins/notifications-dashboards/test_ses_sender.json';
+import testEmailRecipientGroup from '../../../fixtures/plugins/notifications-dashboards/test_email_recipient_group.json';
+
 describe('Test create email senders', () => {
+  before(() => {
+    // Delete all Notification configs
+    cy.deleteAllNotificationConfigs();
+  });
+
   beforeEach(() => {
     cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#email-senders`);
-    cy.wait(NOTIFICATIONS_DELAY * 3);
+    cy.reload(true);
+    cy.wait(NOTIFICATIONS_DELAY * 5);
   });
 
   it('creates ssl sender', () => {
@@ -62,7 +73,7 @@ describe('Test create email senders', () => {
 
     cy.get('.euiButton__text').contains('Create').click({ force: true });
     cy.contains('successfully created.').should('exist');
-    cy.contains('test-ssl-sender').should('exist');
+    cy.contains('test-tls-sender').should('exist');
   });
 
   it('creates SES sender', () => {
@@ -89,16 +100,26 @@ describe('Test create email senders', () => {
 });
 
 describe('Test edit senders', () => {
+  before(() => {
+    // Delete all Notification configs
+    cy.deleteAllNotificationConfigs();
+
+    cy.createNotificationConfig(testSslSmtpSender);
+    cy.createNotificationConfig(testTlsSmtpSender);
+    cy.createNotificationConfig(testSesSender);
+  });
+
   beforeEach(() => {
     cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#email-senders`);
-    cy.wait(NOTIFICATIONS_DELAY * 3);
+    cy.reload(true);
+    cy.wait(NOTIFICATIONS_DELAY * 5);
   });
 
   it('edits sender email address', () => {
     cy.get('.euiCheckbox__input[aria-label="Select this row"]').eq(0).click(); // ssl sender
     cy.get('[data-test-subj="senders-table-edit-button"]').click();
     cy.get('[data-test-subj="create-sender-form-email-input"]').type(
-      '{selectall}{backspace}edited.test@email.com'
+      '{selectall}{backspace}editedtest@email.com'
     );
     cy.wait(NOTIFICATIONS_DELAY);
 
@@ -120,14 +141,26 @@ describe('Test edit senders', () => {
 });
 
 describe('Test delete senders', () => {
+  before(() => {
+    // Delete all Notification configs
+    cy.deleteAllNotificationConfigs();
+
+    cy.createNotificationConfig(testSslSmtpSender);
+    cy.createNotificationConfig(testTlsSmtpSender);
+    cy.createNotificationConfig(testSesSender);
+  });
+
   beforeEach(() => {
     cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#email-senders`);
-    cy.wait(NOTIFICATIONS_DELAY * 3);
+    cy.reload(true);
+    cy.wait(NOTIFICATIONS_DELAY * 5);
   });
 
   it('deletes smtp senders', () => {
     cy.get('.euiCheckbox__input[aria-label="Select this row"]').eq(0).click(); // ssl sender
-    cy.get('[data-test-subj="senders-table-delete-button"]').click();
+    cy.get('[data-test-subj="senders-table-delete-button"]').click({
+      force: true,
+    });
     cy.get('input[placeholder="delete"]').type('delete');
     cy.wait(NOTIFICATIONS_DELAY);
     cy.get('[data-test-subj="delete-sender-modal-delete-button"]').click();
@@ -136,7 +169,10 @@ describe('Test delete senders', () => {
 
   it('deletes ses senders', () => {
     cy.get('.euiCheckbox__input[aria-label="Select this row"]').last().click(); // ses sender
-    cy.get('[data-test-subj="ses-senders-table-delete-button"]').click();
+    cy.wait(NOTIFICATIONS_DELAY);
+    cy.get('[data-test-subj="ses-senders-table-delete-button"]').click({
+      force: true,
+    });
     cy.get('input[placeholder="delete"]').type('delete');
     cy.wait(NOTIFICATIONS_DELAY);
     cy.get('[data-test-subj="delete-sender-modal-delete-button"]').click();
@@ -148,10 +184,16 @@ describe('Test delete senders', () => {
 
 describe('Test create, edit and delete recipient group', () => {
   beforeEach(() => {
+    // Delete all Notification configs
+    cy.deleteAllNotificationConfigs();
+
+    cy.createNotificationConfig(testEmailRecipientGroup);
+
     cy.visit(
       `${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#email-recipient-groups`
     );
-    cy.wait(NOTIFICATIONS_DELAY * 3);
+    cy.reload(true);
+    cy.wait(NOTIFICATIONS_DELAY * 5);
   });
 
   it('creates recipient group', () => {
@@ -210,13 +252,18 @@ describe('Test create, edit and delete recipient group', () => {
   });
 
   it('opens email addresses popup', () => {
-    cy.get('.euiLink').contains('1 more').click({ force: true });
+    cy.get('.euiTableCellContent--overflowingContent .euiLink')
+      .contains('1 more')
+      .click({ force: true });
     cy.contains('custom.email.6@test.com').should('exist');
   });
 
   it('deletes recipient groups', () => {
-    cy.get('[data-test-subj="checkboxSelectAll"]').last().click();
-    cy.get('[data-test-subj="recipient-groups-table-delete-button"]').click();
+    cy.get('[data-test-subj="checkboxSelectAll"]').click({ force: true });
+    cy.wait(NOTIFICATIONS_DELAY);
+    cy.get('[data-test-subj="recipient-groups-table-delete-button"]').click({
+      force: true,
+    });
     cy.get('input[placeholder="delete"]').type('delete');
     cy.wait(NOTIFICATIONS_DELAY);
     cy.get(

--- a/cypress/integration/plugins/notifications-dashboards/2_channels.spec.js
+++ b/cypress/integration/plugins/notifications-dashboards/2_channels.spec.js
@@ -11,7 +11,19 @@ import {
   NOTIFICATIONS_PLUGIN_NAME,
 } from '../../../utils/constants';
 
+import testSlackChannel from '../../../fixtures/plugins/notifications-dashboards/test_slack_channel.json';
+import testChimeChannel from '../../../fixtures/plugins/notifications-dashboards/test_chime_channel.json';
+import testWebhookChannel from '../../../fixtures/plugins/notifications-dashboards/test_webhook_channel.json';
+import testTlsSmtpSender from '../../../fixtures/plugins/notifications-dashboards/test_tls_smtp_sender.json';
+
 describe('Test create channels', () => {
+  before(() => {
+    // Delete all Notification configs
+    cy.deleteAllNotificationConfigs();
+
+    cy.createNotificationConfig(testTlsSmtpSender);
+  });
+
   beforeEach(() => {
     cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#create-channel`);
     cy.wait(NOTIFICATIONS_DELAY * 3);
@@ -58,7 +70,7 @@ describe('Test create channels', () => {
     cy.contains('successfully created.').should('exist');
   });
 
-  it('creates a email channel', () => {
+  it('creates an email channel', () => {
     cy.get('[placeholder="Enter channel name"]').type('Test email channel');
 
     cy.get('.euiSuperSelectControl').contains('Slack').click({ force: true });
@@ -96,7 +108,7 @@ describe('Test create channels', () => {
     cy.contains('successfully created.').should('exist');
   });
 
-  it('creates a email channel with ses sender', () => {
+  it('creates an email channel with ses sender', () => {
     cy.get('[placeholder="Enter channel name"]').type(
       'Test email channel with ses'
     );
@@ -156,7 +168,7 @@ describe('Test create channels', () => {
     cy.contains('successfully created.').should('exist');
   });
 
-  it('creates a sns channel', () => {
+  it('creates an sns channel', () => {
     cy.get('[placeholder="Enter channel name"]').type('test-sns-channel');
 
     cy.get('.euiSuperSelectControl').contains('Slack').click({ force: true });
@@ -179,6 +191,17 @@ describe('Test create channels', () => {
 });
 
 describe('Test channels table', () => {
+  before(() => {
+    // Delete all Notification configs
+    cy.deleteAllNotificationConfigs();
+
+    // Create test channels
+    cy.createNotificationConfig(testSlackChannel);
+    cy.createNotificationConfig(testChimeChannel);
+    cy.createNotificationConfig(testWebhookChannel);
+    cy.createTestEmailChannel();
+  });
+
   beforeEach(() => {
     cy.visit(`${BASE_PATH}/app/${NOTIFICATIONS_PLUGIN_NAME}#channels`);
     cy.wait(NOTIFICATIONS_DELAY * 3);
@@ -260,6 +283,9 @@ describe('Test channel details', () => {
     // cy.get(
     //   '[data-test-subj="create-channel-description-input"]'
     // ).type('{selectall}{backspace}Updated custom webhook description');
+    cy.get('[data-test-subj="create-channel-description-input"]').type(
+      '{selectall}{backspace}Updated custom webhook description'
+    );
     cy.get('.euiTextArea').type(
       '{selectall}{backspace}Updated custom webhook description'
     );

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -29,6 +29,7 @@ import '../utils/plugins/security-dashboards-plugin/commands';
 import '../utils/plugins/alerting-dashboards-plugin/commands';
 import '../utils/plugins/ml-commons-dashboards/commands';
 import '../utils/plugins/security-analytics-dashboards-plugin/commands';
+import '../utils/plugins/notifications-dashboards/commands';
 
 import 'cypress-real-events';
 

--- a/cypress/utils/plugins/notifications-dashboards/commands.js
+++ b/cypress/utils/plugins/notifications-dashboards/commands.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import testTlsSmtpSender from '../../../fixtures/plugins/notifications-dashboards/test_tls_smtp_sender.json';
+import testSmtpEmailChannel from '../../../fixtures/plugins/notifications-dashboards/test_smtp_email_channel.json';
+import { API } from './constants';
+
+Cypress.Commands.add('deleteAllNotificationConfigs', () => {
+  cy.request({
+    method: 'POST',
+    url: `${Cypress.env('openSearchUrl')}/_refresh`,
+  });
+
+  cy.request({
+    method: 'GET',
+    url: `${Cypress.env('openSearchUrl')}${API.CONFIGS_BASE}`,
+  }).then((response) => {
+    if (response.status === 200) {
+      for (let i = 0; i < response.body.total_hits; i++) {
+        cy.request(
+          'DELETE',
+          `${Cypress.env('openSearchUrl')}${API.CONFIGS_BASE}/${
+            response.body.config_list[i].config_id
+          }`
+        );
+      }
+    } else {
+      cy.log('Failed to get configs.', response);
+    }
+  });
+});
+
+Cypress.Commands.add('createNotificationConfig', (notificationConfigJSON) => {
+  cy.request(
+    'POST',
+    `${Cypress.env('openSearchUrl')}${API.CONFIGS_BASE}`,
+    notificationConfigJSON
+  );
+});
+
+Cypress.Commands.add('createTestEmailChannel', () => {
+  cy.createNotificationConfig(testTlsSmtpSender);
+  cy.createNotificationConfig(testSmtpEmailChannel);
+});

--- a/cypress/utils/plugins/notifications-dashboards/constants.js
+++ b/cypress/utils/plugins/notifications-dashboards/constants.js
@@ -5,3 +5,7 @@
 
 export const NOTIFICATIONS_PLUGIN_NAME = 'notifications-dashboards';
 export const NOTIFICATIONS_DELAY = 1000;
+export const NOTIFICATIONS_API_ROUTE_PREFIX = '/_plugins/_notifications';
+export const API = {
+  CONFIGS_BASE: `${NOTIFICATIONS_API_ROUTE_PREFIX}/configs`,
+};


### PR DESCRIPTION
* feat: sync cypress test from notifications-dashboards

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: rename commands

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: update

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: add larger wait time

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: update

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: update

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: update

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

* feat: add refresh before delete all notifications configs

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>

---------

Signed-off-by: SuZhou-Joe <suzhou@amazon.com>
(cherry picked from commit 81f70c37fde7b468915b173b0e81f4a609ecea84)

### Description

[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
