### PR TITLE
[Alerting] Added wait before selecting Cluster Health API

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/cluster_metrics_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/cluster_metrics_monitor_spec.js
@@ -116,6 +116,7 @@ describe('ClusterMetricsMonitor', () => {
       cy.get('input[name="name"]').type(SAMPLE_CLUSTER_METRICS_HEALTH_MONITOR);
 
       // Wait for the API types to load and then type in the Cluster Health API
+      cy.wait(5000);
       cy.get('[data-test-subj="clusterMetricsApiTypeComboBox"]').type(
         'cluster health{enter}'
       );


### PR DESCRIPTION
### Description
Sometimes we see cluster metrics monitor creation test fail due to a slower response from api types monitor execution. Adding wait time before selecting the cluster health API.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
