### PR TITLE
Remove color select on maps document layer setting

### DIFF
--- a/cypress/integration/plugins/custom-import-map-dashboards/documentsLayer.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/documentsLayer.spec.js
@@ -45,11 +45,6 @@ if (!Cypress.env('SECURITY_ENABLED')) {
         'contain',
         'DestLocation'
       );
-      cy.get(`button[testSubj="styleTab"]`).click();
-      cy.contains('Fill color').click();
-      cy.get(`button[aria-label="Select #E7664C as the color"]`).click();
-      cy.contains('Border color').click();
-      cy.get(`button[aria-label="Select #DA8B45 as the color"]`).click();
       cy.get(`button[testSubj="settingsTab"]`).click();
       cy.get('[name="layerName"]').clear().type('Documents layer 1');
       cy.get(`button[data-test-subj="updateButton"]`).click();


### PR DESCRIPTION
### Description

Remove color select on maps document layer setting

### local test

```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/custom-import-map-dashboard      01:54        2        2        -        -        - │
  │    s/documentsLayer.spec.js                                                                    │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        01:54        2        2        -        -        -  

```

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
