### PR TITLE
[Alerting 2.10] Excluding flaky tests

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
@@ -66,7 +66,7 @@ describe('CompositeLevelMonitor', () => {
       });
     });
 
-    it('by visual editor', () => {
+    xit('by visual editor', () => {
       // Select visual editor for method of definition
       cy.get('[data-test-subj="visualEditorRadioCard"]').click({ force: true });
 
@@ -154,7 +154,7 @@ describe('CompositeLevelMonitor', () => {
       });
     });
 
-    it('by visual editor', () => {
+    xit('by visual editor', () => {
       // Verify edit page
       cy.contains('Edit monitor', { timeout: 20000 });
       cy.get('input[name="name"]').type('_edited');


### PR DESCRIPTION
### Description
Excluding flaky tests for composite monitors

### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/737

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
