### PR TITLE
Improve Observability Panels Tests

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
@@ -6,14 +6,14 @@
 /// <reference types="cypress" />
 
 import {
-  PANEL_DELAY as delay,
   TEST_PANEL,
+  TEST_PANEL_COPY,
   BASE_PATH,
+  PANELS_TIMEOUT,
 } from '../../../utils/constants';
 
 const moveToPanelHome = () => {
   cy.visit(`${BASE_PATH}/app/observability-dashboards#`);
-  cy.wait(delay * 3);
 };
 
 describe('Testing panels table', () => {
@@ -22,11 +22,12 @@ describe('Testing panels table', () => {
   });
 
   it('Creates a panel and redirects to the panel', () => {
-    cy.get('.euiButton__text')
+    // Extending timeout so page completely loads
+    cy.get('.euiButton__text', { timeout: PANELS_TIMEOUT })
       .contains('Create Dashboard')
       .trigger('mouseover')
       .click();
-    cy.wait(delay);
+    cy.location('href').should('include', 'create');
     cy.get('input.euiFieldText').focus().type(TEST_PANEL, {
       delay: 50,
     });
@@ -34,19 +35,20 @@ describe('Testing panels table', () => {
       .contains(/^Create$/)
       .trigger('mouseover')
       .click();
-    cy.wait(delay);
+    cy.intercept('POST', '/api/saved_objects/*').as('createDashboard');
+    cy.wait('@createDashboard');
 
     cy.contains(TEST_PANEL).should('exist');
   });
 
   it('Duplicates a panel', () => {
-    cy.get('.euiCheckbox__input[title="Select this row"]')
+    cy.get('.euiCheckbox__input[title="Select this row"]', {
+      timeout: PANELS_TIMEOUT,
+    })
       .eq(0)
       .trigger('mouseover')
       .click();
-    cy.wait(delay);
     cy.get('.euiButton__text').contains('Actions').trigger('mouseover').click();
-    cy.wait(delay);
     cy.get('.euiContextMenuItem__text')
       .contains('Duplicate')
       .trigger('mouseover')
@@ -55,6 +57,9 @@ describe('Testing panels table', () => {
       .contains('Duplicate')
       .trigger('mouseover')
       .click();
-    cy.wait(delay);
+    cy.intercept('POST', '/api/saved_objects/*').as('createDashboard');
+    cy.wait('@createDashboard');
+
+    cy.contains(TEST_PANEL_COPY);
   });
 });

--- a/cypress/utils/plugins/observability-dashboards/constants.js
+++ b/cypress/utils/plugins/observability-dashboards/constants.js
@@ -198,9 +198,8 @@ export const landOnPanels = () => {
  * Panel Constants
  */
 
-export const PANEL_DELAY = 100;
-
 export const TEST_PANEL = 'Test Panel';
+export const TEST_PANEL_COPY = 'Test Panel (copy)';
 export const SAMPLE_PANEL = '[Logs] Web traffic Panel';
 
 export const SAMPLE_VISUALIZATIONS_NAMES = [
@@ -237,6 +236,7 @@ export const PPL_FILTER =
 
 export const TYPING_DELAY = 1500;
 export const TIMEOUT_DELAY = Cypress.env('SECURITY_ENABLED') ? 60000 : 30000;
+export const PANELS_TIMEOUT = 120000;
 
 export const moveToHomePage = () => {
   cy.visit(`${BASE_PATH}/app/observability-applications#`);


### PR DESCRIPTION
### Description

Improving flaky panels tests by removing most unnecessary waits, adding a longer timeout for page to load. Also added a check for the second test

### Issues Resolved

#897 

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
