### PR TITLE
fixed observability tests running forever

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/1_trace_analytics_dashboard.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/1_trace_analytics_dashboard.spec.js
@@ -29,12 +29,13 @@ describe('Testing dashboard table', () => {
       },
     });
     setTimeFilter();
-    cy.get(
-      '[data-test-subj="trace-groups-service-operation-accordian"]'
-    ).click();
   });
 
   it('Adds the percentile filters', () => {
+    cy.get(
+      '[data-test-subj="trace-groups-service-operation-accordian"]'
+    ).click();
+
     cy.contains(' >= 95 percentile').click({ force: true });
     cy.wait(delayTime);
     cy.contains(' >= 95 percentile').click({ force: true });
@@ -60,6 +61,9 @@ describe('Testing dashboard table', () => {
 
   it('Opens latency trend popover', () => {
     setTimeFilter(true);
+    cy.get(
+      '[data-test-subj="trace-groups-service-operation-accordian"]'
+    ).click();
     cy.get('.euiButtonIcon[aria-label="Open popover"]').first().click();
     cy.get('text.ytitle[data-unformatted="Hourly latency (ms)"]').should(
       'exist'
@@ -67,6 +71,9 @@ describe('Testing dashboard table', () => {
   });
 
   it('Redirects to traces table with filter', () => {
+    cy.get(
+      '[data-test-subj="trace-groups-service-operation-accordian"]'
+    ).click();
     cy.get('[data-test-subj="dashboard-table-traces-button"]')
       .contains('13')
       .click();


### PR DESCRIPTION
### Description
Resolved https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/1022

Updated the tests so that time range is set and refresh button is clicked before the `Service and operations` accordion is opened to avoid the `TypeError: Converting circular structure to JSON`.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
