### PR TITLE
add admin credentials for regular release sign-off workflow

### DIFF
--- a/.github/workflows/release-signoff-chrome.yml
+++ b/.github/workflows/release-signoff-chrome.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/.github/workflows/release-signoff-chromium-ad-only.yml
+++ b/.github/workflows/release-signoff-chromium-ad-only.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/.github/workflows/release-signoff-chromium-ism-only.yml
+++ b/.github/workflows/release-signoff-chromium-ism-only.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/.github/workflows/release-signoff-chromium.yml
+++ b/.github/workflows/release-signoff-chromium.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/.github/workflows/release-signoff-electron.yml
+++ b/.github/workflows/release-signoff-electron.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |

--- a/.github/workflows/release-signoff-firefox.yml
+++ b/.github/workflows/release-signoff-firefox.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd opensearch-dashboards-${{ env.VERSION }}
           bin/opensearch-dashboards serve &
-          timeout 300 bash -c 'while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 300 bash -c 'while [[ "$(curl -s -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
       - name: Get Cypress version
         id: cypress_version
         run: |


### PR DESCRIPTION
### Description

The `Run OpenSearch-Dashboards server` task was failed in the regular [release sign-off workflow](https://github.com/opensearch-project/opensearch-dashboards-functional-test/actions/runs/7485045221/job/20372861098), the OSD API status checker missing required credentials and respond 401 error.
Since the OpenSearch was run with security enabled,  we need to pass the admin credentials to the `curl` command.
This PR add `-u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}` to the `curl` call for all release sign-off workflows.

### Issues Resolved

#985 

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
