### PR TITLE
Improve bash checking in test_finder.sh for all OSes

### DIFF
--- a/test_finder.sh
+++ b/test_finder.sh
@@ -28,7 +28,13 @@ if [ -z $TEST_TYPE ]; then
     [ -f $OSD_BUILD_MANIFEST ] && TEST_TYPE="manifest" || TEST_TYPE="default"
 fi
 
-[ ! `echo $SHELL | grep 'bash'` ] && echo "You must run this script with bash as other shells like zsh will fail the script, exit in 10" && sleep 10 && exit 1
+if [ `echo $OSTYPE | grep -i 'linux'` ] || [ `echo $OSTYPE | grep -i 'darwin'` ]
+then
+    [ ! `echo $SHELL | grep -i 'bash'` ] && echo "You must run this script with bash as other shells like zsh will fail the script, exit in 10!" && sleep 10 && exit 1
+else
+    [ ! `readlink /proc/$$/exe | grep -i 'bash'` ] && echo "You must run this script with bash as other shells like zsh will fail the script, exit in 10!!" && sleep 10 && exit 1
+fi
+
 
 # Checks if build manifest in parent directory of current directory under local-test-cluster/opensearch-dashboards-*
 # When the test script executed in the CI, it scales up OpenSearch Dashboards under local-test-cluster with a 


### PR DESCRIPTION
### Description

Improve bash checking in test_finder.sh for all OSes

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/4370#issuecomment-1928454267

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
