### PR TITLE
Ignore the flaky test of opensearchMapLayer when security enabled

### DIFF
--- a/cypress/integration/plugins/custom-import-map-dashboards/opensearchMapLayer.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/opensearchMapLayer.spec.js
@@ -5,47 +5,51 @@
 
 import { BASE_PATH } from '../../../utils/constants';
 
-describe('Default OpenSearch base map layer', () => {
-  before(() => {
-    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`, {
-      retryOnStatusCodeFailure: true,
-      timeout: 60000,
+if (!Cypress.env('SECURITY_ENABLED')) {
+  describe('Default OpenSearch base map layer', () => {
+    before(() => {
+      cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`, {
+        retryOnStatusCodeFailure: true,
+        timeout: 60000,
+      });
+      cy.get('div[data-test-subj="sampleDataSetCardflights"]', {
+        timeout: 60000,
+      })
+        .contains(/(Add|View) data/)
+        .click();
+      cy.wait(60000);
     });
-    cy.get('div[data-test-subj="sampleDataSetCardflights"]', { timeout: 60000 })
-      .contains(/(Add|View) data/)
-      .click();
-    cy.wait(60000);
-  });
 
-  it('check if default OpenSearch map layer can be open', () => {
-    cy.visit(`${BASE_PATH}/app/maps-dashboards`);
-    cy.contains('Create map').click();
-    cy.get('[data-test-subj="layerControlPanel"]').should(
-      'contain',
-      'Default map'
-    );
-    cy.get('canvas.maplibregl-canvas').trigger('mousemove', {
-      x: 100,
-      y: 100,
-      force: true,
+    it('check if default OpenSearch map layer can be open', () => {
+      cy.visit(`${BASE_PATH}/app/maps-dashboards`);
+      cy.contains('Create map').click();
+      cy.get('[data-test-subj="layerControlPanel"]').should(
+        'contain',
+        'Default map'
+      );
+      cy.get('canvas.maplibregl-canvas').trigger('mousemove', {
+        x: 100,
+        y: 100,
+        force: true,
+      });
+      cy.get('canvas.maplibregl-canvas').trigger('mousemove', {
+        x: 200,
+        y: 200,
+        force: true,
+      });
+      for (let i = 0; i < 21; i++) {
+        cy.wait(1000)
+          .get('canvas.maplibregl-canvas')
+          .trigger('dblclick', { force: true });
+      }
+      cy.get('[data-test-subj="mapStatusBar"]').should('contain', 'zoom: 22');
     });
-    cy.get('canvas.maplibregl-canvas').trigger('mousemove', {
-      x: 200,
-      y: 200,
-      force: true,
-    });
-    for (let i = 0; i < 21; i++) {
-      cy.wait(1000)
-        .get('canvas.maplibregl-canvas')
-        .trigger('dblclick', { force: true });
-    }
-    cy.get('[data-test-subj="mapStatusBar"]').should('contain', 'zoom: 22');
-  });
 
-  after(() => {
-    cy.visit(`${BASE_PATH}/app/home#/tutorial_directory`);
-    cy.get('button[data-test-subj="removeSampleDataSetflights"]')
-      .should('be.visible')
-      .click();
+    after(() => {
+      cy.visit(`${BASE_PATH}/app/home#/tutorial_directory`);
+      cy.get('button[data-test-subj="removeSampleDataSetflights"]')
+        .should('be.visible')
+        .click();
+    });
   });
-});
+}


### PR DESCRIPTION
### Description

Ignore the flaky test of opensearchMapLayer when security enabled

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/883

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
