### PR TITLE
Refactored alerting test, and added wait logic to reduce flakiness.

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/monitors_dashboard_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/monitors_dashboard_spec.js
@@ -38,7 +38,7 @@ const clusterHealthMonitor = {
         severity: '1',
         condition: {
           script: {
-            source: 'ctx.results[0].status != "green"',
+            source: 'ctx.results[0].status != "blue"',
             lang: 'painless',
           },
         },
@@ -107,8 +107,13 @@ describe('Monitors dashboard page', () => {
   });
 
   it('Displays expected number of alerts', () => {
+    // Wait for table to finish loading
+    cy.get('tbody > tr').should(($tr) =>
+      expect($tr).to.have.length.greaterThan(1)
+    );
+
     // Ensure the 'Monitor name' column is sorted in ascending order by sorting another column first
-    cy.contains('Last updated by').click({ force: true });
+    cy.contains('Last notification time').click({ force: true });
     cy.contains('Monitor name').click({ force: true });
 
     testMonitors.forEach((entry) => {


### PR DESCRIPTION
### Description

Refactored alerting test, and added wait logic to reduce flakiness.

The edited test passes locally.
![Screenshot 2023-11-15 at 11 26 21 AM](https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/79280347/35315d88-681b-4bfe-912f-0d45680407fd)

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
