### PR TITLE
[Table Visualizations] Tests cleanup

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
@@ -87,7 +87,7 @@ export const removeBucket = (bucket) => {
 
 export const testSplitTables = (num) => {
   cy.getElementByTestId('visTable')
-    .should('have.class', `visTable`)
+    .should('have.class', 'visTable')
     .find('[class="visTable__group"]')
     .should(($tables) => {
       // should have found specified number of tables

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/split.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/split.spec.js
@@ -311,7 +311,7 @@ describe.skip('Split table', () => {
     cy.tbSplitTablesInColumns();
     cy.tbSetupTermsAggregation('age', 'Descending', '2', 2);
     cy.waitForLoader();
-    cy.get('[class="visTable visTable__groupInColumns"]').should('exist');
+    cy.get('[class="visTable"]').should('exist');
     cy.tbGetAllTableDataFromVisualization(2).then((data) => {
       expect(data).to.deep.eq(expectData);
     });


### PR DESCRIPTION
### Description

In https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/731 the usage of `visTable__groupInColumns` was removed, but one usage was left off https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/7f8a7d799abe560549759fa440b0184a3238b61b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/split.spec.js#L314. Also, it covers another follow-up cleanup issue https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/740.

### Issues Resolved

Solves https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/740

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
