### PR TITLE
feat: add functional tests for conversation save to notebook

### DIFF
--- a/cypress/integration/plugins/dashboards-assistant/conversation_save_to_notebook_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/conversation_save_to_notebook_spec.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { BASE_PATH } from '../../../utils/constants';
+import { setStorageItem } from '../../../utils/plugins/dashboards-assistant/helpers';
+
+const QUESTION = 'What are the indices in my cluster?';
+const FINAL_ANSWER =
+  'The indices in your cluster are the names listed in the response obtained from using a tool to get information about the OpenSearch indices.';
+
+if (Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')) {
+  describe('Assistant conversation save to notebook spec', () => {
+    let restoreShowHome;
+    let restoreNewThemeModal;
+    let restoreTenantSwitchModal;
+
+    beforeEach(() => {
+      // Set welcome screen tracking to false
+      restoreShowHome = setStorageItem(
+        localStorage,
+        'home:welcome:show',
+        'false'
+      );
+      // Hide new theme modal
+      restoreNewThemeModal = setStorageItem(
+        localStorage,
+        'home:newThemeModal:show',
+        'false'
+      );
+      restoreTenantSwitchModal = setStorageItem(
+        sessionStorage,
+        'opendistro::security::tenant::show_popup',
+        'false'
+      );
+      // Visit OSD
+      cy.visit(`${BASE_PATH}/app/home`);
+      // Common text to wait for to confirm page loaded, give up to 120 seconds for initial load
+      cy.get(`input[placeholder="Ask question"]`, { timeout: 120000 }).as(
+        'chatInput'
+      );
+      cy.get('@chatInput').should('be.length', 1);
+
+      cy.wait(10000);
+
+      cy.get('@chatInput').click().type(`${QUESTION}{enter}`);
+
+      // should have a LLM Response
+      cy.contains(FINAL_ANSWER);
+    });
+
+    afterEach(() => {
+      if (restoreShowHome) {
+        restoreShowHome();
+      }
+      if (restoreNewThemeModal) {
+        restoreNewThemeModal();
+      }
+      if (restoreTenantSwitchModal) {
+        restoreTenantSwitchModal();
+      }
+    });
+
+    it('show succeed toast after saved notebook', () => {
+      cy.get('button[aria-label="toggle chat context menu"]').click();
+      cy.contains('Save to notebook').click();
+      cy.get('input[aria-label="Notebook name input"]').type('test notebook');
+      cy.get('button[data-test-subj="confirmSaveToNotebookButton"]').click();
+
+      cy.get('div[aria-label="Notification message list"]')
+        .contains('This conversation was saved as')
+        .should('be.visible');
+    });
+
+    it('show conversation details in the created notebook page', () => {
+      cy.get('button[aria-label="toggle chat context menu"]').click();
+      cy.contains('Save to notebook').click();
+      cy.get('input[aria-label="Notebook name input"]').type('test notebook');
+      cy.get('button[data-test-subj="confirmSaveToNotebookButton"]').click();
+
+      // Click created notebook link in current tab
+      cy.get('div[aria-label="Notification message list"]')
+        .contains('test notebook')
+        .invoke('removeAttr', 'target')
+        .as('testNotebookLink');
+
+      cy.wait(1000);
+      cy.get('@testNotebookLink').click();
+
+      cy.location('pathname').should('contains', 'app/observability-notebooks');
+
+      cy.waitForLoader();
+      cy.contains(QUESTION).should('be.visible');
+      cy.contains(FINAL_ANSWER).should('be.visible');
+    });
+  });
+}

--- a/cypress/utils/plugins/dashboards-assistant/helpers.js
+++ b/cypress/utils/plugins/dashboards-assistant/helpers.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const setStorageItem = (storage, key, value) => {
+  const oldValue = storage.getItem(key);
+  storage.setItem(key, value);
+  return () => {
+    if (oldValue === null) {
+      storage.removeItem(key);
+    } else {
+      storage.setItem(key, oldValue);
+    }
+  };
+};


### PR DESCRIPTION
### Description

Add functional tests for save to notebook

https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/4034161/803d7031-0577-4bea-a398-de400dadac54

Due to the [ml-commons issue](https://github.com/opensearch-project/ml-commons/issues/1971), this tests can be passed with previous version of ml-commons plugin.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
