### PR TITLE
dashboards query workbench removed euititle gets

### DIFF
--- a/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
+++ b/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
@@ -91,7 +91,7 @@ describe('Test PPL UI', () => {
 
   it('Test full screen view', () => {
     cy.get('.euiButton__text').contains('Full screen view').should('not.exist');
-    cy.get('.euiTitle').contains('Query Workbench').should('exist');
+    // cy.get('.euiTitle').contains('Query Workbench').should('exist');
 
     cy.get('textarea.ace_text-input')
       .eq(0)
@@ -104,12 +104,12 @@ describe('Test PPL UI', () => {
       .contains('Full screen view')
       .click({ force: true });
 
-    cy.get('.euiTitle').should('not.exist');
+    // cy.get('.euiTitle').should('not.exist');
 
     cy.get('button#exit-fullscreen-button').click({ force: true });
     cy.wait(QUERY_WORKBENCH_DELAY);
     cy.get('.euiButton__text').contains('Full screen view').should('exist');
-    cy.get('.euiTitle').contains('Query Workbench').should('exist');
+    // cy.get('.euiTitle').contains('Query Workbench').should('exist');
   });
 });
 
@@ -179,7 +179,7 @@ describe('Test SQL UI', () => {
 
   it('Test full screen view', () => {
     cy.get('.euiButton__text').contains('Full screen view').should('not.exist');
-    cy.get('.euiTitle').contains('Query Workbench').should('exist');
+    // cy.get('.euiTitle').contains('Query Workbench').should('exist');
 
     cy.get('.euiButton__text').contains('Run').click({ force: true });
     cy.wait(QUERY_WORKBENCH_DELAY * 5);
@@ -187,7 +187,7 @@ describe('Test SQL UI', () => {
       .contains('Full screen view')
       .click({ force: true });
 
-    cy.get('.euiTitle').should('not.exist');
+    // cy.get('.euiTitle').should('not.exist');
   });
 });
 

--- a/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
+++ b/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
@@ -91,7 +91,6 @@ describe('Test PPL UI', () => {
 
   it('Test full screen view', () => {
     cy.get('.euiButton__text').contains('Full screen view').should('not.exist');
-    // cy.get('.euiTitle').contains('Query Workbench').should('exist');
 
     cy.get('textarea.ace_text-input')
       .eq(0)
@@ -104,12 +103,10 @@ describe('Test PPL UI', () => {
       .contains('Full screen view')
       .click({ force: true });
 
-    // cy.get('.euiTitle').should('not.exist');
 
     cy.get('button#exit-fullscreen-button').click({ force: true });
     cy.wait(QUERY_WORKBENCH_DELAY);
     cy.get('.euiButton__text').contains('Full screen view').should('exist');
-    // cy.get('.euiTitle').contains('Query Workbench').should('exist');
   });
 });
 
@@ -179,7 +176,6 @@ describe('Test SQL UI', () => {
 
   it('Test full screen view', () => {
     cy.get('.euiButton__text').contains('Full screen view').should('not.exist');
-    // cy.get('.euiTitle').contains('Query Workbench').should('exist');
 
     cy.get('.euiButton__text').contains('Run').click({ force: true });
     cy.wait(QUERY_WORKBENCH_DELAY * 5);
@@ -187,7 +183,6 @@ describe('Test SQL UI', () => {
       .contains('Full screen view')
       .click({ force: true });
 
-    // cy.get('.euiTitle').should('not.exist');
   });
 });
 


### PR DESCRIPTION
### Description

Removes code that tries to get EuiTitle components which are no longer in the source code.

### Issues Resolved

- Failing tests due to an inability to find EuiTitle components

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
