### PR TITLE
Bump dependency on opensearch-dashboards-test-library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "ISC",
       "dependencies": {
         "@cypress/skip-test": "^2.6.1",
-        "@opensearch-dashboards-test/opensearch-dashboards-test-library": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.4.tar.gz",
+        "@opensearch-dashboards-test/opensearch-dashboards-test-library": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.5.tar.gz",
         "brace": "^0.11.1",
         "prettier": "^2.5.1"
       },
@@ -273,9 +273,9 @@
       "dev": true
     },
     "node_modules/@opensearch-dashboards-test/opensearch-dashboards-test-library": {
-      "version": "1.0.4",
-      "resolved": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.4.tar.gz",
-      "integrity": "sha512-IGxw7GVFRyKgjVs+ubTDynrOEvqlI7gTua+Lf2LbDL9g+f6qQ64gnCyMQWeu3mr+w38r+rvN6Uq0AGCcbQ9mlA==",
+      "version": "1.0.5",
+      "resolved": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.5.tar.gz",
+      "integrity": "sha512-1TIUBDKuAlhBUQg1XqYvsOs0x4R02r/437bDRQxEV21Bz3kP5djPG6hHDtuB7lbJkPE2zTgNO+VeQd50uUr9rQ==",
       "license": "ISC"
     },
     "node_modules/@types/json5": {
@@ -4261,8 +4261,8 @@
       "dev": true
     },
     "@opensearch-dashboards-test/opensearch-dashboards-test-library": {
-      "version": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.4.tar.gz",
-      "integrity": "sha512-IGxw7GVFRyKgjVs+ubTDynrOEvqlI7gTua+Lf2LbDL9g+f6qQ64gnCyMQWeu3mr+w38r+rvN6Uq0AGCcbQ9mlA=="
+      "version": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.5.tar.gz",
+      "integrity": "sha512-1TIUBDKuAlhBUQg1XqYvsOs0x4R02r/437bDRQxEV21Bz3kP5djPG6hHDtuB7lbJkPE2zTgNO+VeQd50uUr9rQ=="
     },
     "@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/opensearch-project/opensearch-dashboards-functional-test",
   "dependencies": {
     "@cypress/skip-test": "^2.6.1",
-    "@opensearch-dashboards-test/opensearch-dashboards-test-library": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.4.tar.gz",
+    "@opensearch-dashboards-test/opensearch-dashboards-test-library": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.5.tar.gz",
     "brace": "^0.11.1",
     "prettier": "^2.5.1"
   },


### PR DESCRIPTION
### Description

Bump dependency on `opensearch-dashboards-test-library` to use the `main` branch on the repo to get the latest changes all the time.


### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
