### PR TITLE
[Dashboard] Retry visbuilder dashboard test

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
@@ -108,38 +108,42 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
       cy.deleteSavedObjectByType(VB_SO_TYPE, `vb${cleanupKey}`);
     });
 
-    it('Should be able to edit a visualization', () => {
-      // Navigate to vis builder
-      cy.getElementByTestId('dashboardEditMode').click();
-      cy.getElementByTestId(
-        `embeddablePanelHeading-${toTestId(VB_METRIC_VIS_TITLE, '')}`
-      )
-        .find('[data-test-subj="embeddablePanelToggleMenuIcon"]')
-        .click();
-      cy.getElementByTestId('embeddablePanelAction-editPanel').click();
-      cy.getElementByTestId('visualizationLoader')
-        .find('.mtrVis__value')
-        .should('contain.text', VB_INDEX_DOC_COUNT);
+    it(
+      'Should be able to edit a visualization',
+      { retries: { runMode: 2 } },
+      () => {
+        // Navigate to vis builder
+        cy.getElementByTestId('dashboardEditMode').click();
+        cy.getElementByTestId(
+          `embeddablePanelHeading-${toTestId(VB_METRIC_VIS_TITLE, '')}`
+        )
+          .find('[data-test-subj="embeddablePanelToggleMenuIcon"]')
+          .click();
+        cy.getElementByTestId('embeddablePanelAction-editPanel').click();
+        cy.getElementByTestId('visualizationLoader')
+          .find('.mtrVis__value')
+          .should('contain.text', VB_INDEX_DOC_COUNT);
 
-      // Edit visualization
-      const newLabel = 'Editied Label';
-      cy.getElementByTestId('dropBoxField-metric-0').click();
-      cy.vbEditAgg([
-        {
-          testSubj: 'visEditorStringInput1customLabel',
-          type: 'input',
-          value: newLabel,
-        },
-      ]);
+        // Edit visualization
+        const newLabel = 'Editied Label';
+        cy.getElementByTestId('dropBoxField-metric-0').click();
+        cy.vbEditAgg([
+          {
+            testSubj: 'visEditorStringInput1customLabel',
+            type: 'input',
+            value: newLabel,
+          },
+        ]);
 
-      // Save and return
-      cy.getElementByTestId('visBuilderSaveAndReturnButton').click();
+        // Save and return
+        cy.getElementByTestId('visBuilderSaveAndReturnButton').click();
 
-      cy.getElementByTestId('visualizationLoader').should(
-        'contain.text',
-        newLabel
-      );
-    });
+        cy.getElementByTestId('visualizationLoader').should(
+          'contain.text',
+          newLabel
+        );
+      }
+    );
 
     after(() => {
       cy.deleteIndex(VB_INDEX_ID);


### PR DESCRIPTION
### Description

Seeing it pass in video replays but occassionally doesn't pass. However, it doesn't pass with security enabled so I'd imagine it could be related to the refreshing of the session.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4947

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
