### PR TITLE
Fix in-context reporting tests

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -115,7 +115,7 @@ describe('Test reporting integration if plugin installed', () => {
     cy.get('button.euiContextMenuItem:nth-child(1)')
       .contains('Download PDF')
       .click();
-    cy.get('#downloadInProgressLoadingModal').should('exist');
+    cy.get('#downloadInProgressLoadingModal').should('not.exist');
   });
 
   it('Create in-context PNG report from notebook', () => {
@@ -123,7 +123,7 @@ describe('Test reporting integration if plugin installed', () => {
     cy.get('button.euiContextMenuItem:nth-child(2)')
       .contains('Download PNG')
       .click();
-    cy.get('#downloadInProgressLoadingModal').should('exist');
+    cy.get('#downloadInProgressLoadingModal').should('not.exist');
   });
 
   it('Create on-demand report definition from context menu', () => {

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -115,9 +115,7 @@ describe('Test reporting integration if plugin installed', () => {
     cy.get('button.euiContextMenuItem:nth-child(1)')
       .contains('Download PDF')
       .click();
-    cy.get('body').should.contains(
-      'Please continue report generation in the new tab'
-    );
+    cy.get('body').contains('Please continue report generation in the new tab');
   });
 
   it('Create in-context PNG report from notebook', () => {
@@ -125,9 +123,7 @@ describe('Test reporting integration if plugin installed', () => {
     cy.get('button.euiContextMenuItem:nth-child(2)')
       .contains('Download PNG')
       .click();
-    cy.get('body').should.contains(
-      'Please continue report generation in the new tab'
-    );
+    cy.get('body').contains('Please continue report generation in the new tab');
   });
 
   it('Create on-demand report definition from context menu', () => {

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -115,7 +115,9 @@ describe('Test reporting integration if plugin installed', () => {
     cy.get('button.euiContextMenuItem:nth-child(1)')
       .contains('Download PDF')
       .click();
-    cy.get('#downloadInProgressLoadingModal').should('not.exist');
+    cy.get('body').should.contains(
+      'Please continue report generation in the new tab'
+    );
   });
 
   it('Create in-context PNG report from notebook', () => {
@@ -123,7 +125,9 @@ describe('Test reporting integration if plugin installed', () => {
     cy.get('button.euiContextMenuItem:nth-child(2)')
       .contains('Download PNG')
       .click();
-    cy.get('#downloadInProgressLoadingModal').should('not.exist');
+    cy.get('body').should.contains(
+      'Please continue report generation in the new tab'
+    );
   });
 
   it('Create on-demand report definition from context menu', () => {


### PR DESCRIPTION
### Description

When checking for a reporting download being triggered, the tests are waiting for a loading screen. This causes test failures if the download happens faster than React renders. In one test run, the test failed when the API returned in 18 ms (whereas a passing test in the same run had a return time of 224 ms). This PR updates the tests to instead check for the success toast.

### Issues Resolved

N/A

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
