### PR TITLE
[Backport 2.x] Add functional test for datasources at observability dashboards plugin

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/7_datasources_dashboard.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/7_datasources_dashboard.spec.js
@@ -56,10 +56,7 @@ describe('Integration tests for datasources plugin', () => {
     visitDatasourcesCreationPage();
 
     cy.get(createS3Button).should('be.visible').click();
-    cy.url().should(
-      'include',
-      'configure/AmazonS3AWSGlue'
-    );
+    cy.url().should('include', 'configure/AmazonS3AWSGlue');
 
     cy.get('h1.euiTitle.euiTitle--medium')
       .should('be.visible')
@@ -70,10 +67,7 @@ describe('Integration tests for datasources plugin', () => {
     visitDatasourcesCreationPage();
 
     cy.get(createPrometheusButton).should('be.visible').click();
-    cy.url().should(
-      'include',
-      'configure/Prometheus'
-    );
+    cy.url().should('include', 'configure/Prometheus');
 
     cy.get('h4.euiTitle.euiTitle--medium')
       .should('be.visible')

--- a/cypress/integration/plugins/observability-dashboards/7_datasources_dashboard.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/7_datasources_dashboard.spec.js
@@ -58,7 +58,7 @@ describe('Integration tests for datasources plugin', () => {
     cy.get(createS3Button).should('be.visible').click();
     cy.url().should(
       'include',
-      DATASOURCES_PATH.DATASOURCES_CONFIG_BASE + '/AmazonS3AWSGlue'
+      'configure/AmazonS3AWSGlue'
     );
 
     cy.get('h1.euiTitle.euiTitle--medium')
@@ -72,7 +72,7 @@ describe('Integration tests for datasources plugin', () => {
     cy.get(createPrometheusButton).should('be.visible').click();
     cy.url().should(
       'include',
-      DATASOURCES_PATH.DATASOURCES_CONFIG_BASE + '/Prometheus'
+      'configure/Prometheus'
     );
 
     cy.get('h4.euiTitle.euiTitle--medium')

--- a/cypress/integration/plugins/observability-dashboards/7_datasources_dashboard.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/7_datasources_dashboard.spec.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/// <reference types="cypress" />
+
+import { BASE_PATH } from '../../../utils/base_constants';
+
+import {
+  DATASOURCES_API_PREFIX,
+  DATASOURCES_PATH,
+} from '../../../utils/plugins/observability-dashboards/constants';
+
+const manageDataSourcesTag = 'button[data-test-subj="manage"]';
+const newDataSourcesTag = 'button[data-test-subj="new"]';
+const createS3Button = '[data-test-subj="datasource_card_s3glue"]';
+const createPrometheusButton = '[data-test-subj="datasource_card_prometheus"]';
+
+const visitDatasourcesHomePage = () => {
+  cy.visit(BASE_PATH + DATASOURCES_API_PREFIX);
+};
+
+const visitDatasourcesCreationPage = () => {
+  cy.visit(BASE_PATH + DATASOURCES_PATH.DATASOURCES_CREATION_BASE);
+};
+
+describe('Integration tests for datasources plugin', () => {
+  it('Navigates to datasources plugin and expects the correct header', () => {
+    visitDatasourcesHomePage();
+    cy.get('[data-test-subj="dataconnections-header"]', {
+      timeout: 120000,
+    }).should('exist');
+  });
+
+  it('Tests navigation between tabs', () => {
+    visitDatasourcesHomePage();
+
+    cy.get(manageDataSourcesTag)
+      .should('have.class', 'euiTab-isSelected')
+      .and('have.attr', 'aria-selected', 'true');
+    cy.get(manageDataSourcesTag).click();
+    cy.url().should('include', '/manage');
+
+    cy.get(newDataSourcesTag).click();
+    cy.get(newDataSourcesTag)
+      .should('have.class', 'euiTab-isSelected')
+      .and('have.attr', 'aria-selected', 'true');
+    cy.url().should('include', '/new');
+
+    cy.get(createS3Button).should('be.visible');
+    cy.get(createPrometheusButton).should('be.visible');
+  });
+
+  it('Tests navigation of S3 datasources creation page with hash', () => {
+    visitDatasourcesCreationPage();
+
+    cy.get(createS3Button).should('be.visible').click();
+    cy.url().should(
+      'include',
+      DATASOURCES_PATH.DATASOURCES_CONFIG_BASE + '/AmazonS3AWSGlue'
+    );
+
+    cy.get('h1.euiTitle.euiTitle--medium')
+      .should('be.visible')
+      .and('contain', 'Configure Amazon S3 data source');
+  });
+
+  it('Tests navigation of Prometheus datasources creation page with hash', () => {
+    visitDatasourcesCreationPage();
+
+    cy.get(createPrometheusButton).should('be.visible').click();
+    cy.url().should(
+      'include',
+      DATASOURCES_PATH.DATASOURCES_CONFIG_BASE + '/Prometheus'
+    );
+
+    cy.get('h4.euiTitle.euiTitle--medium')
+      .should('be.visible')
+      .and('contain', 'Configure Prometheus data source');
+  });
+});

--- a/cypress/utils/plugins/observability-dashboards/constants.js
+++ b/cypress/utils/plugins/observability-dashboards/constants.js
@@ -6,6 +6,13 @@ import { BASE_PATH } from '../../base_constants';
 
 export const delayTime = 1500;
 
+//Datasources API Constants
+export const DATASOURCES_API_PREFIX = '/app/datasources';
+export const DATASOURCES_PATH = {
+  DATASOURCES_CREATION_BASE: `${DATASOURCES_API_PREFIX}#/new`,
+  DATASOURCES_CONFIG_BASE: `${DATASOURCES_API_PREFIX}#/configure`,
+};
+
 // trace analytics
 export const TRACE_ID = '8832ed6abbb2a83516461960c89af49d';
 export const SPAN_ID = 'a673bc074b438374';


### PR DESCRIPTION
### Description
Add functional test for datasources at observability dashboards plugin

### Issues Resolved
* Backport https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/987

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
