### PR TITLE
[Alerting 2.x] Override element covered check for name input in Composite monitor creation

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
@@ -71,16 +71,20 @@ describe('CompositeLevelMonitor', () => {
       cy.get('[data-test-subj="visualEditorRadioCard"]').click({ force: true });
 
       // Wait for input to load and then type in the monitor name
-      cy.get('input[name="name"]').type(SAMPLE_VISUAL_EDITOR_MONITOR);
+      cy.get('input[name="name"]').type(SAMPLE_VISUAL_EDITOR_MONITOR, {
+        force: true,
+      });
 
       // Select associated monitors
       cy.get('[data-test-subj="monitors_list_0"]').type('monitorOne', {
         delay: 50,
+        force: true,
       });
       cy.get('[title="monitorOne"]').click({ force: true });
 
       cy.get('[data-test-subj="monitors_list_1"]').type('monitorTwo', {
         delay: 50,
+        force: true,
       });
       cy.get('[title="monitorTwo"]').click({ force: true });
 
@@ -88,9 +92,9 @@ describe('CompositeLevelMonitor', () => {
 
       // Type trigger name
       cy.get('[data-test-subj="composite-trigger-name"]')
-        .type('{selectall}')
-        .type('{backspace}')
-        .type('Composite trigger');
+        .type('{selectall}', { force: true })
+        .type('{backspace}', { force: true })
+        .type('Composite trigger', { force: true });
 
       cy.intercept('api/alerting/workflows').as('createMonitorRequest');
       cy.intercept(`api/alerting/monitors?*`).as('getMonitorsRequest');

--- a/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
@@ -76,13 +76,13 @@ describe('CompositeLevelMonitor', () => {
       });
 
       // Select associated monitors
-      cy.get('[data-test-subj="monitors_list_0"]').type('monitorOne', {
+      cy.get('[id="associatedMonitorsList_0"]').type('monitorOne', {
         delay: 50,
         force: true,
       });
       cy.get('[title="monitorOne"]').click({ force: true });
 
-      cy.get('[data-test-subj="monitors_list_1"]').type('monitorTwo', {
+      cy.get('[id="associatedMonitorsList_1"]').type('monitorTwo', {
         delay: 50,
         force: true,
       });
@@ -163,8 +163,9 @@ describe('CompositeLevelMonitor', () => {
 
       cy.get('button').contains('Add another monitor').click({ force: true });
 
-      cy.get('[data-test-subj="monitors_list_2"]').type('monitorThree', {
+      cy.get('[id="associatedMonitorsList_2"]').type('monitorThree', {
         delay: 50,
+        force: true,
       });
       cy.get('[title="monitorThree"]').click({ force: true });
 


### PR DESCRIPTION
### Description
We are seeing flaky behavior when creating composite monitor. The name input element is sometimes not in view which prevents cypress from typing the name. Since this behavior won't happen when a user is creating the monitor it is safe to force the typing in the name element and the monitor selector elements.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
