### PR TITLE
[Vis builder]  get correct element

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
@@ -138,7 +138,7 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
         // Save and return
         cy.getElementByTestId('visBuilderSaveAndReturnButton').click();
 
-        cy.getElementByTestId('visualizationLoader').should(
+        cy.getElementByTestId('visBuilderLoader').should(
           'contain.text',
           newLabel
         );


### PR DESCRIPTION
### Description

Finds the correct element when loading instead of a regular visualization loader.

Error easier to catch since wait for loader is less flakey.

### Issues Resolved

opensearch-project/OpenSearch-Dashboards#5043

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
