### PR TITLE
[Forwardport main] Fix datasources test cases' url assertion

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/7_datasources_dashboard.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/7_datasources_dashboard.spec.js
@@ -56,10 +56,7 @@ describe('Integration tests for datasources plugin', () => {
     visitDatasourcesCreationPage();
 
     cy.get(createS3Button).should('be.visible').click();
-    cy.url().should(
-      'include',
-      DATASOURCES_PATH.DATASOURCES_CONFIG_BASE + '/AmazonS3AWSGlue'
-    );
+    cy.url().should('include', 'configure/AmazonS3AWSGlue');
 
     cy.get('h1.euiTitle.euiTitle--medium')
       .should('be.visible')
@@ -70,10 +67,7 @@ describe('Integration tests for datasources plugin', () => {
     visitDatasourcesCreationPage();
 
     cy.get(createPrometheusButton).should('be.visible').click();
-    cy.url().should(
-      'include',
-      DATASOURCES_PATH.DATASOURCES_CONFIG_BASE + '/Prometheus'
-    );
+    cy.url().should('include', 'configure/Prometheus');
 
     cy.get('h4.euiTitle.euiTitle--medium')
       .should('be.visible')


### PR DESCRIPTION
### Description
Fix datasources test cases' url assertion when security is enabled
**Please merge after https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1023 so that we can verify the fix in CI.**

### Issues Resolved
* Forwardport https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1024

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
