### PR TITLE
[Index-mgmt] Renamed index to avoid collision for other tests

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
@@ -256,8 +256,7 @@ describe('Indices', () => {
   });
 
   describe('can search with reindex & recovery status', () => {
-    const reindexedIndex =
-      'reindex_opensearch_dashboards_sample_data_ecommerce';
+    const reindexedIndex = 'reindex_sample_data_ecommerce';
     const splittedIndex = 'split_opensearch_dashboards_sample_data_logs';
     before(() => {
       cy.deleteAllIndices();

--- a/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
@@ -256,7 +256,7 @@ describe('Indices', () => {
   });
 
   describe('can search with reindex & recovery status', () => {
-    const reindexedIndex = 'reindex_sample_data_ecommerce';
+    const reindexedIndex = `${Date.now()}_reindex_sample_data_ecommerce`;
     const splittedIndex = 'split_opensearch_dashboards_sample_data_logs';
     before(() => {
       cy.deleteAllIndices();


### PR DESCRIPTION
### Description
During one of the tests for indices, we create an index with name `reindex_opensearch_dashboards_sample_data_ecommerce` that is superstring for the sample index `opensearch_dashboards_sample_data_ecommerce`. This new index is supposed to get deleted but sometimes it might not get deleted due to failure in backend and after that if some other test looks for the sample index and tries to select that index from a combo box, it faces collision and might end up not selecting any index. This PR renames the new index to avoid this situation.

### Issues Resolved
Fixes flaky test in Index Management Dashboards - https://github.com/opensearch-project/index-management-dashboards-plugin/issues/880

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
