### PR TITLE
[Table Visualizations] Test Update

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
@@ -88,7 +88,7 @@ export const removeBucket = (bucket) => {
 export const testSplitTables = (num) => {
   cy.getElementByTestId('visTable')
     .should('have.class', 'visTable')
-    .find('[class="visTable__group"]')
+    .find('[class*="visTable__group"]')
     .should(($tables) => {
       // should have found specified number of tables
       expect($tables).to.have.length(num);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
@@ -88,7 +88,7 @@ export const removeBucket = (bucket) => {
 export const testSplitTables = (num) => {
   cy.getElementByTestId('visTable')
     .should('have.class', 'visTable')
-    .find('[class*="visTable__group"]')
+    .find('.visTable__group')
     .should(($tables) => {
       // should have found specified number of tables
       expect($tables).to.have.length(num);


### PR DESCRIPTION
### Description

In this dashboards [PR](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4272) we replaced div container with `OuiFlexItem`. So this line:
https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/7f8a7d799abe560549759fa440b0184a3238b61b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js#L91
Was causing error, because it matches element with exactly single `visTable__group` class, while after the PR we had additional `euiFlexItem` class. As a result we got undefined. Here is the screenshot of error.
![Vis Builder Table Chart -- Basic test (failed)](https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/67782303/55bf842e-55cd-4aa3-8972-f797becf54f8)

Now after this fix this test suite do pass, here is the screenshot from my local cypress run.
<img width="1222" alt="image" src="https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/67782303/e01da8b3-5ada-4f28-ab2e-e8726e6645f7">

As we can see it does match all 4 elements like it should.


### Issues Resolved

It solves cypress error when trying to merge https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4272

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
