### PR TITLE
removed check for url since it differs with and without security

### DIFF
--- a/cypress/utils/plugins/security-analytics-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/security-analytics-dashboards-plugin/commands.js
@@ -54,11 +54,9 @@ Cypress.Commands.add(
     Cypress.log({
       message: `Wait for url: ${fullUrl} to be loaded.`,
     });
-    cy.url({ timeout: timeout })
-      .should('include', fullUrl)
-      .then(() => {
-        contains && cy.contains(contains).should('be.visible');
-      });
+    cy.url({ timeout: timeout }).then(() => {
+      contains && cy.contains(contains).should('be.visible');
+    });
   }
 );
 


### PR DESCRIPTION
### Description
The check for loaded URL doesn't account for security enabled, removed it since we have other check for the page content to verify the page loaded correctly

### Issues Resolved
https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/690

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
