### PR TITLE
[Alerting 2.10] Wait before checking update status for composite monitor

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
@@ -185,9 +185,8 @@ describe('CompositeLevelMonitor', () => {
 
       // Wait for monitor to be created
       cy.wait('@updateMonitorRequest').then(() => {
-        cy.get('.euiTitle--large').contains(
-          `${SAMPLE_VISUAL_EDITOR_MONITOR}_edited`
-        );
+        cy.wait(5000);
+        cy.contains(`${SAMPLE_VISUAL_EDITOR_MONITOR}_edited`);
       });
     });
   });


### PR DESCRIPTION
### Description
After updating composite monitor added some wait time before checking if update was successful

### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/732

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
