### PR TITLE
Fix share link for 2.x branch

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
@@ -75,7 +75,7 @@ describe('shared links', () => {
 
     it('should allow for copying the saved object URL', function () {
       const url =
-        'http://localhost:5601/app/data-explorer/discover/#/view/ab12e3c0-f231-11e6-9486-733b1ac9221a?_g=%28filters%3A%21%28%29%2CrefreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2Ctime%3A%28from%3A%272015-09-19T13%3A31%3A44.000Z%27%2Cto%3A%272015-09-24T01%3A31%3A44.000Z%27%29%29';
+        "http://localhost:5601/app/data-explorer/discover/#/view/ab12e3c0-f231-11e6-9486-733b1ac9221a?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3A'2015-09-19T13%3A31%3A44.000Z'%2Cto%3A'2015-09-24T01%3A31%3A44.000Z'))";
 
       cy.getElementByTestId('exportAsSavedObject')
         .get('.euiRadio__input')


### PR DESCRIPTION
### Description
Fix share link of save search for 2.x branch.

### Issues Resolved
Because of https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5095, the URL parsing is handled differently on main branch and 2.x branch. Therefore, this cypress test on 2.x branch needs to be modified.