### PR TITLE
feat: add CYPRESS_NO_COMMAND_LOG to release signoff workflows

### DIFF
--- a/.github/workflows/release-signoff-chrome.yml
+++ b/.github/workflows/release-signoff-chrome.yml
@@ -15,6 +15,8 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
       # 2.12 onwards security demo configuration require a custom admin password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
+      # Disable command log to unhang
+      CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
         uses: actions/checkout@v2

--- a/.github/workflows/release-signoff-chromium-ad-only.yml
+++ b/.github/workflows/release-signoff-chromium-ad-only.yml
@@ -15,6 +15,8 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
       # 2.12 onwards security demo configuration require a custom admin password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
+      # Disable command log to unhang
+      CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
         uses: actions/checkout@v2

--- a/.github/workflows/release-signoff-chromium-ism-only.yml
+++ b/.github/workflows/release-signoff-chromium-ism-only.yml
@@ -15,6 +15,8 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
       # 2.12 onwards security demo configuration require a custom admin password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
+      # Disable command log to unhang
+      CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
         uses: actions/checkout@v2

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
@@ -15,6 +15,8 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
       # 2.12 onwards security demo configuration require a custom admin password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
+      # Disable command log to unhang
+      CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
         uses: actions/checkout@v2

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
@@ -15,6 +15,8 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
       # 2.12 onwards security demo configuration require a custom admin password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
+      # Disable command log to unhang
+      CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
         uses: actions/checkout@v2

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
@@ -15,6 +15,8 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
       # 2.12 onwards security demo configuration require a custom admin password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
+      # Disable command log to unhang
+      CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
         uses: actions/checkout@v2

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
@@ -15,6 +15,8 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
       # 2.12 onwards security demo configuration require a custom admin password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
+      # Disable command log to unhang
+      CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
         uses: actions/checkout@v2

--- a/.github/workflows/release-signoff-chromium.yml
+++ b/.github/workflows/release-signoff-chromium.yml
@@ -15,6 +15,8 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
       # 2.12 onwards security demo configuration require a custom admin password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
+      # Disable command log to unhang
+      CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
         uses: actions/checkout@v2

--- a/.github/workflows/release-signoff-electron.yml
+++ b/.github/workflows/release-signoff-electron.yml
@@ -15,6 +15,8 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
       # 2.12 onwards security demo configuration require a custom admin password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
+      # Disable command log to unhang
+      CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
         uses: actions/checkout@v2

--- a/.github/workflows/release-signoff-firefox.yml
+++ b/.github/workflows/release-signoff-firefox.yml
@@ -15,6 +15,8 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
       # 2.12 onwards security demo configuration require a custom admin password
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
+      # Disable command log to unhang
+      CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description

The release sign off test workflow always hang during test execution. 
Add `CYPRESS_NO_COMMAND_LOG=1` to env variables to unhang. 

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
