### PR TITLE
[Tests] Set default tenancy to global for data explorer tests

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/aaa_before.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/aaa_before.spec.js
@@ -3,10 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { CURRENT_TENANT } from '../../../../../utils/commands';
+
 /// <reference types="cypress" />
 
 describe('Before', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     cy.deleteAllIndices();
     cy.deleteSavedObjectByType('index-pattern');
   });

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/date_nanos.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/date_nanos.spec.js
@@ -7,6 +7,8 @@ import {
   TestFixtureHandler,
   MiscUtils,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
+
 const testFixtureHandler = new TestFixtureHandler(
   cy,
   Cypress.env('openSearchUrl')
@@ -18,6 +20,7 @@ describe('date_nanos', () => {
   const fromTime = 'Sep 21, 2019 @ 20:31:44.000';
   const toTime = 'Sep 23, 2019 @ 03:31:44.000';
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     // import date nanos
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/date_nanos/mappings.json.txt'
@@ -29,7 +32,6 @@ describe('date_nanos', () => {
     cy.setAdvancedSetting({
       defaultIndex: 'date-nanos',
     });
-
     miscUtils.visitPage('app/data-explorer/discover#/');
     cy.waitForLoader();
 

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/date_nanos_mixed.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/date_nanos_mixed.spec.js
@@ -7,6 +7,7 @@ import {
   TestFixtureHandler,
   MiscUtils,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -16,6 +17,7 @@ const testFixtureHandler = new TestFixtureHandler(
 
 describe('date_nanos_mixed', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     //import date nanos
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/date_nanos_mix/mappings.json.txt'
@@ -27,7 +29,6 @@ describe('date_nanos_mixed', () => {
     cy.setAdvancedSetting({
       defaultIndex: 'timestamp-*',
     });
-
     miscUtils.visitPage('app/data-explorer/discover#/');
     cy.waitForLoader();
 

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
@@ -11,6 +11,7 @@ import {
   DE_DEFAULT_END_TIME,
   DE_DEFAULT_START_TIME,
 } from '../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -25,6 +26,7 @@ const indexSet = [
 
 describe('discover app', { scrollBehavior: false }, () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     // import logstash functional
     testFixtureHandler.importJSONDocIfNeeded(
       indexSet,

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_histogram.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_histogram.spec.js
@@ -7,6 +7,7 @@ import {
   TestFixtureHandler,
   MiscUtils,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -21,6 +22,7 @@ const indexSet = [
 
 describe('discover histogram', { scrollBehavior: false }, () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     cy.log('load opensearch-dashboards index with default index pattern');
 
     // import long window logstash index pattern

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/doc_navigation.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/doc_navigation.spec.js
@@ -7,6 +7,7 @@ import {
   MiscUtils,
   TestFixtureHandler,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -21,6 +22,7 @@ const indexSet = [
 
 describe('doc link in discover', () => {
   beforeEach(() => {
+    CURRENT_TENANT.newTenant = 'global';
     // import logstash functional
     testFixtureHandler.importJSONDocIfNeeded(
       indexSet,

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/doc_table.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/doc_table.spec.js
@@ -7,6 +7,7 @@ import {
   MiscUtils,
   TestFixtureHandler,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -21,6 +22,7 @@ const indexSet = [
 
 describe('discover doc table', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     // import logstash functional
     testFixtureHandler.importJSONDocIfNeeded(
       indexSet,

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/errors.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/errors.spec.js
@@ -11,6 +11,7 @@ import {
   DE_DEFAULT_END_TIME,
   DE_DEFAULT_START_TIME,
 } from '../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -20,6 +21,7 @@ const testFixtureHandler = new TestFixtureHandler(
 
 describe('errors', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     // import invalid_scripted_field
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/invalid_scripted_field/mappings.json.txt'

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/field_data.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/field_data.spec.js
@@ -7,6 +7,7 @@ import {
   TestFixtureHandler,
   MiscUtils,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -21,6 +22,7 @@ const indexSet = [
 
 describe('discover tab', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     // import logstash functional
     testFixtureHandler.importJSONDocIfNeeded(
       indexSet,

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/field_visualize.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/field_visualize.spec.js
@@ -7,6 +7,7 @@ import {
   MiscUtils,
   TestFixtureHandler,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -21,6 +22,7 @@ const indexSet = [
 
 describe('discover field visualize button', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/filter_editor.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/filter_editor.spec.js
@@ -7,6 +7,7 @@ import {
   MiscUtils,
   TestFixtureHandler,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -21,6 +22,7 @@ const indexSet = [
 
 describe('discover filter editor', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/index_pattern_with_encoded_id.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/index_pattern_with_encoded_id.spec.js
@@ -11,6 +11,7 @@ import {
   DE_DEFAULT_END_TIME,
   DE_DEFAULT_START_TIME,
 } from '../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -20,6 +21,7 @@ const testFixtureHandler = new TestFixtureHandler(
 
 describe('index pattern with encoded id', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_pattern_with_encoded_id/mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/index_pattern_without_field.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/index_pattern_without_field.spec.js
@@ -7,6 +7,7 @@ import {
   TestFixtureHandler,
   MiscUtils,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -16,6 +17,7 @@ const testFixtureHandler = new TestFixtureHandler(
 
 describe('index pattern without field spec', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_pattern_without_timefield/mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/inspector.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/inspector.spec.js
@@ -11,6 +11,7 @@ import {
   DE_DEFAULT_END_TIME,
   DE_DEFAULT_START_TIME,
 } from '../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -25,6 +26,7 @@ const indexSet = [
 
 describe('inspector', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     // import logstash functional
     testFixtureHandler.importJSONDocIfNeeded(
       indexSet,

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/large_string.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/large_string.spec.js
@@ -7,6 +7,7 @@ import {
   TestFixtureHandler,
   MiscUtils,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -16,6 +17,7 @@ const testFixtureHandler = new TestFixtureHandler(
 
 describe('test large strings', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/empty_opensearch_dashboards/mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/saved_queries.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/saved_queries.spec.js
@@ -11,6 +11,7 @@ import {
   DE_DEFAULT_END_TIME,
   DE_DEFAULT_START_TIME,
 } from '../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -27,6 +28,7 @@ describe('saved queries saved objects', () => {
   const fromTime = 'Sep 20, 2015 @ 08:00:00.000';
   const toTime = 'Sep 21, 2015 @ 08:00:00.000';
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
@@ -11,6 +11,7 @@ import {
   DE_DEFAULT_END_TIME,
   DE_DEFAULT_START_TIME,
 } from '../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -25,6 +26,7 @@ const indexSet = [
 
 describe('shared links', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/sidebar.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/sidebar.spec.js
@@ -7,6 +7,7 @@ import {
   MiscUtils,
   TestFixtureHandler,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -21,6 +22,7 @@ const indexSet = [
 
 describe('discover sidebar', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/source_filter.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/source_filter.spec.js
@@ -7,6 +7,7 @@ import {
   TestFixtureHandler,
   MiscUtils,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -16,6 +17,7 @@ const testFixtureHandler = new TestFixtureHandler(
 
 describe('source filters', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/visualize_source-filters/mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/zzz_after.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/zzz_after.spec.js
@@ -6,6 +6,7 @@
 /// <reference types="cypress" />
 
 import { TestFixtureHandler } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const testFixtureHandler = new TestFixtureHandler(
   cy,
@@ -14,6 +15,7 @@ const testFixtureHandler = new TestFixtureHandler(
 
 describe('After', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     //cy.deleteAllIndices();
     testFixtureHandler.clearJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/logstash/logstash.mappings.json.txt'

--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -403,6 +403,11 @@ Cypress.Commands.add('setAdvancedSetting', (changes) => {
     .request({
       method: 'POST',
       url,
+      qs: Cypress.env('SECURITY_ENABLED')
+        ? {
+            security_tenant: CURRENT_TENANT.defaultTenant,
+          }
+        : {},
       headers: {
         'content-type': 'application/json;charset=UTF-8',
         'osd-xsrf': true,


### PR DESCRIPTION
### Description

<img width="1769" alt="Screenshot 2023-11-22 at 4 29 17 PM" src="https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/105884062/0b13dfec-3e6a-424e-97f3-de8418fc374e">


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
