### PR TITLE
Adapt recent changes in the security plugin to pass integ test

### DIFF
--- a/cypress/integration/plugins/security/internalusers_spec.js
+++ b/cypress/integration/plugins/security/internalusers_spec.js
@@ -57,7 +57,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
         }
       );
 
-      cy.contains('span', 'Create internal user');
+      cy.contains('span', 'Create user account');
 
       cy.url().should((url) => {
         expect(url).to.not.contain('/users/create');

--- a/cypress/utils/plugins/security/commands.js
+++ b/cypress/utils/plugins/security/commands.js
@@ -6,7 +6,7 @@
 import {
   SEC_API_CONFIG_PATH,
   SEC_API_ROLES_PATH,
-  SEC_API_INTERNAL_USERS_PATH,
+  SEC_API_INTERNAL_ACCOUNTS_PATH,
   SEC_API_ACTIONGROUPS_PATH,
   SEC_API_TENANTS_PATH,
   SEC_API_AUDIT_PATH,
@@ -48,7 +48,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'mockInternalUsersAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(SEC_API_INTERNAL_USERS_PATH, {
+    cy.intercept(SEC_API_INTERNAL_ACCOUNTS_PATH, {
       fixture: fixtureFileName,
     }).as('getInternalUsersDetails');
 

--- a/cypress/utils/plugins/security/constants.js
+++ b/cypress/utils/plugins/security/constants.js
@@ -55,6 +55,8 @@ export const SEC_API_ACTIONGROUPS_PATH = BASE_SEC_API_PATH + '/actiongroups';
 export const SEC_API_TENANTS_PATH = BASE_SEC_API_PATH + '/tenants';
 
 export const SEC_API_INTERNAL_USERS_PATH = BASE_SEC_API_PATH + '/internalusers';
+export const SEC_API_INTERNAL_ACCOUNTS_PATH =
+  BASE_SEC_API_PATH + '/internalaccounts';
 
 export const SEC_API_ACCOUNT_PATH = BASE_SEC_API_PATH + '/account';
 


### PR DESCRIPTION
### Description

This PR changed the API called in main, but was not backported to 2.x: https://github.com/opensearch-project/security-dashboards-plugin/pull/1502. It also changes some text. This updates internal users tests to accommodate those changes. It should **NOT** be backported to 2.x line.

### Issues Resolved

Fix: https://github.com/opensearch-project/security-dashboards-plugin/issues/1645

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
