### PR TITLE
Change from legacy discover to data explorer

### DIFF
--- a/cypress/integration/common/dashboard_sample_data_spec.js
+++ b/cypress/integration/common/dashboard_sample_data_spec.js
@@ -247,9 +247,8 @@ export function dashboardSanityTests() {
 
       describe('checking discover', () => {
         before(() => {
-          cy.setAdvancedSetting({ 'discover:v2': false });
           // Go to the Discover page
-          miscUtils.visitPage('app/discover#/');
+          miscUtils.visitPage('app/data-explorer/discover#/');
         });
 
         after(() => {});
@@ -280,10 +279,7 @@ export function dashboardSanityTests() {
         });
 
         it('checking index pattern switch button display', () => {
-          commonUI.checkElementExists(
-            'button[data-test-subj="indexPattern-switch-link"]',
-            1
-          );
+          cy.getElementByTestId('dataExplorerDSSelect').should('be.visible');
         });
 
         it('checking field filter display', () => {


### PR DESCRIPTION
### Description
In 2.11, we will get rid of angular dependency and legacy discover. The change cypress test to use data explorer.
