### PR TITLE
fix(workflow): paths-filter error on push event

### DIFF
--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
@@ -11,9 +11,11 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
+      - uses: actions/checkout@v2
       - uses: dorny/paths-filter@v2
         id: filter
         with:
+          base: ${{ github.ref }}
           filters: |
             tests:
               - 'cypress/**/core-opensearch-dashboards/**'

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
@@ -2,28 +2,15 @@ name: Bundle Snapshot based E2E Cypress tests workflow for core Dashboards (Wind
 on:
   pull_request:
     branches: [ '**' ]
+    paths:
+      - 'cypress/**/core-opensearch-dashboards/**'
   push:
     branches: [ '**' ]
+    paths:
+      - 'cypress/**/core-opensearch-dashboards/**'
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      tests: ${{ steps.filter.outputs.tests }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          base: ${{ github.ref }}
-          filters: |
-            tests:
-              - 'cypress/**/core-opensearch-dashboards/**'
-              - 'cypress/utils/dashboards/**'
-
   tests-with-security:
-    needs: changes
-    if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template-windows.yml
     with:
       test-name: Core Dashboards using Bundle Snapshot
@@ -32,8 +19,6 @@ jobs:
       #osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
 
   tests-without-security:
-    needs: changes
-    if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template-windows.yml
     with:
       test-name: Core Dashboards using Bundle Snapshot

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
@@ -4,10 +4,12 @@ on:
     branches: [ '**' ]
     paths:
       - 'cypress/**/core-opensearch-dashboards/**'
+      - 'cypress/utils/dashboards/**'
   push:
     branches: [ '**' ]
     paths:
       - 'cypress/**/core-opensearch-dashboards/**'
+      - 'cypress/utils/dashboards/**'
 
 jobs:
   tests-with-security:

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -11,9 +11,11 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
+      - uses: actions/checkout@v2
       - uses: dorny/paths-filter@v2
         id: filter
         with:
+          base: ${{ github.ref }}
           filters: |
             tests:
               - 'cypress/**/core-opensearch-dashboards/**'

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -4,10 +4,12 @@ on:
     branches: [ '**' ]
     paths:
       - 'cypress/**/core-opensearch-dashboards/**'
+      - 'cypress/utils/dashboards/**'
   push:
     branches: [ '**' ]
     paths:
       - 'cypress/**/core-opensearch-dashboards/**'
+      - 'cypress/utils/dashboards/**'
 
 jobs:
   tests-with-security:

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -2,28 +2,15 @@ name: Bundle Snapshot based E2E Cypress tests workflow for core Dashboards
 on:
   pull_request:
     branches: [ '**' ]
+    paths:
+      - 'cypress/**/core-opensearch-dashboards/**'
   push:
     branches: [ '**' ]
+    paths:
+      - 'cypress/**/core-opensearch-dashboards/**'
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      tests: ${{ steps.filter.outputs.tests }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          base: ${{ github.ref }}
-          filters: |
-            tests:
-              - 'cypress/**/core-opensearch-dashboards/**'
-              - 'cypress/utils/dashboards/**'
-
   tests-with-security:
-    needs: changes
-    if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
     with:
       test-name: Core Dashboards using Bundle Snapshot
@@ -31,8 +18,6 @@ jobs:
       osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true --ml_commons_dashboards.enabled=true
 
   tests-without-security:
-    needs: changes
-    if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
     with:
       test-name: Core Dashboards using Bundle Snapshot


### PR DESCRIPTION
Resolved 
https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/993
https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/1108

Removed `dorny/paths-filter` action and use GitHub workflow builtin path filter

### Description

[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
