### PR TITLE
[feature/cypress12] Update security and security-dashboards-plugin tests to run with Cypress12

### DIFF
--- a/cypress/e2e/plugins/security-dashboards-plugin/aggregation_view.cy.js
+++ b/cypress/e2e/plugins/security-dashboards-plugin/aggregation_view.cy.js
@@ -29,7 +29,6 @@ if (Cypress.env('SECURITY_ENABLED') && Cypress.env('AGGREGATION_VIEW')) {
     // start a server so that server responses can be mocked via fixtures
     // in all of the below test cases
     before(() => {
-      cy.server();
       cy.createTenant(tenantName, tenantDescription);
 
       cy.createIndexPattern('index-pattern1', {

--- a/cypress/e2e/plugins/security-dashboards-plugin/default_tenant.cy.js
+++ b/cypress/e2e/plugins/security-dashboards-plugin/default_tenant.cy.js
@@ -13,7 +13,6 @@ const tenantName = 'test';
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Multi Tenancy Default Tenant Tests: ', () => {
     before(() => {
-      cy.server();
       cy.createTenant(tenantName, tenantDescription);
       cy.changeDefaultTenant({
         multitenancy_enabled: true,

--- a/cypress/e2e/plugins/security-dashboards-plugin/inaccessible_tenancy_features.cy.js
+++ b/cypress/e2e/plugins/security-dashboards-plugin/inaccessible_tenancy_features.cy.js
@@ -7,9 +7,6 @@ import { TENANTS_MANAGE_PATH } from '../../../utils/dashboards/constants';
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Multi Tenancy Tests: ', () => {
-    before(() => {
-      cy.server();
-    });
     it('Test Dashboards tenancy features should not be accessible ', () => {
       // This test is to ensure tenancy related features are not accessible when opensearch_security.multitenancy.enabled is disabled in the opensearchdashboard.yaml
       cy.visit(TENANTS_MANAGE_PATH);

--- a/cypress/e2e/plugins/security-dashboards-plugin/multi_tenancy.cy.js
+++ b/cypress/e2e/plugins/security-dashboards-plugin/multi_tenancy.cy.js
@@ -19,7 +19,6 @@ const tenantName = 'test';
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Multi Tenancy Tests: ', () => {
     before(() => {
-      cy.server();
       cy.createTenant(tenantName, tenantDescription);
       cy.createIndexPattern(
         'index-pattern1',

--- a/cypress/e2e/plugins/security/audit_log.cy.js
+++ b/cypress/e2e/plugins/security/audit_log.cy.js
@@ -10,12 +10,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Audit logs page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.server();
-    });
-
     it('should load Audit logs page properly', () => {
       cy.mockAuditLogsAction(
         SEC_AUDIT_FIXTURES_PATH + '/audit_info_response.json',

--- a/cypress/e2e/plugins/security/auth.cy.js
+++ b/cypress/e2e/plugins/security/auth.cy.js
@@ -10,12 +10,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Authc and Authz page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.server();
-    });
-
     it('authentication and authorization section should exist', () => {
       cy.mockAuthAction(SEC_FIXTURES_BASE_PATH + '/auth_response.json', () => {
         cy.visit(SEC_UI_AUTH_PATH);

--- a/cypress/e2e/plugins/security/get_started.cy.js
+++ b/cypress/e2e/plugins/security/get_started.cy.js
@@ -10,12 +10,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Home(Get Started) page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.server();
-    });
-
     it('should load Home page properly', () => {
       cy.visit(BASE_SEC_UI_PATH);
 

--- a/cypress/e2e/plugins/security/internalusers.cy.js
+++ b/cypress/e2e/plugins/security/internalusers.cy.js
@@ -11,12 +11,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Internal users page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.server();
-    });
-
     it('should load internal users page properly', () => {
       cy.mockInternalUsersAction(
         SEC_INTERNALUSERS_FIXTURES_PATH + '/internalusers_info_response.json',

--- a/cypress/e2e/plugins/security/permissions.cy.js
+++ b/cypress/e2e/plugins/security/permissions.cy.js
@@ -10,12 +10,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Permissions page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.server();
-    });
-
     it('should load Permissions page properly', () => {
       cy.mockPermissionsAction(
         SEC_PERMISSIONS_FIXTURES_PATH + '/actiongroups_response.json',

--- a/cypress/e2e/plugins/security/roles.cy.js
+++ b/cypress/e2e/plugins/security/roles.cy.js
@@ -11,12 +11,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Roles page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.server();
-    });
-
     it('should load Roles page properly', () => {
       cy.mockRolesAction(
         SEC_ROLES_FIXTURES_PATH + '/roles_response.json',

--- a/cypress/e2e/plugins/security/tenants.cy.js
+++ b/cypress/e2e/plugins/security/tenants.cy.js
@@ -10,12 +10,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Tenants page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.server();
-    });
-
     it('should load Tenants page properly', () => {
       cy.mockTenantsAction(
         SEC_TENANTS_FIXTURES_PATH + '/tenants_info_response.json',


### PR DESCRIPTION
### Description

Removes unnecessary references to `cy.server()` that were removed in Cypress12.

Migration guide: https://docs.cypress.io/guides/references/migration-guide#cyserver-cyroute-and-CypressServerdefaults

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1562

Related https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/408

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
