### PR TITLE
Read-only tenant mode tests

### DIFF
--- a/cypress/integration/plugins/security-dashboards-plugin/readonly.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/readonly.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import roleWithoutTestJson from '../../../fixtures/plugins/security-dashboards-plugin/roles/roleWithoutTest';
+import { BASE_PATH } from '../../../utils/base_constants';
+import { ADMIN_AUTH, CURRENT_TENANT } from '../../../utils/commands';
+
+const TEST_CONFIG = {
+  role: {
+    name: 'test_readonly_role',
+    json: Object.assign({}, roleWithoutTestJson, {
+      tenant_permissions: [
+        {
+          tenant_patterns: ['test_readonly_tenant'],
+          allowed_actions: ['kibana_all_read'],
+        },
+      ],
+    }),
+  },
+  tenant: {
+    name: 'test_readonly_tenant',
+    description: 'Testing read-only tenant mode',
+  },
+  user: {
+    username: 'test_readonly_user',
+    password: 'testUserPassword123',
+  },
+};
+
+if (Cypress.env('SECURITY_ENABLED')) {
+  describe('Read Only mode', () => {
+    before(() => {
+      cy.server();
+
+      cy.createTenant(TEST_CONFIG.tenant.name, {
+        description: TEST_CONFIG.tenant.description,
+      });
+
+      cy.createInternalUser(TEST_CONFIG.user.username, {
+        password: TEST_CONFIG.user.password,
+      });
+
+      cy.createRole(TEST_CONFIG.role.name, TEST_CONFIG.role.json);
+
+      cy.createRoleMapping(TEST_CONFIG.role.name, {
+        users: [TEST_CONFIG.user.username],
+      });
+    });
+
+    it('should create sample data', () => {
+      CURRENT_TENANT.newTenant = TEST_CONFIG.tenant.name;
+      cy.loadSampleData('flights');
+    });
+
+    it('should be able to modify the dashboard as admin', () => {
+      CURRENT_TENANT.newTenant = TEST_CONFIG.tenant.name;
+
+      cy.visit(BASE_PATH);
+      cy.waitForLoader();
+
+      cy.getElementByTestId('tenant-switch-modal')
+        .find('[data-test-subj="confirm"]')
+        .click({ force: true });
+      cy.waitForLoader();
+
+      cy.visitDashboard('[Logs] Web Traffic');
+
+      cy.getElementByTestId('dashboardClone').should('exist');
+      cy.getElementByTestId('dashboardEditMode').should('exist');
+    });
+
+    it('should not be able to modify the dashboard when is performing as a custom readonly tenant', () => {
+      ADMIN_AUTH.newUser = TEST_CONFIG.user.username;
+      ADMIN_AUTH.newPassword = TEST_CONFIG.user.password;
+      CURRENT_TENANT.newTenant = TEST_CONFIG.tenant.name;
+
+      cy.visit(BASE_PATH);
+      cy.waitForLoader();
+
+      cy.visitDashboard('[Logs] Web Traffic');
+
+      cy.getElementByTestId('dashboardClone').should('not.exist');
+      cy.getElementByTestId('dashboardEditMode').should('not.exist');
+    });
+  });
+}

--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -483,3 +483,12 @@ Cypress.Commands.add(
       });
   }
 );
+
+// type: logs, ecommerce, flights
+Cypress.Commands.add('loadSampleData', (type) => {
+  cy.request({
+    method: 'POST',
+    headers: { 'osd-xsrf': 'opensearch-dashboards' },
+    url: `${BASE_PATH}/api/sample_data/${type}`,
+  });
+});


### PR DESCRIPTION
### Description

Introduces tests for read-only tenant mode.

### Issues Resolved

This is a complementary PR for:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4498
https://github.com/opensearch-project/security-dashboards-plugin/pull/1472

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
