### PR TITLE
Skip flaky data explorer tests 

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
@@ -146,7 +146,8 @@ describe('discover app', { scrollBehavior: false }, () => {
     }
   );
 
-  describe('nested query', () => {
+  // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5495
+  describe.skip('nested query', () => {
     before(() => {
       cy.setTopNavDate(DE_DEFAULT_START_TIME, DE_DEFAULT_END_TIME);
       cy.waitForSearch();
@@ -158,7 +159,8 @@ describe('discover app', { scrollBehavior: false }, () => {
     });
   });
 
-  describe('data-shared-item', function () {
+  // https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5495
+  describe.skip('data-shared-item', function () {
     it('should have correct data-shared-item title and description', () => {
       const expected = {
         title: 'A Saved Search',

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/doc_navigation.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/doc_navigation.spec.js
@@ -89,6 +89,8 @@ describe('doc link in discover', () => {
 
     cy.waitForSearch();
 
+    cy.wait(500);
+
     cy.getElementByTestId(`docTableExpandToggleColumn-0`)
       .should('be.visible')
       .click();


### PR DESCRIPTION
### Description
Because of https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5495, we decide to skip the failed tests.

