### PR TITLE
Ignore flaky test on customImportMaps when security enabled

### DIFF
--- a/cypress/integration/plugins/custom-import-map-dashboards/add_saved_object.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/add_saved_object.spec.js
@@ -5,33 +5,37 @@
 
 import { BASE_PATH } from '../../../utils/constants';
 
-describe('Add flights dataset saved object', () => {
-  before(() => {
-    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`, {
-      retryOnStatusCodeFailure: true,
-      timeout: 60000,
+if (!Cypress.env('SECURITY_ENABLED')) {
+  describe('Add flights dataset saved object', () => {
+    before(() => {
+      cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`, {
+        retryOnStatusCodeFailure: true,
+        timeout: 60000,
+      });
+      cy.get('div[data-test-subj="sampleDataSetCardflights"]', {
+        timeout: 60000,
+      })
+        .contains(/Add data/)
+        .click();
+      cy.wait(60000);
     });
-    cy.get('div[data-test-subj="sampleDataSetCardflights"]', { timeout: 60000 })
-      .contains(/Add data/)
-      .click();
-    cy.wait(60000);
-  });
 
-  after(() => {
-    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory`);
-    cy.get('button[data-test-subj="removeSampleDataSetflights"]')
-      .should('be.visible')
-      .click();
-  });
+    after(() => {
+      cy.visit(`${BASE_PATH}/app/home#/tutorial_directory`);
+      cy.get('button[data-test-subj="removeSampleDataSetflights"]')
+        .should('be.visible')
+        .click();
+    });
 
-  it('check if maps saved object of flights dataset can be found and open', () => {
-    cy.visit(`${BASE_PATH}/app/maps-dashboards`);
-    cy.contains(
-      '[Flights] Flights Status on Maps Destination Location'
-    ).click();
-    cy.get('[data-test-subj="layerControlPanel"]').should(
-      'contain',
-      'Flights On Time'
-    );
+    it('check if maps saved object of flights dataset can be found and open', () => {
+      cy.visit(`${BASE_PATH}/app/maps-dashboards`);
+      cy.contains(
+        '[Flights] Flights Status on Maps Destination Location'
+      ).click();
+      cy.get('[data-test-subj="layerControlPanel"]').should(
+        'contain',
+        'Flights On Time'
+      );
+    });
   });
-});
+}

--- a/cypress/integration/plugins/custom-import-map-dashboards/documentsLayer.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/documentsLayer.spec.js
@@ -5,75 +5,83 @@
 
 import { BASE_PATH } from '../../../utils/constants';
 
-describe('Documents layer', () => {
-  before(() => {
-    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`, {
-      retryOnStatusCodeFailure: true,
-      timeout: 60000,
+if (!Cypress.env('SECURITY_ENABLED')) {
+  describe('Documents layer', () => {
+    before(() => {
+      cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`, {
+        retryOnStatusCodeFailure: true,
+        timeout: 60000,
+      });
+      cy.get('div[data-test-subj="sampleDataSetCardflights"]', {
+        timeout: 60000,
+      })
+        .contains(/(Add|View) data/)
+        .click();
+      cy.wait(60000);
     });
-    cy.get('div[data-test-subj="sampleDataSetCardflights"]', { timeout: 60000 })
-      .contains(/(Add|View) data/)
-      .click();
-    cy.wait(60000);
-  });
 
-  const uniqueName = 'saved-map-' + Date.now().toString();
+    const uniqueName = 'saved-map-' + Date.now().toString();
 
-  it('Add new documents layer with configuration', () => {
-    cy.visit(`${BASE_PATH}/app/maps-dashboards`);
-    cy.contains('Create map').click();
-    cy.get("button[data-test-subj='addLayerButton']").click();
-    cy.contains('Documents').click();
-    cy.contains('Select data source', { timeout: 60000 }).click({
-      force: true,
+    it('Add new documents layer with configuration', () => {
+      cy.visit(`${BASE_PATH}/app/maps-dashboards`);
+      cy.contains('Create map').click();
+      cy.get("button[data-test-subj='addLayerButton']").click();
+      cy.contains('Documents').click();
+      cy.contains('Select data source', { timeout: 60000 }).click({
+        force: true,
+      });
+      cy.wait(5000)
+        .contains('opensearch_dashboards_sample_data_flights')
+        .click();
+      cy.contains('Select data field', { timeout: 60000 }).click({
+        force: true,
+      });
+      cy.wait(5000).contains('DestLocation').click();
+      cy.get('[data-test-subj="indexPatternSelect"]').should(
+        'contain',
+        'opensearch_dashboards_sample_data_flights'
+      );
+      cy.get('[data-test-subj="geoFieldSelect"]').should(
+        'contain',
+        'DestLocation'
+      );
+      cy.get(`button[testSubj="styleTab"]`).click();
+      cy.contains('Fill color').click();
+      cy.get(`button[aria-label="Select #E7664C as the color"]`).click();
+      cy.contains('Border color').click();
+      cy.get(`button[aria-label="Select #DA8B45 as the color"]`).click();
+      cy.get(`button[testSubj="settingsTab"]`).click();
+      cy.get('[name="layerName"]').clear().type('Documents layer 1');
+      cy.get(`button[data-test-subj="updateButton"]`).click();
+      cy.get('[data-test-subj="layerControlPanel"]').should(
+        'contain',
+        'Documents layer 1'
+      );
+      cy.wait(5000).get('[data-test-subj="top-nav"]').click();
+      cy.wait(5000).get('[data-test-subj="savedObjectTitle"]').type(uniqueName);
+      cy.wait(5000)
+        .get('[data-test-subj="confirmSaveSavedObjectButton"]')
+        .click();
+      cy.wait(5000)
+        .get('[data-test-subj="breadcrumb last"]')
+        .should('contain', uniqueName);
     });
-    cy.wait(5000).contains('opensearch_dashboards_sample_data_flights').click();
-    cy.contains('Select data field', { timeout: 60000 }).click({ force: true });
-    cy.wait(5000).contains('DestLocation').click();
-    cy.get('[data-test-subj="indexPatternSelect"]').should(
-      'contain',
-      'opensearch_dashboards_sample_data_flights'
-    );
-    cy.get('[data-test-subj="geoFieldSelect"]').should(
-      'contain',
-      'DestLocation'
-    );
-    cy.get(`button[testSubj="styleTab"]`).click();
-    cy.contains('Fill color').click();
-    cy.get(`button[aria-label="Select #E7664C as the color"]`).click();
-    cy.contains('Border color').click();
-    cy.get(`button[aria-label="Select #DA8B45 as the color"]`).click();
-    cy.get(`button[testSubj="settingsTab"]`).click();
-    cy.get('[name="layerName"]').clear().type('Documents layer 1');
-    cy.get(`button[data-test-subj="updateButton"]`).click();
-    cy.get('[data-test-subj="layerControlPanel"]').should(
-      'contain',
-      'Documents layer 1'
-    );
-    cy.wait(5000).get('[data-test-subj="top-nav"]').click();
-    cy.wait(5000).get('[data-test-subj="savedObjectTitle"]').type(uniqueName);
-    cy.wait(5000)
-      .get('[data-test-subj="confirmSaveSavedObjectButton"]')
-      .click();
-    cy.wait(5000)
-      .get('[data-test-subj="breadcrumb last"]')
-      .should('contain', uniqueName);
-  });
 
-  it('Open saved map with documents layer', () => {
-    cy.visit(`${BASE_PATH}/app/maps-dashboards`);
-    cy.get('[data-test-subj="mapListingPage"]').should('contain', uniqueName);
-    cy.contains(uniqueName).click();
-    cy.get('[data-test-subj="layerControlPanel"]').should(
-      'contain',
-      'Documents layer 1'
-    );
-  });
+    it('Open saved map with documents layer', () => {
+      cy.visit(`${BASE_PATH}/app/maps-dashboards`);
+      cy.get('[data-test-subj="mapListingPage"]').should('contain', uniqueName);
+      cy.contains(uniqueName).click();
+      cy.get('[data-test-subj="layerControlPanel"]').should(
+        'contain',
+        'Documents layer 1'
+      );
+    });
 
-  after(() => {
-    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory`);
-    cy.get('button[data-test-subj="removeSampleDataSetflights"]')
-      .should('be.visible')
-      .click();
+    after(() => {
+      cy.visit(`${BASE_PATH}/app/home#/tutorial_directory`);
+      cy.get('button[data-test-subj="removeSampleDataSetflights"]')
+        .should('be.visible')
+        .click();
+    });
   });
-});
+}


### PR DESCRIPTION
### Description

Ignore the flaky test on customImportMaps when security enabled

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
