### PR TITLE
fix workbench download text and csv schema

### DIFF
--- a/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
+++ b/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
@@ -207,14 +207,7 @@ describe('Test and verify SQL downloads', () => {
             'select * from accounts where balance > 49500 order by account_number',
         },
       }).then((response) => {
-        if (
-          title === 'Download and verify CSV' ||
-          title === 'Download and verify Text'
-        ) {
-          expect(response.body.data.body).to.have.string(files[file]);
-        } else {
-          expect(response.body.data.resp).to.have.string(files[file]);
-        }
+        expect(response.body.data.resp).to.have.string(files[file]);
       });
     });
   });


### PR DESCRIPTION
### Description

based on the API call, response schema changed back to have data in `response.body.data.resp`. `resp` used to be `"resp": "Unable to parse/serialize body",` is fixed for 2.9, please also port this to main

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
