### PR TITLE
Add tests for data source selector

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/data_source_selector.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/data_source_selector.spec.js
@@ -7,6 +7,7 @@ import {
   MiscUtils,
   TestFixtureHandler,
 } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 const testFixtureHandler = new TestFixtureHandler(
@@ -16,6 +17,7 @@ const testFixtureHandler = new TestFixtureHandler(
 
 describe('Data source selector', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_pattern_without_timefield/mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/data_source_selector.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/data_source_selector.spec.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  MiscUtils,
+  TestFixtureHandler,
+} from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+
+const miscUtils = new MiscUtils(cy);
+const testFixtureHandler = new TestFixtureHandler(
+  cy,
+  Cypress.env('openSearchUrl')
+);
+
+describe('Data source selector', () => {
+  before(() => {
+    testFixtureHandler.importJSONMapping(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_pattern_without_timefield/mappings.json.txt'
+    );
+    testFixtureHandler.importJSONDoc(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_pattern_without_timefield/data.json.txt'
+    );
+
+    miscUtils.visitPage('app/data-explorer/discover#/');
+    cy.waitForLoader();
+  });
+
+  after(() => {
+    testFixtureHandler.clearJSONMapping(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_pattern_without_timefield/mappings.json.txt'
+    );
+    cy.deleteSavedObjectByType('index-pattern');
+  });
+
+  it('displays all data sources by default', () => {
+    cy.get('[data-test-subj="dataExplorerDSSelect"]').click();
+    cy.get('.euiComboBoxOptionsList').should('exist');
+    cy.get('.euiComboBoxOption__content').should('have.length', 2);
+  });
+
+  it('filters options based on user input', () => {
+    cy.get('[data-test-subj="dataExplorerDSSelect"] input').type('without', {
+      force: true,
+    });
+    cy.get('.euiComboBoxOption__content').should('have.length', 1);
+    cy.get('.euiComboBoxOption__content')
+      .first()
+      .should('contain', 'without-timefield');
+  });
+
+  it('updates the visual length of the dropdown based on filtered results', () => {
+    cy.get('[data-test-subj="dataExplorerDSSelect"] input').clear({
+      force: true,
+    });
+    cy.get('[data-test-subj="dataExplorerDSSelect"] input').type(
+      'without-timefield',
+      {
+        force: true,
+      }
+    );
+    cy.get('.euiComboBoxOptionsList').then(($listAfterFilter) => {
+      const heightAfterFilter = $listAfterFilter.height();
+      cy.get('[data-test-subj="dataExplorerDSSelect"] input').clear({
+        force: true,
+      });
+      cy.get('.euiComboBoxOptionsList').should(($listAll) => {
+        expect($listAll.height()).to.be.greaterThan(heightAfterFilter);
+      });
+    });
+  });
+
+  it('selects the correct option when clicked', () => {
+    cy.get('[data-test-subj="dataExplorerDSSelect"] input').type(
+      'with-timefield',
+      {
+        force: true,
+      }
+    );
+
+    cy.contains('.euiComboBoxOption__content', 'with-timefield').click();
+    cy.get('[data-test-subj="dataExplorerDSSelect"] .euiComboBoxPill').should(
+      'contain',
+      'with-timefield'
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "osd:ciGroup3": "echo \"apps/vis-augmenter/*.js\"",
     "osd:ciGroup4": "echo \"dashboard_sample_data_with_datasource_spec.js,dashboard_sanity_test_spec.js\"",
     "osd:ciGroup5": "echo \"datasource-management-plugin/*.js\"",
-    "osd:ciGroup6": "echo \"apps/data_explorer/aaa_before.spec.js,apps/data_explorer/date_nanos_mixed.spec.js,apps/data_explorer/date_nanos.spec.js,apps/data_explorer/discover_histogram.spec.js,apps/data_explorer/discover.spec.js,apps/data_explorer/zzz_after.spec.js\"",
+    "osd:ciGroup6": "echo \"apps/data_explorer/aaa_before.spec.js,apps/data_explorer/data_source_selector.spec.js,apps/data_explorer/date_nanos_mixed.spec.js,apps/data_explorer/date_nanos.spec.js,apps/data_explorer/discover_histogram.spec.js,apps/data_explorer/discover.spec.js,apps/data_explorer/zzz_after.spec.js\"",
     "osd:ciGroup7": "echo \"apps/data_explorer/aaa_before.spec.js,apps/data_explorer/doc_navigation.spec.js,apps/data_explorer/doc_table.spec.js,apps/data_explorer/errors.spec.js,apps/data_explorer/field_data.spec.js,apps/data_explorer/zzz_after.spec.js\"",
     "osd:ciGroup8": "echo \"apps/data_explorer/aaa_before.spec.js,apps/data_explorer/field_visualize.spec.js,apps/data_explorer/filter_editor.spec.js,apps/data_explorer/index_pattern_with_encoded_id.spec.js,apps/data_explorer/index_pattern_without_field.spec.js,apps/data_explorer/zzz_after.spec.js\"",
     "osd:ciGroup9": "echo \"apps/data_explorer/aaa_before.spec.js,apps/data_explorer/inspector.spec.js,apps/data_explorer/large_string.spec.js,apps/data_explorer/saved_queries.spec.js,apps/data_explorer/shared_links.spec.js,apps/data_explorer/sidebar.spec.js,apps/data_explorer/source_filter.spec.js,apps/data_explorer/zzz_after.spec.js\""


### PR DESCRIPTION
### Description

Add e2e tests for data source selector.

```
  Data source selector
    ✓ displays all data sources by default (5755ms)
    ✓ filters options based on user input
    ✓ updates the visual length of the dropdown based on filtered results
    ✓ selects the correct option when clicked


  4 passing (9s)
```

### Issues Resolved

Following up on [#5211](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5211)

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
