### PR TITLE
fixed failed discover app shared links tests

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
@@ -26,7 +26,6 @@ const indexSet = [
 
 describe('shared links', () => {
   before(() => {
-    CURRENT_TENANT.newTenant = 'global';
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.mappings.json.txt'
     );
@@ -45,16 +44,19 @@ describe('shared links', () => {
     cy.setAdvancedSetting({
       defaultIndex: 'logstash-*',
     });
-
-    miscUtils.visitPage('app/data-explorer/discover#/');
-    cy.waitForLoader();
-    cy.setTopNavDate(DE_DEFAULT_START_TIME, DE_DEFAULT_END_TIME);
-    cy.waitForSearch();
   });
 
   describe('shared links with state in query', () => {
+    beforeEach(() => {
+      CURRENT_TENANT.newTenant = 'global';
+      miscUtils.visitPage('app/data-explorer/discover#/');
+      cy.waitForLoader();
+      cy.setTopNavDate(DE_DEFAULT_START_TIME, DE_DEFAULT_END_TIME);
+      cy.waitForSearch();
+    });
+
     it('should allow for copying the snapshot URL', function () {
-      const url = `http://localhost:5601/app/data-explorer/discover#/?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'logstash-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))&_q=(filters:!(),query:(language:kuery,query:''))`;
+      const url = `http://localhost:5601/app/data-explorer/discover?security_tenant=global#/?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'logstash-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))&_q=(filters:!(),query:(language:kuery,query:''))`;
       cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
       cy.getElementByTestId('copyShareUrlButton')
         .invoke('attr', 'data-share-url')
@@ -66,6 +68,7 @@ describe('shared links', () => {
     });
 
     it('should allow for copying the snapshot URL as a short URL', function () {
+      cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
       cy.getElementByTestId('useShortUrl')
         .should('be.visible')
         .invoke('attr', 'aria-checked', 'true');
@@ -76,9 +79,11 @@ describe('shared links', () => {
     });
 
     it('should allow for copying the saved object URL', function () {
-      const url =
-        'http://localhost:5601/app/data-explorer/discover/#/view/ab12e3c0-f231-11e6-9486-733b1ac9221a?_g=%28filters%3A%21%28%29%2CrefreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2Ctime%3A%28from%3A%272015-09-19T13%3A31%3A44.000Z%27%2Cto%3A%272015-09-24T01%3A31%3A44.000Z%27%29%29';
+      const url = decodeURI(
+        'http://localhost:5601/app/data-explorer/discover/#/view/ab12e3c0-f231-11e6-9486-733b1ac9221a?_g=%28filters%3A%21%28%29%2CrefreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2Ctime%3A%28from%3A%272015-09-19T13%3A31%3A44.000Z%27%2Cto%3A%272015-09-24T01%3A31%3A44.000Z%27%29%29'
+      );
 
+      cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
       cy.getElementByTestId('exportAsSavedObject')
         .get('.euiRadio__input')
         .should('be.disabled');
@@ -103,7 +108,10 @@ describe('shared links', () => {
       cy.setAdvancedSetting({
         'state:storeInSessionStorage': true,
       });
+    });
 
+    beforeEach(() => {
+      CURRENT_TENANT.newTenant = 'global';
       miscUtils.visitPage('app/data-explorer/discover#/');
       cy.waitForLoader();
       cy.setTopNavDate(DE_DEFAULT_START_TIME, DE_DEFAULT_END_TIME);
@@ -127,6 +135,7 @@ describe('shared links', () => {
     });
 
     it('should allow for copying the snapshot URL as a short URL', function () {
+      cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
       cy.getElementByTestId('useShortUrl').should('be.visible').click();
       cy.getElementByTestId('copyShareUrlButton')
         .invoke('attr', 'data-share-url')
@@ -137,6 +146,7 @@ describe('shared links', () => {
     });
 
     it('should allow for copying the saved object URL', function () {
+      cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
       cy.getElementByTestId('exportAsSavedObject')
         .get('.euiRadio__input')
         .should('be.disabled');


### PR DESCRIPTION
1. refactor so that each test case is independent from each other
2. use decodeURI to make url consistent so that the url matches

### Description

this PR fixed the 3 failed tests of `cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js`

```
  shared links
    shared links with state in query
      1) should allow for copying the snapshot URL
      ✓ should allow for copying the snapshot URL as a short URL
      2) should allow for copying the saved object URL
    shared links with state in sessionStorage
      ✓ should allow for copying the snapshot URL (12854ms)
      ✓ should allow for copying the snapshot URL as a short URL
      3) should allow for copying the saved object URL


  3 passing (4m)
  3 failing

  1) shared links
       shared links with state in query
         should allow for copying the snapshot URL:

      Timed out retrying after 60000ms
      + expected - actual

      -'http://localhost:5601/app/data-explorer/discover?security_tenant=global#/?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:\'logstash-*\',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:\'2015-09-19T04:31:44.000Z\',to:\'2015-09-23T16:31:44.000Z\'))&_q=(filters:!(),query:(language:kuery,query:\'\'))'
      +'http://localhost:5601/app/data-explorer/discover#/?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:\'logstash-*\',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:\'2015-09-19T13:31:44.000Z\',to:\'2015-09-24T01:31:44.000Z\'))&_q=(filters:!(),query:(language:kuery,query:\'\'))'
      
      at Context.eval (http://localhost:5601/__cypress/tests?p=cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js:187:84)

  2) shared links
       shared links with state in query
         should allow for copying the saved object URL:
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `[data-test-subj="savedObjectTitleA-Saved-Search"]`, but never found it.
      at Context.eval (http://localhost:5601/__cypress/tests?p=cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js:473:13)

  3) shared links
       shared links with state in sessionStorage
         should allow for copying the saved object URL:
     AssertionError: Timed out retrying after 60000ms: Expected to find element: `[data-test-subj="savedObjectTitleA-Saved-Search"]`, but never found it.
      at Context.eval (http://localhost:5601/__cypress/tests?p=cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js:473:13)
```

[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
