### PR TITLE
Add token credential check before calling orchestrator logic

### DIFF
--- a/auth.groovy
+++ b/auth.groovy
@@ -1,0 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+// Fetch GitHub credentials using Jenkins' withCredentials step
+def getCredentials() {
+    try {
+        withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER')]) { 
+            env.REMOTE_GITHUB_TOKEN = sh(script: 'echo $GITHUB_TOKEN', returnStdout: true).trim()
+        }
+    } catch (Exception ex) {
+        echo "Error: Unable to fetch GitHub token from Jenkins credentials. Message: ${ex.getMessage()}"
+    }
+}
+
+getCredentials()

--- a/integtest.sh
+++ b/integtest.sh
@@ -111,6 +111,15 @@ echo -e "Test Files List:"
 echo $TEST_FILES | tr ',' '\n'
 echo "BROWSER_PATH: $BROWSER_PATH"
 
+# Verify if GITHUB_TOKEN is empty and if yes call groovy function to get the credentials as part of Jenkins pipeline step
+if [ -z "$GITHUB_TOKEN" ]; then
+    # integtest script is run as part of release CI jenkins job where groovy is installed
+    groovy auth.groovy
+    export GITHUB_TOKEN="$REMOTE_GITHUB_TOKEN"
+else
+    echo "GITHUB_TOKEN is not empty. Skipping credential retrieval."
+fi
+
 # Can be used as Jenkins environment variable set for the orchestrator feature flag, default: true
 ORCHESTRATOR_FEATURE_FLAG=${ORCHESTRATOR_FEATURE_FLAG:-true}
 
@@ -167,7 +176,7 @@ wait_file() {
     done < "$pid_file"
 }
 
-if [[ $REMOTE_CYPRESS_ENABLED = "true" &&  $ORCHESTRATOR_FEATURE_FLAG = 'true' ]]; then
+if [[ -n "$GITHUB_TOKEN" && $REMOTE_CYPRESS_ENABLED && $ORCHESTRATOR_FEATURE_FLAG ]]; then
     # Parse the JSON file to iterate over the components array
     components=$(jq -c '.components[]' "$REMOTE_MANIFEST_FILE")
     echo "Components: $components"


### PR DESCRIPTION
### Description

Follow-up to this PR https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/988 
Addressing comments
### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
