### PR TITLE
[Backport 1.2] added fix for gantt-charts test for different timezones

### DIFF
--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -5,7 +5,11 @@
 
 /// <reference types="cypress" />
 
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import dayjs from 'dayjs';
 import { BASE_PATH } from '../../../utils/constants';
+
+dayjs.extend(customParseFormat);
 
 const delay = 100;
 const GANTT_VIS_NAME =
@@ -169,37 +173,60 @@ describe('Configure panel settings', () => {
   });
 
   it('Changes time formats', () => {
-    cy.contains('12:59:07.303 PM').should('exist');
-
     cy.get('select').eq(3).select('MM/DD hh:mm:ss A');
     cy.wait(delay);
     cy.get('.euiButton__text').contains('Update').click({ force: true });
-    cy.wait(delay);
-    cy.contains('05/28 12:59:07 PM').should('exist');
+    cy.wait(1000);
+    cy.get('.xtick')
+      .eq(0)
+      .invoke('text')
+      .then((text) => {
+        expect(dayjs(text, 'MM/DD hh:mm:ss A', true).isValid()).to.be.true;
+      });
 
     cy.get('select').eq(3).select('MM/DD/YY hh:mm A');
     cy.wait(delay);
     cy.get('.euiButton__text').contains('Update').click({ force: true });
-    cy.wait(delay);
-    cy.contains('05/28/20 12:59 PM').should('exist');
+    cy.wait(1000);
+    cy.get('.xtick')
+      .eq(0)
+      .invoke('text')
+      .then((text) => {
+        expect(dayjs(text, 'MM/DD/YY hh:mm A', true).isValid()).to.be.true;
+      });
 
     cy.get('select').eq(3).select('HH:mm:ss.SSS');
     cy.wait(delay);
     cy.get('.euiButton__text').contains('Update').click({ force: true });
-    cy.wait(delay);
-    cy.contains('12:59:07.303').should('exist');
+    cy.wait(1000);
+    cy.get('.xtick')
+      .eq(0)
+      .invoke('text')
+      .then((text) => {
+        expect(dayjs(text, 'HH:mm:ss.SSS', true).isValid()).to.be.true;
+      });
 
     cy.get('select').eq(3).select('MM/DD HH:mm:ss');
     cy.wait(delay);
     cy.get('.euiButton__text').contains('Update').click({ force: true });
-    cy.wait(delay);
-    cy.contains('05/28 12:59:07').should('exist');
+    cy.wait(1000);
+    cy.get('.xtick')
+      .eq(0)
+      .invoke('text')
+      .then((text) => {
+        expect(dayjs(text, 'MM/DD HH:mm:ss', true).isValid()).to.be.true;
+      });
 
     cy.get('select').eq(3).select('MM/DD/YY HH:mm');
     cy.wait(delay);
     cy.get('.euiButton__text').contains('Update').click({ force: true });
-    cy.wait(delay);
-    cy.contains('05/28/20 12:59').should('exist');
+    cy.wait(1000);
+    cy.get('.xtick')
+      .eq(0)
+      .invoke('text')
+      .then((text) => {
+        expect(dayjs(text, 'MM/DD/YY HH:mm', true).isValid()).to.be.true;
+      });
   });
 
   it('Hides legends', () => {

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -5,11 +5,8 @@
 
 /// <reference types="cypress" />
 
-import customParseFormat from 'dayjs/plugin/customParseFormat';
-import dayjs from 'dayjs';
+import moment from 'moment';
 import { BASE_PATH } from '../../../utils/constants';
-
-dayjs.extend(customParseFormat);
 
 const delay = 100;
 const GANTT_VIS_NAME =
@@ -181,7 +178,9 @@ describe('Configure panel settings', () => {
       .eq(0)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'MM/DD hh:mm:ss A', true).isValid()).to.be.true;
+        expect(
+          moment(text, 'MM/DD hh:mm:ss A').format('MM/DD hh:mm:ss A')
+        ).equal(text);
       });
 
     cy.get('select').eq(3).select('MM/DD/YY hh:mm A');
@@ -192,7 +191,9 @@ describe('Configure panel settings', () => {
       .eq(0)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'MM/DD/YY hh:mm A', true).isValid()).to.be.true;
+        expect(
+          moment(text, 'MM/DD hh:mm:ss A').format('MM/DD hh:mm:ss A')
+        ).equal(text);      
       });
 
     cy.get('select').eq(3).select('HH:mm:ss.SSS');
@@ -203,7 +204,9 @@ describe('Configure panel settings', () => {
       .eq(0)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'HH:mm:ss.SSS', true).isValid()).to.be.true;
+        expect(
+          moment(text, 'MM/DD hh:mm:ss A').format('MM/DD hh:mm:ss A')
+        ).equal(text);
       });
 
     cy.get('select').eq(3).select('MM/DD HH:mm:ss');
@@ -214,7 +217,9 @@ describe('Configure panel settings', () => {
       .eq(0)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'MM/DD HH:mm:ss', true).isValid()).to.be.true;
+        expect(
+          moment(text, 'MM/DD hh:mm:ss A').format('MM/DD hh:mm:ss A')
+        ).equal(text);
       });
 
     cy.get('select').eq(3).select('MM/DD/YY HH:mm');
@@ -225,7 +230,9 @@ describe('Configure panel settings', () => {
       .eq(0)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'MM/DD/YY HH:mm', true).isValid()).to.be.true;
+        expect(
+          moment(text, 'MM/DD hh:mm:ss A').format('MM/DD hh:mm:ss A')
+        ).equal(text);
       });
   });
 


### PR DESCRIPTION
### Description

Fix gantt-charts test for different timezones


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
