### PR TITLE
Add functional test for dashboard assistant trace page  

### DIFF
--- a/cypress/fixtures/plugins/dashboards-assistant/agent-framework-thought-response.json
+++ b/cypress/fixtures/plugins/dashboards-assistant/agent-framework-thought-response.json
@@ -1,0 +1,5 @@
+{
+  "completion": " ```json\n{\n  \"thought\": \"Thought: Let me use tool to figure out\",\n  \"action\": \"CatIndexTool\",\n  \"action_input\": \"\"}\n```\n",
+  "stop_reason": "stop_sequence",
+  "stop": "\n\nHuman:"
+}

--- a/cypress/integration/plugins/dashboards-assistant/chatbot_agent_framework_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/chatbot_agent_framework_spec.js
@@ -28,7 +28,7 @@ if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
       it('toggle Chatbot and enable to interact', () => {
         // input question
         cy.get(`input[placeholder="Ask question"]`)
-          .focus()
+          .click()
           .type('What are the indices in my cluster?{enter}');
 
         // should have a LLM Response

--- a/cypress/integration/plugins/dashboards-assistant/chatbot_agent_framework_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/chatbot_agent_framework_spec.js
@@ -26,11 +26,10 @@ if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
 
     describe('Interact with Agent framework', () => {
       it('toggle Chatbot and enable to interact', () => {
-        // enable to toggle and show Chatbot
-        cy.get(`img[aria-label="toggle chat flyout icon"]`).click();
-
-        // click suggestions to generate response
-        cy.contains('What are the indices in my cluster?').click();
+        // input question
+        cy.get(`input[placeholder="Ask question"]`)
+          .focus()
+          .type('What are the indices in my cluster?{enter}');
 
         // should have a LLM Response
         cy.contains(

--- a/cypress/integration/plugins/dashboards-assistant/chatbot_agent_framework_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/chatbot_agent_framework_spec.js
@@ -27,6 +27,7 @@ if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
     describe('Interact with Agent framework', () => {
       it('toggle Chatbot and enable to interact', () => {
         // input question
+        cy.wait(1000);
         cy.get(`input[placeholder="Ask question"]`)
           .click()
           .type('What are the indices in my cluster?{enter}');

--- a/cypress/integration/plugins/dashboards-assistant/chatbot_interaction_trace_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/chatbot_interaction_trace_spec.js
@@ -23,7 +23,7 @@ if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
       );
 
       cy.get(`input[placeholder="Ask question"]`)
-        .focus()
+        .click()
         .type('What are the indices in my cluster?{enter}');
 
       // should have a LLM Response

--- a/cypress/integration/plugins/dashboards-assistant/chatbot_interaction_trace_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/chatbot_interaction_trace_spec.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BASE_PATH } from '../../../utils/constants';
+
+if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
+  describe('Interaction trace spec', () => {
+    before(() => {
+      // Set welcome screen tracking to false
+      localStorage.setItem('home:welcome:show', 'false');
+      // Set new theme modal to false
+      localStorage.setItem('home:newThemeModal:show', 'false');
+
+      cy.visit(`${BASE_PATH}/app/home`);
+      // cy.waitForLoader();
+
+      // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
+      cy.get(`input[placeholder="Ask question"]`, { timeout: 120000 }).should(
+        'be.length',
+        1
+      );
+
+      cy.get(`input[placeholder="Ask question"]`)
+        .focus()
+        .type('What are the indices in my cluster?{enter}');
+
+      // should have a LLM Response
+      cy.contains(
+        'The indices in your cluster are the names listed in the response obtained from using a tool to get information about the OpenSearch indices.'
+      );
+    });
+
+    describe('Trace page', () => {
+      it('open trace page and verify page content', () => {
+        // click How was this generated? to view trace
+        cy.contains('How was this generated?').click();
+
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+          .find(`button[aria-label="back"]`)
+          .should('have.length', 1);
+
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+          .find(`button[aria-label="close"]`)
+          .should('have.length', 0);
+
+        // title
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`).contains(
+          'h1',
+          'How was this generated'
+        );
+
+        // question
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`).contains(
+          'What are the indices in my cluster?'
+        );
+
+        // result
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`).contains(
+          'The indices in your cluster are the names listed in the response obtained from using a tool to get information about the OpenSearch indices.'
+        );
+      });
+
+      it('tools invocation displayed in trace steps', () => {
+        // trace
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+          .find('.euiAccordion')
+          .should('have.length', 1);
+
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+          .find('.euiAccordion')
+          // tool name
+          .contains('Step 1 - CatIndexTool')
+          .click({ force: true });
+
+        // tool output
+        cy.contains('Output: health	status	index');
+      });
+
+      it('trace page display correctly in fullscreen mode', () => {
+        cy.get(`.llm-chat-flyout-header`)
+          .find(`button[aria-label="fullScreen"]`)
+          .click({ force: true });
+
+        // show close button
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+          .find(`button[aria-label="close"]`)
+          .should('have.length', 1);
+
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+          .find(`button[aria-label="back"]`)
+          .should('have.length', 0);
+
+        // both chat and trace are both displayed
+        cy.contains('How was this generated?').click();
+      });
+    });
+  });
+}

--- a/cypress/integration/plugins/dashboards-assistant/chatbot_interaction_trace_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/chatbot_interaction_trace_spec.js
@@ -17,12 +17,14 @@ if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
       // cy.waitForLoader();
 
       // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
-      cy.get(`input[placeholder="Ask question"]`, { timeout: 120000 }).should(
-        'be.length',
-        1
+      cy.get(`input[placeholder="Ask question"]`, { timeout: 120000 }).as(
+        'chatInput'
       );
+      cy.get('@chatInput').should('be.length', 1);
 
-      cy.get(`input[placeholder="Ask question"]`)
+      cy.wait(1000);
+
+      cy.get('@chatInput')
         .click()
         .type('What are the indices in my cluster?{enter}');
 
@@ -37,38 +39,33 @@ if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
         // click How was this generated? to view trace
         cy.contains('How was this generated?').click();
 
-        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`).as('tracePage');
+        cy.get('@tracePage')
           .find(`button[aria-label="back"]`)
           .should('have.length', 1);
 
-        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+        cy.get('@tracePage')
           .find(`button[aria-label="close"]`)
           .should('have.length', 0);
 
         // title
-        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`).contains(
-          'h1',
-          'How was this generated'
-        );
+        cy.get('@tracePage').contains('h1', 'How was this generated');
 
         // question
-        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`).contains(
-          'What are the indices in my cluster?'
-        );
+        cy.get('@tracePage').contains('What are the indices in my cluster?');
 
         // result
-        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`).contains(
+        cy.get('@tracePage').contains(
           'The indices in your cluster are the names listed in the response obtained from using a tool to get information about the OpenSearch indices.'
         );
       });
 
       it('tools invocation displayed in trace steps', () => {
         // trace
-        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
-          .find('.euiAccordion')
-          .should('have.length', 1);
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`).as('tracePage');
+        cy.get('@tracePage').find('.euiAccordion').should('have.length', 1);
 
-        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+        cy.get('@tracePage')
           .find('.euiAccordion')
           // tool name
           .contains('Step 1 - CatIndexTool')
@@ -84,11 +81,12 @@ if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
           .click({ force: true });
 
         // show close button
-        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`).as('tracePage');
+        cy.get('@tracePage')
           .find(`button[aria-label="close"]`)
           .should('have.length', 1);
 
-        cy.get(`.llm-chat-flyout .llm-chat-flyout-body`)
+        cy.get('@tracePage')
           .find(`button[aria-label="back"]`)
           .should('have.length', 0);
 

--- a/cypress/integration/plugins/dashboards-assistant/chatbot_interaction_trace_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/chatbot_interaction_trace_spec.js
@@ -16,7 +16,7 @@ if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
       cy.visit(`${BASE_PATH}/app/home`);
       // cy.waitForLoader();
 
-      // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
+      // Common text to wait for to confirm page loaded, give up to 120 seconds for initial load
       cy.get(`input[placeholder="Ask question"]`, { timeout: 120000 }).as(
         'chatInput'
       );
@@ -32,6 +32,12 @@ if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
       cy.contains(
         'The indices in your cluster are the names listed in the response obtained from using a tool to get information about the OpenSearch indices.'
       );
+    });
+
+    // clean up localStorage items
+    after(() => {
+      localStorage.removeItem('home:welcome:show');
+      localStorage.removeItem('home:newThemeModal:show');
     });
 
     describe('Trace page', () => {

--- a/cypress/support/assistant-dummy-llm.js
+++ b/cypress/support/assistant-dummy-llm.js
@@ -4,11 +4,13 @@
  */
 const http = require('http');
 const agentFrameworkJson = require('../fixtures/plugins/dashboards-assistant/agent-framework-response.json');
+const agentFrameworkThoughtJson = require('../fixtures/plugins/dashboards-assistant/agent-framework-thought-response.json');
 const suggestionJson = require('../fixtures/plugins/dashboards-assistant/suggestion-response.json');
 
 const MATCH_AGENT_FRAMEWORK_PROMPT =
   'Assistant is designed to be able to assist with a wide range of tasks';
 const MATCH_SUGGESTION_PROMPT = 'You are an AI that only speaks JSON';
+const TOOL_RESPONSE = 'TOOL RESPONSE:';
 
 const server = http.createServer((req, res) => {
   // Set the content type to JSON
@@ -27,7 +29,11 @@ const server = http.createServer((req, res) => {
       // Why add a delay here? reference: https://github.com/opensearch-project/ml-commons/issues/1894
       setTimeout(() => {
         if (requestBody.includes(MATCH_AGENT_FRAMEWORK_PROMPT)) {
-          return res.end(JSON.stringify(agentFrameworkJson));
+          if (requestBody.includes(TOOL_RESPONSE)) {
+            return res.end(JSON.stringify(agentFrameworkJson));
+          } else {
+            return res.end(JSON.stringify(agentFrameworkThoughtJson));
+          }
         } else if (requestBody.includes(MATCH_SUGGESTION_PROMPT)) {
           return res.end(JSON.stringify(suggestionJson));
         }


### PR DESCRIPTION
### Description

1. Add functional test for chat assistant trace page
2. Add tool invocation into mock LLM server



https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/113890546/3e4ab295-4711-4121-b714-086b62c7f639





### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
