### PR TITLE
[Security Analytics 2.10] Avoid clicking filter menu btn twice

### DIFF
--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/3_alerts.spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/3_alerts.spec.js
@@ -381,7 +381,6 @@ describe('Alerts', () => {
       .should('have.length', 1);
 
     // Filter the table to show only "Acknowledged" alerts
-    cy.get('[data-text="Status"]').click({ force: true });
     cy.get('[class="euiFilterSelect__items"]').within(() => {
       cy.contains('Active').click({ force: true });
       cy.contains('Acknowledged').click({ force: true });


### PR DESCRIPTION
### Description
When checking for acknowledged alerts, since the filter menu is already open, clicking the button closes it. This PR fixes the test to avoid opening the menu twice.

### Issues Resolved
https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/690

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
