### PR TITLE
[Security Analytics] Add force type option to avoid element getting covered error

### DIFF
--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/2_rules.spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/2_rules.spec.js
@@ -516,7 +516,7 @@ describe('Rules', () => {
       );
       toastShouldExist();
       getSelectionPanelByIndex(0).within(() =>
-        getMapValueField().type('FieldValue')
+        getMapValueField().type('FieldValue', { force: true })
       );
 
       // selection map list field
@@ -527,7 +527,7 @@ describe('Rules', () => {
       toastShouldExist();
       getSelectionPanelByIndex(0).within(() => {
         getListRadioField().click({ force: true });
-        getMapListField().type('FieldValue');
+        getMapListField().type('FieldValue', { force: true });
       });
 
       // tags field


### PR DESCRIPTION
### Description
Detection text area gets covered by the breadcrumbs element due to which cypress throws when trying to type. Adding `force` option to avoid throwing error since it doesn't affect the behavior.

### Issues Resolved
https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/857

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
