### PR TITLE
Add wait time after selecting a color

### DIFF
--- a/cypress/integration/plugins/custom-import-map-dashboards/documentsLayer.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/documentsLayer.spec.js
@@ -41,9 +41,9 @@ describe('Documents layer', () => {
     cy.get(`button[testSubj="styleTab"]`).click();
     cy.contains('Fill color').click();
     cy.get(`button[aria-label="Select #E7664C as the color"]`).click();
-    cy.contains('Border color').click();
+    cy.wait(1000).contains('Border color').click();
     cy.get(`button[aria-label="Select #DA8B45 as the color"]`).click();
-    cy.get(`button[testSubj="settingsTab"]`).click();
+    cy.wait(1000).get(`button[testSubj="settingsTab"]`).click();
     cy.get('[name="layerName"]').clear().type('Documents layer 1');
     cy.get(`button[data-test-subj="updateButton"]`).click();
     cy.get('[data-test-subj="layerControlPanel"]').should(


### PR DESCRIPTION
### Description

After selecting a color from color palette, it takes time for the palette to disappear and it could cause two palette to be visible at the same time which could cause an error like `Your subject contained 2 elements.`
```
 Opening Cypress...
[376:1025/064054.202674:ERROR:gpu_init.cc(453)] Passthrough is not supported, GL is swiftshader, ANGLE is 

================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        9.5.4                                                                          │
  │ Browser:        Chromium 112 (headless)                                                        │
  │ Node Version:   v16.14.2 (/usr/share/opensearch/.nvm/versions/node/v16.14.2/bin/node)          │
  │ Specs:          4 found (plugins/custom-import-map-dashboards/add_saved_object.spec.js, plugin │
  │                 s/custom-import-map-dashboards/documentsLayer.spec.js, plugins/custom-import-m │
  │                 ap-dashboards/import_vector_map_tab.spec.js, plugins/custom-import-map-dashboa │
  │                 rds/opensearchMapLayer...)                                                     │
  │ Searched:       cypress/integration/plugins/custom-import-map-dashboards/*.js                  │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  plugins/custom-import-map-dashboards/add_saved_object.spec.js                   (1 of 4)
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating


  Add flights dataset saved object
    ✓ check if maps saved object of flights dataset can be found and open (69926ms)


  1 passing (1m)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     1 minute, 12 seconds                                                             │
  │ Spec Ran:     plugins/custom-import-map-dashboards/add_saved_object.spec.js                    │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /docker/cypress/videos/plugins/custom-import-map-dashboards    (6 seconds)
                          /add_saved_object.spec.js.mp4                                             


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  plugins/custom-import-map-dashboards/documentsLayer.spec.js                     (2 of 4)


  Documents layer
    ✓ Add new documents layer with configuration (103402ms)
    ✓ Open saved map with documents layer


  2 passing (2m)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        2                                                                                │
  │ Passing:      2                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     1 minute, 50 seconds                                                             │
  │ Spec Ran:     plugins/custom-import-map-dashboards/documentsLayer.spec.js                      │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /docker/cypress/videos/plugins/custom-import-map-dashboards    (9 seconds)
                          /documentsLayer.spec.js.mp4                                               


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  plugins/custom-import-map-dashboards/import_vector_map_tab.spec.js              (3 of 4)


  Verify the presence of import custom map tab in region map plugin
    ✓ checks import custom map tab is present (38751ms)


  1 passing (41s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     41 seconds                                                                       │
  │ Spec Ran:     plugins/custom-import-map-dashboards/import_vector_map_tab.spec.js               │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /docker/cypress/videos/plugins/custom-import-map-dashboards    (3 seconds)
                          /import_vector_map_tab.spec.js.mp4                                        


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  plugins/custom-import-map-dashboards/opensearchMapLayer.spec.js                 (4 of 4)


  Default OpenSearch base map layer
    ✓ check if default OpenSearch map layer can be open (90807ms)


  1 passing (2m)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     1 minute, 34 seconds                                                             │
  │ Spec Ran:     plugins/custom-import-map-dashboards/opensearchMapLayer.spec.js                  │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /docker/cypress/videos/plugins/custom-import-map-dashboards    (7 seconds)
                          /opensearchMapLayer.spec.js.mp4                                           


================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/custom-import-map-dashboard      01:12        1        1        -        -        - │
  │    s/add_saved_object.spec.js                                                                  │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/custom-import-map-dashboard      01:50        2        2        -        -        - │
  │    s/documentsLayer.spec.js                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/custom-import-map-dashboard      00:41        1        1        -        -        - │
  │    s/import_vector_map_tab.spec.js                                                             │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/custom-import-map-dashboard      01:34        1        1        -        -        - │
  │    s/opensearchMapLayer.spec.js                                                                │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        05:18        5        5        -        -        -  
```
### Issues Resolved
N/A

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
