### PR TITLE
[Alerting 2.10] Use input element for typing when selecting delegate monitor

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
@@ -76,13 +76,13 @@ describe('CompositeLevelMonitor', () => {
       });
 
       // Select associated monitors
-      cy.get('[data-test-subj="monitors_list_0"]').type('monitorOne', {
+      cy.get('[id="associatedMonitorsList_0"]').type('monitorOne', {
         delay: 50,
         force: true,
       });
       cy.get('[title="monitorOne"]').click({ force: true });
 
-      cy.get('[data-test-subj="monitors_list_1"]').type('monitorTwo', {
+      cy.get('[id="associatedMonitorsList_1"]').type('monitorTwo', {
         delay: 50,
         force: true,
       });
@@ -163,8 +163,9 @@ describe('CompositeLevelMonitor', () => {
 
       cy.get('button').contains('Add another monitor').click({ force: true });
 
-      cy.get('[data-test-subj="monitors_list_2"]').type('monitorThree', {
+      cy.get('[id="associatedMonitorsList_2"]').type('monitorThree', {
         delay: 50,
+        force: true,
       });
       cy.get('[title="monitorThree"]').click({ force: true });
 


### PR DESCRIPTION
### Description
When selecting delegate monitors for composite monitor creation, we are typing in the combo box div element which is throwing invalid typing element error. This PR fixes that by selecting the child input element instead.

This change is already part of #866 for 2.x

### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/728

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
