### PR TITLE
Skipping flaky tests for panels and notebooks in Observability

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
@@ -136,7 +136,7 @@ describe('Testing a panel', () => {
 });
 
 describe('Clean up all test data', () => {
-  it('Deletes test panel', () => {
+  it.skip('Deletes test panel', () => {
     moveToPanelHome();
     cy.get('.euiCheckbox__input[data-test-subj="checkboxSelectAll"]')
       .trigger('mouseover')
@@ -155,8 +155,8 @@ describe('Clean up all test data', () => {
     });
     cy.get('button.euiButton--danger').should('not.be.disabled');
     cy.get('.euiButton__text').contains('Delete').trigger('mouseover').click();
-
-    cy.get('.euiTextAlign')
+    cy.wait(delay * 5);
+    cy.get('[data-test-subj="customPanels__noPanelsHome"]')
       .contains('No Observability Dashboards')
       .should('exist');
   });

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -172,7 +172,7 @@ describe('Testing paragraphs', () => {
     cy.get('.euiTextColor').contains('Last successful run').should('exist');
   });
 
-  it('Duplicates paragraphs', () => {
+  it.skip('Duplicates paragraphs', () => {
     cy.get('.euiButtonIcon[aria-label="Open paragraph menu"]').eq(0).click();
     cy.wait(delayTime);
     cy.get('.euiContextMenuItem__text').contains('Duplicate').eq(0).click();


### PR DESCRIPTION
### Description

Latest RC for 2.10 release has seen 2 flaky tests in Observability plugin

### Issues Resolved

Skips below flaky tests:
* 6_notebooks.spec.js/Testing paragraphs -- Duplicates paragraphs
* 4_panels.spec.js/Testing panels table -- Deletes panels

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
