### PR TITLE
feat: add test map for dashboards-assistant

### DIFF
--- a/test_finder.sh
+++ b/test_finder.sh
@@ -22,6 +22,7 @@ OSD_COMPONENT_TEST_MAP=( "OpenSearch-Dashboards:opensearch-dashboards"
                          "searchRelevanceDashboards:search-relevance-dashboards"
                          "mlCommonsDashboards:ml-commons-dashboards"
                          "securityAnalyticsDashboards:security-analytics-dashboards-plugin"
+                         "assistantDashboards:dashboards-assistant"
                        )
 
 if [ -z $TEST_TYPE ]; then


### PR DESCRIPTION
### Description
For new onboarding plugin, need to add test map so that intetest.sh can find the directory based on the input of `component`.

For assistant component name, refer to https://github.com/opensearch-project/opensearch-build/pull/4363

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
