### PR TITLE
Add remote cypress orchestrator integration with integtest script

### DIFF
--- a/.github/workflows/remote-cypress-workflow.yml
+++ b/.github/workflows/remote-cypress-workflow.yml
@@ -18,7 +18,8 @@ on:
       branch_ref:
         description: 'Test branch name or commit reference id'
         required: true
-
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   trigger-cypress:
     runs-on: ubuntu-latest
@@ -27,10 +28,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        
-      - name: Run Bash Script
-        env:
-          GITHUB_SECRET_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ./remoteCypress.sh -r "${{ github.event.inputs.repo }}" -w "${{ github.event.inputs.workflow_name }}" -o "${{ github.event.inputs.os_url }}" -d "${{ github.event.inputs.osd_url }}" -b "${{ github.event.inputs.branch_ref }}"
 
+      - name: Run Remote Cypress Orchestrator Script
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "Executing remoteCypress script for workflow_dispatch event"
+          ./remoteCypress.sh -r "${{ github.event.inputs.repo }}" -w "${{ github.event.inputs.workflow_name }}" -o "${{ github.event.inputs.os_url }}" -d "${{ github.event.inputs.osd_url }}" -b "${{ github.event.inputs.branch_ref }}"

--- a/integtest.sh
+++ b/integtest.sh
@@ -19,11 +19,12 @@ function usage() {
     echo -e "-t TEST_COMPONENTS\t(OpenSearch-Dashboards reportsDashboards etc.), optional, specify test components, separate with space, else test everything."
     echo -e "-v VERSION\t, no defaults, indicates the OpenSearch version to test."
     echo -e "-o OPTION\t, no defaults, determine the TEST_TYPE value among(default, manifest) in test_finder.sh, optional."
+    echo -e "-r REMOTE_CYPRESS_ENABLED\t(true | false), defaults to true. Feature flag set to specify remote cypress orchestrator runs are enabled or not."
     echo -e "-h\tPrint this message."
     echo "--------------------------------------------------------------------------"
 }
 
-while getopts ":hb:p:s:c:t:v:o:" arg; do
+while getopts ":hb:p:s:c:t:v:o:r:" arg; do
     case $arg in
         h)
             usage
@@ -49,6 +50,9 @@ while getopts ":hb:p:s:c:t:v:o:" arg; do
             ;;
         o)
             OPTION=$OPTARG
+            ;;
+        r)
+            REMOTE_CYPRESS_ENABLED=$OPTARG
             ;;
         :)
             echo "-${OPTARG} requires an argument"
@@ -78,6 +82,11 @@ then
   SECURITY_ENABLED="true"
 fi
 
+if [ -z "$REMOTE_CYPRESS_ENABLED" ]
+then
+  REMOTE_CYPRESS_ENABLED="true"
+fi
+
 if [ -z "$CREDENTIAL" ]
 then
   # Starting in 2.12.0, security demo configuration script requires an initial admin password
@@ -102,17 +111,111 @@ echo -e "Test Files List:"
 echo $TEST_FILES | tr ',' '\n'
 echo "BROWSER_PATH: $BROWSER_PATH"
 
+# Can be used as Jenkins environment variable set for the orchestrator feature flag, default: true
+ORCHESTRATOR_FEATURE_FLAG=${ORCHESTRATOR_FEATURE_FLAG:-true}
+
+# Read inputs from the manifest file for remote cypress orchestrator
+REMOTE_MANIFEST_FILE="remote_cypress_manifest.json"
+
+# PID file to store remote cypress workflow background processes IDs when run in parallel
+pid_file="process_ids.txt"
+
+run_remote_cypress() {
+    local repo="$1"
+    local workflow_name="$2"
+    local os_url="$3"
+    local osd_url="$4"
+    local branch_ref="$5"
+
+    # Call the remoteCypress.sh script with the required arguments
+    source remoteCypress.sh -r "$repo" -w "$workflow_name" -o "$os_url" -d "$osd_url" -b "$branch_ref" &
+    bg_process_pid=$!
+    echo "PID for the repo $repo is : $bg_process_pid"
+    echo "$bg_process_pid" >> "$pid_file"
+}
+
+# Helper function to extract information from a component and return a tuple
+get_component_info() {
+    local component="$1"
+    local repo workflow_name os_url osd_url branch_ref release_version os arch
+
+    release_version=$(jq -r '.build.version' "$REMOTE_MANIFEST_FILE")
+    repo=$(echo "$component" | jq -r '.["repository"]')
+    workflow_name=$(echo "$component" | jq -r '.["workflow-name"]')
+    os=$(echo "$component" | jq -r '.["operating-system"]')
+    arch=$(echo "$component" | jq -r '.["arch"]')
+    branch_ref=$(echo "$component" | jq -r '.["ref"]')
+
+
+    # Check if OS and Arch are defined
+    if [ -n "$os" ] && [ -n "$arch" ]; then
+        os_url="https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/$release_version/latest/$os/$arch/tar/dist/opensearch/opensearch-$release_version-$os-$arch.tar.gz"
+        osd_url="https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/$release_version/latest/$os/$arch/tar/dist/opensearch-dashboards/opensearch-dashboards-$release_version-$os-$arch.tar.gz"
+    else
+        # Default to linux-x64 if not defined in the manifest
+        os_url="https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/$release_version/latest/linux/x64/tar/dist/opensearch/opensearch-$release_version-linux-x64.tar.gz"
+        osd_url="https://ci.opensearch.org/ci/dbc/distribution-build-opensearch-dashboards/$release_version/latest/linux/x64/tar/dist/opensearch-dashboards/opensearch-dashboards-$release_version-linux-x64.tar.gz"
+    fi
+
+    echo "$repo" "$workflow_name" "$os_url" "$osd_url" "$branch_ref"
+}
+
+# Wait for all processes to finish
+wait_file() {
+    while read -r pid; do
+        wait "$pid"
+    done < "$pid_file"
+}
+
+if [[ $REMOTE_CYPRESS_ENABLED = "true" &&  $ORCHESTRATOR_FEATURE_FLAG = 'true' ]]; then
+    # Parse the JSON file to iterate over the components array
+    components=$(jq -c '.components[]' "$REMOTE_MANIFEST_FILE")
+    echo "Components: $components"
+   
+
+    for component in $components; do
+        read -r repo workflow_name os_url osd_url branch_ref <<< "$(get_component_info "$component")"
+        
+        echo "Processing for the component: $component"
+        echo "repo: $repo"
+        echo "workflow_name: $workflow_name"
+        echo "os_url: $os_url"
+        echo "osd_url: $osd_url"
+        echo "branch_ref: $branch_ref"
+
+        # Call the function for each component
+        run_remote_cypress "$repo" "$workflow_name" "$os_url" "$osd_url" "$branch_ref" 
+    done
+
+    wait_file
+    log_directory="/tmp/logfiles"
+
+    # Read log files in tmp folder and put the output to CI
+    find "$log_directory" -type f -name "*.txt" | while IFS= read -r log_file; do
+        if [ -f "$log_file" ]; then
+            echo "Log content for file: $log_file"
+            cat "$log_file"
+        else
+            echo "Log file not found: $log_file"
+        fi
+    done
+
+    # Delete the temporary log files and folder after writing to CI
+    rm -rf "$log_directory"
+fi
+rm "$pid_file"
+
 ## WARNING: THIS LOGIC NEEDS TO BE THE LAST IN THIS FILE! ##
 # Cypress returns back the test failure count in the error code
 # The CI outputs the error code as test failure count.
 #
 # We need to ensure the cypress tests are the last execute process to
 # the error code gets passed to the CI.
-if [ $SECURITY_ENABLED = "true" ]
-then
-   echo "run security enabled tests"
-   yarn cypress:run-with-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
+
+if [ $SECURITY_ENABLED = "true" ]; then
+    echo "Running security enabled tests"
+    yarn cypress:run-with-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
 else
-   echo "run security disabled tests"
-   yarn cypress:run-without-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
+    echo "Running security disabled tests"
+    yarn cypress:run-without-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
 fi

--- a/remote_cypress_manifest.json
+++ b/remote_cypress_manifest.json
@@ -1,0 +1,31 @@
+{
+  "schema-version": "1.0",
+  "build": {
+    "name": "OpenSearch Dashboards Functional Test",
+    "version": "3.0.0"
+  },
+  "ci": {
+    "image": {
+    }
+  },
+  "components": [
+    {
+      "name": "OpenSearch-Dashboards",
+      "repository": "opensearch-project/OpenSearch-Dashboards",
+      "workflow-name": "",
+      "ref": "",
+      "operating-system": "linux",
+      "arch": "x64",
+      "integ-test": {
+        "test-configs": [
+          "with-security",
+          "without-security"
+        ],
+        "additional-cluster-configs": {
+          "vis_builder.enabled": true,
+          "data_source.enabled": true
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description

Adding remote cypress workflow orchestrator script integration with existing logic of integtest.sh script. This will keep the current behavior of integtest script as it is when triggered along with silently triggering the remote cypress workflows present in the plugin/components as defined in manifest json file and continue to poll them till its completion. 

Changes summary:

* Orchestrator integration with integtest script.
* Adding manifest json file to define plugin/components that gets onboarded to use orchestrator workflow. This manifest is used to capture plugin repo name, workflow name, branch that needs to be tested and any additional security related configuration that needs to be passed to the cypress tests running remote github workflows.
* In this iteration I'm adding Dashboards component to manifest but the workflow file and branch related information will be added once they are ready within Dashboards component.


### Issues Resolved
Follow-up to
https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/972

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/991
### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
