### PR TITLE
Increase delay times in gantt charts

### DIFF
--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -61,7 +61,7 @@ describe('Save a gantt chart', () => {
   });
 
   it('Creates and saves a gantt chart', () => {
-    cy.contains('Create ').click({ force: true });
+    cy.get('.euiButton__text').contains('Create ').click({ force: true });
     cy.wait(delay);
     cy.get('[data-test-subj="visTypeTitle"]')
       .contains('Gantt Chart')

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -61,7 +61,7 @@ describe('Save a gantt chart', () => {
   });
 
   it('Creates and saves a gantt chart', () => {
-    cy.contains('Create visualization').click({ force: true });
+    cy.contains('Create ').click({ force: true });
     cy.wait(delay);
     cy.get('[data-test-subj="visTypeTitle"]')
       .contains('Gantt Chart')

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -11,7 +11,7 @@ import { BASE_PATH } from '../../../utils/constants';
 
 dayjs.extend(customParseFormat);
 
-const delay = 100;
+const delay = 5000;
 const GANTT_VIS_NAME =
   'A test gantt chart ' + Math.random().toString(36).substring(2);
 const Y_LABEL = 'A unique label for Y-axis';
@@ -57,10 +57,11 @@ describe('Dump test data', () => {
 describe('Save a gantt chart', () => {
   beforeEach(() => {
     cy.visit(`${BASE_PATH}/app/visualize#`);
+    cy.wait(delay);
   });
 
   it('Creates and saves a gantt chart', () => {
-    cy.get('.euiButton__text').contains('Create ').click({ force: true });
+    cy.contains('Create visualization').click({ force: true });
     cy.wait(delay);
     cy.get('[data-test-subj="visTypeTitle"]')
       .contains('Gantt Chart')
@@ -83,8 +84,10 @@ describe('Save a gantt chart', () => {
 
 describe('Render and configure a gantt chart', () => {
   beforeEach(() => {
+    cy.wait(delay);
     cy.visit(`${BASE_PATH}/app/visualize#`);
     cy.contains(GANTT_VIS_NAME).click({ force: true });
+    cy.wait(delay);
   });
 
   it('Renders no data message', () => {
@@ -114,7 +117,7 @@ describe('Render and configure a gantt chart', () => {
     cy.wait(delay);
 
     cy.get('.traces').should('have.length', DEFAULT_SIZE);
-
+    cy.wait(delay);
     cy.get('.euiButton__text').contains('Save').click({ force: true });
     cy.wait(delay);
     cy.get('button[data-test-subj="confirmSaveSavedObjectButton"]').click({
@@ -128,6 +131,7 @@ describe('Configure panel settings', () => {
     cy.visit(`${BASE_PATH}/app/visualize#`);
     cy.contains(GANTT_VIS_NAME).click({ force: true });
     cy.contains('Panel settings').click({ force: true });
+    cy.wait(delay);
   });
 
   it('Changes y-axis label', () => {
@@ -244,7 +248,7 @@ describe('Configure panel settings', () => {
 describe('Add gantt chart to dashboard', () => {
   it('Adds gantt chart to dashboard', () => {
     cy.visit(`${BASE_PATH}/app/dashboards#/create`);
-
+    cy.wait(delay);
     cy.contains('Add an existing').click({ force: true });
     cy.wait(delay);
     cy.get('input[data-test-subj="savedObjectFinderSearchInput"]')


### PR DESCRIPTION
### Description

Increase delay times in gantt charts. This solves the tests not working as expected in environments where UI takes more time to load especially when security plugin is enabled.

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/914

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
