### PR TITLE
[Backport 2.x] Increased timeout thresholds for alerting cypress tests to reduce flakiness when running on slow domains. #1093

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/acknowledge_alerts_modal_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/acknowledge_alerts_modal_spec.js
@@ -6,6 +6,7 @@
 import {
   ALERTING_INDEX,
   ALERTING_PLUGIN_NAME,
+  ALERTING_PLUGIN_TIMEOUT,
 } from '../../../utils/plugins/alerting-dashboards-plugin/constants';
 import sampleAlertsFlyoutBucketMonitor from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_alerts_flyout_bucket_level_monitor.json';
 import sampleAlertsFlyoutQueryMonitor from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_alerts_flyout_query_level_monitor.json';
@@ -15,8 +16,6 @@ const BUCKET_MONITOR = 'sample_alerts_flyout_bucket_level_monitor';
 const BUCKET_TRIGGER = 'sample_alerts_flyout_bucket_level_trigger';
 const QUERY_MONITOR = 'sample_alerts_flyout_query_level_monitor';
 const QUERY_TRIGGER = 'sample_alerts_flyout_query_level_trigger';
-
-const TWENTY_SECONDS = 20000;
 
 describe('AcknowledgeAlertsModal', () => {
   before(() => {
@@ -34,8 +33,8 @@ describe('AcknowledgeAlertsModal', () => {
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/monitors`);
 
     // Confirm test monitors were created successfully
-    cy.contains(BUCKET_MONITOR, { timeout: TWENTY_SECONDS });
-    cy.contains(QUERY_MONITOR, { timeout: TWENTY_SECONDS });
+    cy.contains(BUCKET_MONITOR, { timeout: ALERTING_PLUGIN_TIMEOUT });
+    cy.contains(QUERY_MONITOR, { timeout: ALERTING_PLUGIN_TIMEOUT });
 
     // Wait 1 minute for the test monitors to trigger alerts, then go to the 'Alerts by trigger' dashboard page to view alerts
     cy.wait(60000);
@@ -46,8 +45,8 @@ describe('AcknowledgeAlertsModal', () => {
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/dashboard`);
 
     // Confirm dashboard is displaying rows for the test monitors.
-    cy.contains(BUCKET_MONITOR, { timeout: TWENTY_SECONDS });
-    cy.contains(QUERY_MONITOR, { timeout: TWENTY_SECONDS });
+    cy.contains(BUCKET_MONITOR, { timeout: ALERTING_PLUGIN_TIMEOUT });
+    cy.contains(QUERY_MONITOR, { timeout: ALERTING_PLUGIN_TIMEOUT });
   });
 
   it('Acknowledge button disabled when more than 1 trigger selected', () => {
@@ -55,7 +54,7 @@ describe('AcknowledgeAlertsModal', () => {
     cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Active');
 
     // Confirm the 'Alerts by trigger' dashboard contains more than 1 row.
-    cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+    cy.get('tbody > tr', { timeout: ALERTING_PLUGIN_TIMEOUT }).should(($tr) =>
       expect($tr).to.have.length.greaterThan(1)
     );
 
@@ -72,7 +71,7 @@ describe('AcknowledgeAlertsModal', () => {
     cy.get(`input[type="search"]`).focus().type(BUCKET_TRIGGER);
 
     // Confirm the dashboard is displaying only 1 row.
-    cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+    cy.get('tbody > tr', { timeout: ALERTING_PLUGIN_TIMEOUT }).should(($tr) =>
       expect($tr).to.have.length(1)
     );
 
@@ -95,18 +94,18 @@ describe('AcknowledgeAlertsModal', () => {
 
         // This monitor configuration consistently returns 46 alerts when testing locally.
         // Confirm the modal dashboard contains more than 1 ACTIVE alert.
-        cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
-          expect($tr).to.have.length.greaterThan(1)
+        cy.get('tbody > tr', { timeout: ALERTING_PLUGIN_TIMEOUT }).should(
+          ($tr) => expect($tr).to.have.length.greaterThan(1)
         );
 
         // Select the first and last alerts in the table.
         cy.get('input[data-test-subj^="checkboxSelectRow-"]', {
-          timeout: TWENTY_SECONDS,
+          timeout: ALERTING_PLUGIN_TIMEOUT,
         })
           .first()
           .click();
         cy.get('input[data-test-subj^="checkboxSelectRow-"]', {
-          timeout: TWENTY_SECONDS,
+          timeout: ALERTING_PLUGIN_TIMEOUT,
         })
           .last()
           .click();
@@ -130,8 +129,8 @@ describe('AcknowledgeAlertsModal', () => {
         );
 
         // Confirm the table displays 2 acknowledged alerts.
-        cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
-          expect($tr).to.have.length(2)
+        cy.get('tbody > tr', { timeout: ALERTING_PLUGIN_TIMEOUT }).should(
+          ($tr) => expect($tr).to.have.length(2)
         );
       }
     );
@@ -150,7 +149,7 @@ describe('AcknowledgeAlertsModal', () => {
     cy.get(`input[type="search"]`).focus().type(QUERY_TRIGGER);
 
     // Confirm the dashboard is displaying only 1 row.
-    cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
+    cy.get('tbody > tr', { timeout: ALERTING_PLUGIN_TIMEOUT }).should(($tr) =>
       expect($tr).to.have.length(1)
     );
 
@@ -172,8 +171,8 @@ describe('AcknowledgeAlertsModal', () => {
         cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Active');
 
         // Confirm the modal dashboard contains 1 alert.
-        cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
-          expect($tr).to.have.length(1)
+        cy.get('tbody > tr', { timeout: ALERTING_PLUGIN_TIMEOUT }).should(
+          ($tr) => expect($tr).to.have.length(1)
         );
 
         // Select the alert.
@@ -198,8 +197,8 @@ describe('AcknowledgeAlertsModal', () => {
         );
 
         // Confirm the table displays 1 acknowledged alert.
-        cy.get('tbody > tr', { timeout: TWENTY_SECONDS }).should(($tr) =>
-          expect($tr).to.have.length(1)
+        cy.get('tbody > tr', { timeout: ALERTING_PLUGIN_TIMEOUT }).should(
+          ($tr) => expect($tr).to.have.length(1)
         );
       }
     );

--- a/cypress/integration/plugins/alerting-dashboards-plugin/alert_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/alert_spec.js
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ALERTING_PLUGIN_NAME } from '../../../utils/plugins/alerting-dashboards-plugin/constants';
+import {
+  ALERTING_PLUGIN_NAME,
+  ALERTING_PLUGIN_TIMEOUT,
+} from '../../../utils/plugins/alerting-dashboards-plugin/constants';
 import sampleQueryLevelMonitorWithAlwaysTrueTrigger from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_query_level_monitor_with_always_true_trigger';
 import sampleQueryLevelMonitorWorkflow from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_query_level_monitor_workflow';
 import { BASE_PATH } from '../../../utils/base_constants';
@@ -19,7 +22,7 @@ describe('Alerts', () => {
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/dashboard`);
 
     // Common text to wait for to confirm page loaded, give up to 30 seconds for initial load
-    cy.contains('Acknowledge', { timeout: 30000 });
+    cy.contains('Acknowledge', { timeout: ALERTING_PLUGIN_TIMEOUT });
   });
 
   describe("can be in 'Active' state", () => {

--- a/cypress/integration/plugins/alerting-dashboards-plugin/alerts_dashboard_flyout_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/alerts_dashboard_flyout_spec.js
@@ -6,6 +6,7 @@
 import {
   ALERTING_INDEX,
   ALERTING_PLUGIN_NAME,
+  ALERTING_PLUGIN_TIMEOUT,
 } from '../../../utils/plugins/alerting-dashboards-plugin/constants';
 import sampleAlertsFlyoutBucketMonitor from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_alerts_flyout_bucket_level_monitor.json';
 import sampleAlertsFlyoutQueryMonitor from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_alerts_flyout_query_level_monitor.json';
@@ -44,8 +45,8 @@ describe('Alerts by trigger flyout', () => {
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/monitors`);
 
     // Confirm test monitors were created successfully
-    cy.contains(BUCKET_MONITOR_NAME);
-    cy.contains(QUERY_MONITOR_NAME);
+    cy.contains(BUCKET_MONITOR_NAME, { timeout: ALERTING_PLUGIN_TIMEOUT });
+    cy.contains(QUERY_MONITOR_NAME, { timeout: ALERTING_PLUGIN_TIMEOUT });
 
     // Wait 1 minutes for the test monitors to trigger alerts,
     // then go to the 'Alerts by trigger' dashboard page to view alerts
@@ -57,8 +58,8 @@ describe('Alerts by trigger flyout', () => {
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/dashboard`);
 
     // Confirm dashboard is displaying rows for the test monitors.
-    cy.contains(BUCKET_MONITOR_NAME);
-    cy.contains(QUERY_MONITOR_NAME);
+    cy.contains(BUCKET_MONITOR_NAME, { timeout: ALERTING_PLUGIN_TIMEOUT });
+    cy.contains(QUERY_MONITOR_NAME, { timeout: ALERTING_PLUGIN_TIMEOUT });
 
     // Waiting 5 seconds for alerts to finish loading.
     // This short wait period alleviates flakiness observed during these tests.
@@ -67,91 +68,144 @@ describe('Alerts by trigger flyout', () => {
 
   it('Bucket-level monitor flyout test', () => {
     // Click the link for the flyout.
-    cy.get(`[data-test-subj="euiLink_${BUCKET_TRIGGER}"]`).click();
+    cy.get(`[data-test-subj="euiLink_${BUCKET_TRIGGER}"]`, {
+      timeout: ALERTING_PLUGIN_TIMEOUT,
+    }).click();
 
     // Perform the test checks within the flyout component.
-    cy.get(`[data-test-subj="alertsDashboardFlyout_${BUCKET_TRIGGER}"]`).within(
-      () => {
-        // Confirm flyout header contains expected text.
-        cy.get(
-          `[data-test-subj="alertsDashboardFlyout_header_${BUCKET_TRIGGER}"]`
-        ).contains(`Alerts by ${BUCKET_TRIGGER}`);
+    cy.get(`[data-test-subj="alertsDashboardFlyout_${BUCKET_TRIGGER}"]`, {
+      timeout: ALERTING_PLUGIN_TIMEOUT,
+    }).within(() => {
+      // Confirm flyout header contains expected text.
+      cy.get(
+        `[data-test-subj="alertsDashboardFlyout_header_${BUCKET_TRIGGER}"]`,
+        { timeout: ALERTING_PLUGIN_TIMEOUT }
+      ).contains(`Alerts by ${BUCKET_TRIGGER}`, {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
 
-        // Confirm 'Trigger name' sections renders as expected.
-        cy.get(
-          `[data-test-subj="alertsDashboardFlyout_triggerName_${BUCKET_TRIGGER}"]`
-        ).as('triggerName');
-        cy.get('@triggerName').contains('Trigger name');
-        cy.get('@triggerName').contains(BUCKET_TRIGGER);
+      // Confirm 'Trigger name' sections renders as expected.
+      cy.get(
+        `[data-test-subj="alertsDashboardFlyout_triggerName_${BUCKET_TRIGGER}"]`,
+        { timeout: ALERTING_PLUGIN_TIMEOUT }
+      ).as('triggerName');
+      cy.get('@triggerName').contains('Trigger name', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
+      cy.get('@triggerName').contains(BUCKET_TRIGGER, {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
 
-        // Confirm 'Severity' sections renders as expected.
-        cy.get(
-          `[data-test-subj="alertsDashboardFlyout_severity_${BUCKET_TRIGGER}"]`
-        ).as('severity');
-        cy.get('@severity').contains('Severity');
-        cy.get('@severity').contains('4 (Low)');
+      // Confirm 'Severity' sections renders as expected.
+      cy.get(
+        `[data-test-subj="alertsDashboardFlyout_severity_${BUCKET_TRIGGER}"]`,
+        { timeout: ALERTING_PLUGIN_TIMEOUT }
+      ).as('severity');
+      cy.get('@severity', { timeout: ALERTING_PLUGIN_TIMEOUT }).contains(
+        'Severity',
+        { timeout: ALERTING_PLUGIN_TIMEOUT }
+      );
+      cy.get('@severity', { timeout: ALERTING_PLUGIN_TIMEOUT }).contains(
+        '4 (Low)',
+        { timeout: ALERTING_PLUGIN_TIMEOUT }
+      );
 
-        // Confirm 'Monitor' sections renders as expected.
-        cy.get(
-          `[data-test-subj="alertsDashboardFlyout_monitor_${BUCKET_TRIGGER}"]`
-        ).as('monitor');
-        cy.get('@monitor').contains('Monitor');
-        cy.get('@monitor').contains(BUCKET_MONITOR_NAME);
+      // Confirm 'Monitor' sections renders as expected.
+      cy.get(
+        `[data-test-subj="alertsDashboardFlyout_monitor_${BUCKET_TRIGGER}"]`
+      ).as('monitor');
+      cy.get('@monitor').contains('Monitor', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
+      cy.get('@monitor').contains(BUCKET_MONITOR_NAME, {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
 
-        // Confirm 'Conditions' sections renders as expected.
-        cy.get(
-          `[data-test-subj="alertsDashboardFlyout_conditions_${BUCKET_TRIGGER}"]`
-        ).as('conditions');
-        cy.get('@conditions').contains('Conditions');
+      // Confirm 'Conditions' sections renders as expected.
+      cy.get(
+        `[data-test-subj="alertsDashboardFlyout_conditions_${BUCKET_TRIGGER}"]`
+      ).as('conditions');
+      cy.get('@conditions').contains('Conditions', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
 
-        // Confirm the 'Conditions' sections renders with all of the expected conditions.
-        [
-          'params._count < 10000',
-          'OR',
-          'params.avg_products_price == 10',
-        ].forEach((entry) => cy.get('@conditions').contains(entry));
+      // Confirm the 'Conditions' sections renders with all of the expected conditions.
+      [
+        'params._count < 10000',
+        'OR',
+        'params.avg_products_price == 10',
+      ].forEach((entry) =>
+        cy
+          .get('@conditions')
+          .contains(entry, { timeout: ALERTING_PLUGIN_TIMEOUT })
+      );
 
-        // Confirm 'Time range for the last' sections renders as expected.
-        cy.get(
-          `[data-test-subj="alertsDashboardFlyout_timeRange_${BUCKET_TRIGGER}"]`
-        ).as('timeRange');
-        cy.get('@timeRange').contains('Time range for the last');
-        cy.get('@timeRange').contains('10 day(s)');
+      // Confirm 'Time range for the last' sections renders as expected.
+      cy.get(
+        `[data-test-subj="alertsDashboardFlyout_timeRange_${BUCKET_TRIGGER}"]`
+      ).as('timeRange');
+      cy.get('@timeRange').contains('Time range for the last', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
+      cy.get('@timeRange').contains('10 day(s)', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
 
-        // Confirm 'Filters' sections renders as expected.
-        cy.get(
-          `[data-test-subj="alertsDashboardFlyout_filters_${BUCKET_TRIGGER}"]`
-        ).as('filters');
-        cy.get('@filters').contains('Filters');
-        cy.get('@filters').contains('All fields are included');
+      // Confirm 'Filters' sections renders as expected.
+      cy.get(
+        `[data-test-subj="alertsDashboardFlyout_filters_${BUCKET_TRIGGER}"]`
+      ).as('filters');
+      cy.get('@filters').contains('Filters', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
+      cy.get('@filters').contains('All fields are included', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
 
-        // Confirm 'Group by' sections renders as expected.
-        cy.get(
-          `[data-test-subj="alertsDashboardFlyout_groupBy_${BUCKET_TRIGGER}"]`
-        ).as('groupBy');
-        cy.get('@groupBy').contains('Group by');
-        cy.get('@groupBy').contains('customer_gender, user');
+      // Confirm 'Group by' sections renders as expected.
+      cy.get(
+        `[data-test-subj="alertsDashboardFlyout_groupBy_${BUCKET_TRIGGER}"]`
+      ).as('groupBy');
+      cy.get('@groupBy').contains('Group by', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
+      cy.get('@groupBy').contains('customer_gender, user', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      });
 
-        // Set the 'severity' filter to only display ACTIVE alerts.
-        cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Active');
+      // Set the 'severity' filter to only display ACTIVE alerts.
+      cy.get('[data-test-subj="dashboardAlertStateFilter"]', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      }).select('Active');
 
-        // This monitor configuration consistently returns 46 alerts when testing locally.
-        // Confirm the flyout dashboard contains more than 1 ACTIVE alert.
-        cy.get('tbody > tr').should(($tr) =>
-          expect($tr).to.have.length.greaterThan(1)
-        );
+      // This monitor configuration consistently returns 46 alerts when testing locally.
+      // Confirm the flyout dashboard contains more than 1 ACTIVE alert.
+      cy.get('tbody > tr').should(($tr) =>
+        expect($tr).to.have.length.greaterThan(1)
+      );
 
-        // Select the first and last alerts in the table.
-        cy.get('input[data-test-subj^="checkboxSelectRow-"]').first().click();
-        cy.get('input[data-test-subj^="checkboxSelectRow-"]').last().click();
+      // Select the first and last alerts in the table.
+      cy.get('input[data-test-subj^="checkboxSelectRow-"]', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      })
+        .first()
+        .click();
+      cy.get('input[data-test-subj^="checkboxSelectRow-"]', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      })
+        .last()
+        .click();
 
-        // Press the flyout 'Acknowledge button, and wait for the AcknowledgeAlerts API call to complete.
-        cy.get('[data-test-subj="flyoutAcknowledgeAlertsButton"]').click();
-      }
-    );
+      // Press the flyout 'Acknowledge button, and wait for the AcknowledgeAlerts API call to complete.
+      cy.get('[data-test-subj="flyoutAcknowledgeAlertsButton"]', {
+        timeout: ALERTING_PLUGIN_TIMEOUT,
+      }).click();
+    });
 
     // Confirm acknowledge alerts toast displays expected text.
-    cy.contains('Successfully acknowledged 2 alerts.');
+    cy.contains('Successfully acknowledged 2 alerts.', {
+      timeout: ALERTING_PLUGIN_TIMEOUT,
+    });
 
     // Confirm alerts were acknowledged as expected.
     cy.get(`[data-test-subj="alertsDashboardFlyout_${BUCKET_TRIGGER}"]`).within(
@@ -185,58 +239,85 @@ describe('Alerts by trigger flyout', () => {
         // Confirm flyout header contains expected text.
         cy.get(
           `[data-test-subj="alertsDashboardFlyout_header_${QUERY_TRIGGER}"]`
-        ).contains(`Alerts by ${QUERY_TRIGGER}`);
+        ).contains(`Alerts by ${QUERY_TRIGGER}`, {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
 
         // Confirm 'Trigger name' sections renders as expected.
         cy.get(
           `[data-test-subj="alertsDashboardFlyout_triggerName_${QUERY_TRIGGER}"]`
         ).as('triggerName');
-        cy.get('@triggerName').contains('Trigger name');
-        cy.get('@triggerName').contains(QUERY_TRIGGER);
+        cy.get('@triggerName').contains('Trigger name', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
+        cy.get('@triggerName').contains(QUERY_TRIGGER, {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
 
         // Confirm 'Severity' sections renders as expected.
         cy.get(
           `[data-test-subj="alertsDashboardFlyout_severity_${QUERY_TRIGGER}"]`
         ).as('severity');
-        cy.get('@severity').contains('Severity');
-        cy.get('@severity').contains('2 (High)');
+        cy.get('@severity').contains('Severity', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
+        cy.get('@severity').contains('2 (High)', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
 
         // Confirm 'Monitor' sections renders as expected.
         cy.get(
           `[data-test-subj="alertsDashboardFlyout_monitor_${QUERY_TRIGGER}"]`
         ).as('monitor');
-        cy.get('@monitor').contains('Monitor');
-        cy.get('@monitor').contains(QUERY_MONITOR_NAME);
+        cy.get('@monitor').contains('Monitor', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
+        cy.get('@monitor').contains(QUERY_MONITOR_NAME, {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
 
         // Confirm 'Conditions' sections renders as expected.
         cy.get(
           `[data-test-subj="alertsDashboardFlyout_conditions_${QUERY_TRIGGER}"]`
         ).as('conditions');
-        cy.get('@conditions').contains('Condition');
+        cy.get('@conditions').contains('Condition', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
         cy.get('@conditions').contains(
-          `ctx.results[0].hits.total.value < 10000`
+          `ctx.results[0].hits.total.value < 10000`,
+          { timeout: ALERTING_PLUGIN_TIMEOUT }
         );
 
         // Confirm 'Time range for the last' sections renders as expected.
         cy.get(
           `[data-test-subj="alertsDashboardFlyout_timeRange_${QUERY_TRIGGER}"]`
         ).as('timeRange');
-        cy.get('@timeRange').contains('Time range for the last');
-        cy.get('@timeRange').contains('10 day(s)');
+        cy.get('@timeRange').contains('Time range for the last', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
+        cy.get('@timeRange').contains('10 day(s)', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
 
         // Confirm 'Filters' sections renders as expected.
         cy.get(
           `[data-test-subj="alertsDashboardFlyout_filters_${QUERY_TRIGGER}"]`
         ).as('filters');
-        cy.get('@filters').contains('Filters');
-        cy.get('@filters').contains('-');
+        cy.get('@filters').contains('Filters', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
+        cy.get('@filters').contains('-', { timeout: ALERTING_PLUGIN_TIMEOUT });
 
         // Confirm 'Group by' sections renders as expected.
         cy.get(
           `[data-test-subj="alertsDashboardFlyout_groupBy_${QUERY_TRIGGER}"]`
         ).as('groupBy');
-        cy.get('@groupBy').contains('Group by');
-        cy.get('@groupBy').contains('user');
+        cy.get('@groupBy').contains('Group by', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
+        cy.get('@groupBy').contains('user', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        });
 
         // Set the 'severity' filter to only display ACTIVE alerts.
         cy.get('[data-test-subj="dashboardAlertStateFilter"]').select('Active');

--- a/cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js
@@ -6,6 +6,7 @@
 import {
   ALERTING_INDEX,
   ALERTING_PLUGIN_NAME,
+  ALERTING_PLUGIN_TIMEOUT,
 } from '../../../utils/plugins/alerting-dashboards-plugin/constants';
 import sampleAggregationQuery from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_aggregation_query';
 import sampleVisualEditorMonitor from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_visual_editor_bucket_level_monitor';
@@ -135,7 +136,7 @@ describe('Bucket-Level Monitors', () => {
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/monitors`);
 
     // Common text to wait for to confirm page loaded, give up to 20 seconds for initial load
-    cy.contains('Create monitor', { timeout: 20000 });
+    cy.contains('Create monitor', { timeout: ALERTING_PLUGIN_TIMEOUT });
   });
 
   describe('can be created', () => {
@@ -177,7 +178,7 @@ describe('Bucket-Level Monitors', () => {
             force: true,
             parseSpecialCharSequences: false,
             delay: 5,
-            timeout: 20000,
+            timeout: ALERTING_PLUGIN_TIMEOUT,
           })
           .trigger('blur', { force: true });
       });
@@ -352,20 +353,20 @@ describe('Bucket-Level Monitors', () => {
 
         // Confirm Index field only contains the expected text
         cy.get('[data-test-subj="indicesComboBox"]').contains('*', {
-          timeout: 20000,
+          timeout: ALERTING_PLUGIN_TIMEOUT,
         });
         cy.get('[data-test-subj="indicesComboBox"]').contains(TESTING_INDEX_A, {
-          timeout: 20000,
+          timeout: ALERTING_PLUGIN_TIMEOUT,
         });
         cy.get('[data-test-subj="indicesComboBox"]').contains(TESTING_INDEX_B, {
-          timeout: 20000,
+          timeout: ALERTING_PLUGIN_TIMEOUT,
         });
 
         // Click the update button
         cy.get('button').contains('Update').last().click({ force: true });
 
         // Confirm we're on the Monitor Details page by searching for the History element
-        cy.contains('History', { timeout: 20000 });
+        cy.contains('History', { timeout: ALERTING_PLUGIN_TIMEOUT });
       });
     });
   });

--- a/cypress/integration/plugins/alerting-dashboards-plugin/cluster_metrics_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/cluster_metrics_monitor_spec.js
@@ -8,6 +8,7 @@ import sampleClusterMetricsMonitor from '../../../fixtures/plugins/alerting-dash
 import {
   ALERTING_INDEX,
   ALERTING_PLUGIN_NAME,
+  ALERTING_PLUGIN_TIMEOUT,
 } from '../../../utils/plugins/alerting-dashboards-plugin/constants';
 import { BASE_PATH } from '../../../utils/base_constants';
 
@@ -28,7 +29,9 @@ const addClusterMetricsTrigger = (
   source
 ) => {
   // Click 'Add trigger' button
-  cy.contains('Add trigger', { timeout: 20000 }).click({ force: true });
+  cy.contains('Add trigger', { timeout: ALERTING_PLUGIN_TIMEOUT }).click({
+    force: true,
+  });
 
   if (isEdit === true) {
     // TODO: Passing button props in EUI accordion was added in newer versions (31.7.0+).
@@ -52,7 +55,7 @@ const addClusterMetricsTrigger = (
         force: true,
         parseSpecialCharSequences: false,
         delay: 5,
-        timeout: 20000,
+        timeout: ALERTING_PLUGIN_TIMEOUT,
       })
       .trigger('blur', { force: true });
   });
@@ -91,7 +94,7 @@ describe('ClusterMetricsMonitor', () => {
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/monitors`);
 
     // Common text to wait for to confirm page loaded, give up to 20 seconds for initial load
-    cy.contains('Create monitor', { timeout: 20000 });
+    cy.contains('Create monitor', { timeout: ALERTING_PLUGIN_TIMEOUT });
   });
 
   describe('can be created', () => {
@@ -105,7 +108,9 @@ describe('ClusterMetricsMonitor', () => {
       cy.contains('There are no existing monitors');
 
       // Go to create monitor page
-      cy.contains('Create monitor', { timeout: 20000 }).click({ force: true });
+      cy.contains('Create monitor', { timeout: ALERTING_PLUGIN_TIMEOUT }).click(
+        { force: true }
+      );
 
       // Select ClusterMetrics radio card
       cy.get('[data-test-subj="clusterMetricsMonitorRadioCard"]').click({
@@ -237,7 +242,9 @@ describe('ClusterMetricsMonitor', () => {
       cy.contains('There are no existing monitors');
 
       // Go to create monitor page
-      cy.contains('Create monitor', { timeout: 20000 }).click({ force: true });
+      cy.contains('Create monitor', { timeout: ALERTING_PLUGIN_TIMEOUT }).click(
+        { force: true }
+      );
 
       // Select ClusterMetrics radio card
       cy.get('[data-test-subj="clusterMetricsMonitorRadioCard"]').click({
@@ -406,7 +413,7 @@ describe('ClusterMetricsMonitor', () => {
         );
 
         // Confirm there are 0 triggers defined
-        cy.contains('Triggers (0)', { timeout: 20000 });
+        cy.contains('Triggers (0)', { timeout: ALERTING_PLUGIN_TIMEOUT });
       });
     });
   });

--- a/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js
@@ -6,6 +6,7 @@
 import {
   ALERTING_API,
   ALERTING_PLUGIN_NAME,
+  ALERTING_PLUGIN_TIMEOUT,
 } from '../../../utils/plugins/alerting-dashboards-plugin/constants';
 import sampleCompositeJson from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_composite_level_monitor.json';
 import * as _ from 'lodash';
@@ -54,8 +55,22 @@ describe('CompositeLevelMonitor', () => {
       // Visit Alerting OpenSearch Dashboards
       cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/monitors`);
 
+      // Confirm sample delegate monitors are present
+      cy.contains(
+        sampleCompositeJson.sample_composite_associated_monitor_1.name,
+        { timeout: ALERTING_PLUGIN_TIMEOUT }
+      );
+      cy.contains(
+        sampleCompositeJson.sample_composite_associated_monitor_2.name,
+        { timeout: ALERTING_PLUGIN_TIMEOUT }
+      );
+      cy.contains(
+        sampleCompositeJson.sample_composite_associated_monitor_3.name,
+        { timeout: ALERTING_PLUGIN_TIMEOUT }
+      );
+
       // Common text to wait for to confirm page loaded, give up to 20 seconds for initial load
-      cy.contains('Create monitor', { timeout: 20000 });
+      cy.contains('Create monitor', { timeout: ALERTING_PLUGIN_TIMEOUT });
 
       // Go to create monitor page
       cy.contains('Create monitor').click({ force: true });
@@ -76,17 +91,15 @@ describe('CompositeLevelMonitor', () => {
       });
 
       // Select associated monitors
-      cy.get('[id="associatedMonitorsList_0"]').type('monitorOne', {
-        delay: 50,
-        force: true,
-      });
-      cy.get('[title="monitorOne"]').click({ force: true });
+      cy.get('[id="associatedMonitorsList_0"]').type(
+        'monitorOne{downArrow}{enter}',
+        { delay: 200 }
+      );
 
-      cy.get('[id="associatedMonitorsList_1"]').type('monitorTwo', {
-        delay: 50,
-        force: true,
-      });
-      cy.get('[title="monitorTwo"]').click({ force: true });
+      cy.get('[id="associatedMonitorsList_1"]').type(
+        'monitorTwo{downArrow}{enter}',
+        { delay: 200 }
+      );
 
       cy.get('button').contains('Add trigger').click({ force: true });
 
@@ -156,18 +169,17 @@ describe('CompositeLevelMonitor', () => {
 
     it('by visual editor', () => {
       // Verify edit page
-      cy.contains('Edit monitor', { timeout: 20000 });
+      cy.contains('Edit monitor', { timeout: ALERTING_PLUGIN_TIMEOUT });
       cy.get('input[name="name"]').type('_edited');
 
       cy.get('label').contains('Visual editor').click({ force: true });
 
-      cy.get('button').contains('Add another monitor').click({ force: true });
+      cy.contains('Add another monitor').click();
 
-      cy.get('[id="associatedMonitorsList_2"]').type('monitorThree', {
-        delay: 50,
-        force: true,
-      });
-      cy.get('[title="monitorThree"]').click({ force: true });
+      cy.get('[id="associatedMonitorsList_2"]').type(
+        'monitorThree{downArrow}{enter}',
+        { delay: 200 }
+      );
 
       cy.get('button').contains('Composite trigger').click({ force: true });
 
@@ -185,8 +197,9 @@ describe('CompositeLevelMonitor', () => {
 
       // Wait for monitor to be created
       cy.wait('@updateMonitorRequest').then(() => {
+        cy.wait(5000);
         cy.contains(`${SAMPLE_VISUAL_EDITOR_MONITOR}_edited`, {
-          timeout: 5000,
+          timeout: ALERTING_PLUGIN_TIMEOUT,
         });
       });
     });

--- a/cypress/integration/plugins/alerting-dashboards-plugin/document_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/document_level_monitor_spec.js
@@ -4,7 +4,10 @@
  */
 
 import _ from 'lodash';
-import { ALERTING_PLUGIN_NAME } from '../../../utils/plugins/alerting-dashboards-plugin/constants';
+import {
+  ALERTING_PLUGIN_NAME,
+  ALERTING_PLUGIN_TIMEOUT,
+} from '../../../utils/plugins/alerting-dashboards-plugin/constants';
 import sampleDocumentLevelMonitor from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_document_level_monitor.json';
 import { BASE_PATH } from '../../../utils/base_constants';
 
@@ -117,7 +120,7 @@ describe('DocumentLevelMonitor', () => {
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/monitors`);
 
     // Common text to wait for to confirm page loaded, give up to 20 seconds for initial load
-    cy.contains('Create monitor', { timeout: 20000 });
+    cy.contains('Create monitor', { timeout: ALERTING_PLUGIN_TIMEOUT });
   });
 
   describe('can be created', () => {
@@ -163,7 +166,7 @@ describe('DocumentLevelMonitor', () => {
               force: true,
               parseSpecialCharSequences: false,
               delay: 5,
-              timeout: 20000,
+              timeout: ALERTING_PLUGIN_TIMEOUT,
             }
           )
           .trigger('blur', { force: true });
@@ -191,7 +194,7 @@ describe('DocumentLevelMonitor', () => {
               force: true,
               parseSpecialCharSequences: false,
               delay: 5,
-              timeout: 20000,
+              timeout: ALERTING_PLUGIN_TIMEOUT,
             }
           )
           .trigger('blur', { force: true });
@@ -421,7 +424,7 @@ describe('DocumentLevelMonitor', () => {
                   force: true,
                   parseSpecialCharSequences: false,
                   delay: 5,
-                  timeout: 20000,
+                  timeout: ALERTING_PLUGIN_TIMEOUT,
                 }
               )
               .trigger('blur', { force: true });
@@ -539,7 +542,9 @@ describe('DocumentLevelMonitor', () => {
         cy.contains('Edit').click({ force: true });
 
         // Remove the trigger from the monitor as it's not needed for this test case
-        cy.contains('Remove trigger', { timeout: 20000 }).click({
+        cy.contains('Remove trigger', {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        }).click({
           force: true,
         });
 
@@ -561,14 +566,14 @@ describe('DocumentLevelMonitor', () => {
           TESTING_INDEX_A
         );
         cy.get('[data-test-subj="indicesComboBox"]').contains(TESTING_INDEX_B, {
-          timeout: 20000,
+          timeout: ALERTING_PLUGIN_TIMEOUT,
         });
 
         // Click the update button
         cy.get('button').contains('Update').last().click({ force: true });
 
         // Confirm we're on the Monitor Details page by searching for the History element
-        cy.contains('History', { timeout: 20000 });
+        cy.contains('History', { timeout: ALERTING_PLUGIN_TIMEOUT });
       });
     });
   });

--- a/cypress/integration/plugins/alerting-dashboards-plugin/monitors_dashboard_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/monitors_dashboard_spec.js
@@ -6,6 +6,7 @@
 import {
   ALERTING_INDEX,
   ALERTING_PLUGIN_NAME,
+  ALERTING_PLUGIN_TIMEOUT,
 } from '../../../utils/plugins/alerting-dashboards-plugin/constants';
 import sampleAlertsFlyoutBucketMonitor from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_alerts_flyout_bucket_level_monitor.json';
 import sampleAlertsFlyoutQueryMonitor from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_alerts_flyout_query_level_monitor.json';
@@ -103,7 +104,7 @@ describe('Monitors dashboard page', () => {
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/monitors`);
 
     // Common text to wait for to confirm page loaded, give up to 20 seconds for initial load
-    cy.contains('Create monitor', { timeout: 20000 });
+    cy.contains('Create monitor', { timeout: ALERTING_PLUGIN_TIMEOUT });
   });
 
   it('Displays expected number of alerts', () => {
@@ -118,30 +119,36 @@ describe('Monitors dashboard page', () => {
 
     testMonitors.forEach((entry) => {
       cy.get('tbody > tr')
-        .filter(`:contains(${entry.monitor.name})`, { timeout: 20000 })
+        .filter(`:contains(${entry.monitor.name})`, {
+          timeout: ALERTING_PLUGIN_TIMEOUT,
+        })
         .within(() => {
           cy.get('[class="euiTableRowCell"]')
-            .filter(':contains(Latest alert)', { timeout: 20000 })
+            .filter(':contains(Latest alert)', {
+              timeout: ALERTING_PLUGIN_TIMEOUT,
+            })
             .should('contain', entry.triggerName);
 
           cy.get('[class="euiTableRowCell"]')
-            .filter(':contains(State)', { timeout: 20000 })
+            .filter(':contains(State)', { timeout: ALERTING_PLUGIN_TIMEOUT })
             .should('contain', 'Disabled');
 
           cy.get('[class="euiTableRowCell"]')
-            .filter(':contains(Active)', { timeout: 20000 })
+            .filter(':contains(Active)', { timeout: ALERTING_PLUGIN_TIMEOUT })
             .should('contain', entry.expectedAlertsCount);
 
           cy.get('[class="euiTableRowCell"]')
-            .filter(':contains(Acknowledged)', { timeout: 20000 })
+            .filter(':contains(Acknowledged)', {
+              timeout: ALERTING_PLUGIN_TIMEOUT,
+            })
             .should('contain', 0);
 
           cy.get('[class="euiTableRowCell"]')
-            .filter(':contains(Errors)', { timeout: 20000 })
+            .filter(':contains(Errors)', { timeout: ALERTING_PLUGIN_TIMEOUT })
             .should('contain', 0);
 
           cy.get('[class="euiTableRowCell"]')
-            .filter(':contains(Ignored)', { timeout: 20000 })
+            .filter(':contains(Ignored)', { timeout: ALERTING_PLUGIN_TIMEOUT })
             .should('contain', 0);
         });
     });

--- a/cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js
@@ -7,6 +7,7 @@ import _ from 'lodash';
 import {
   ALERTING_INDEX,
   ALERTING_PLUGIN_NAME,
+  ALERTING_PLUGIN_TIMEOUT,
 } from '../../../utils/plugins/alerting-dashboards-plugin/constants';
 import sampleQueryLevelMonitor from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_query_level_monitor';
 import sampleQueryLevelMonitorWithAlwaysTrueTrigger from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_query_level_monitor_with_always_true_trigger';
@@ -35,9 +36,13 @@ const addVisualQueryLevelTrigger = (
 ) => {
   // Click 'Add trigger' button
   if (triggerIndex === 0)
-    cy.contains('Add trigger', { timeout: 20000 }).click({ force: true });
+    cy.contains('Add trigger', { timeout: ALERTING_PLUGIN_TIMEOUT }).click({
+      force: true,
+    });
   else
-    cy.contains('Add another trigger', { timeout: 20000 }).click({
+    cy.contains('Add another trigger', {
+      timeout: ALERTING_PLUGIN_TIMEOUT,
+    }).click({
       force: true,
     });
 
@@ -86,7 +91,7 @@ describe('Query-Level Monitors', () => {
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/monitors`);
 
     // Common text to wait for to confirm page loaded, give up to 20 seconds for initial load
-    cy.contains('Create monitor', { timeout: 20000 });
+    cy.contains('Create monitor', { timeout: ALERTING_PLUGIN_TIMEOUT });
   });
 
   describe('can be created', () => {
@@ -165,13 +170,15 @@ describe('Query-Level Monitors', () => {
 
     it('by changing the name', () => {
       // Confirm we can see the created monitor in the list
-      cy.contains(SAMPLE_MONITOR, { timeout: 20000 });
+      cy.contains(SAMPLE_MONITOR, { timeout: ALERTING_PLUGIN_TIMEOUT });
 
       // Select the existing monitor
       cy.get(`[data-test-subj="${SAMPLE_MONITOR}"]`).click({ force: true });
 
       // Click Edit button
-      cy.contains('Edit', { timeout: 20000 }).click({ force: true });
+      cy.contains('Edit', { timeout: ALERTING_PLUGIN_TIMEOUT }).click({
+        force: true,
+      });
 
       // Wait for input to load and then type in the new monitor name
       cy.get('input[name="name"]')
@@ -194,13 +201,15 @@ describe('Query-Level Monitors', () => {
 
     it('to have multiple indices', () => {
       // Confirm we can see the created monitor in the list
-      cy.contains(SAMPLE_MONITOR, { timeout: 20000 });
+      cy.contains(SAMPLE_MONITOR, { timeout: ALERTING_PLUGIN_TIMEOUT });
 
       // Select the existing monitor
       cy.get(`[data-test-subj="${SAMPLE_MONITOR}"]`).click({ force: true });
 
       // Click Edit button
-      cy.contains('Edit', { timeout: 20000 }).click({ force: true });
+      cy.contains('Edit', { timeout: ALERTING_PLUGIN_TIMEOUT }).click({
+        force: true,
+      });
 
       // Click on the Index field and type in multiple index names to replicate the bug
       cy.get('#index')
@@ -212,20 +221,20 @@ describe('Query-Level Monitors', () => {
 
       // Confirm Index field only contains the expected text
       cy.get('[data-test-subj="indicesComboBox"]').contains('*', {
-        timeout: 20000,
+        timeout: ALERTING_PLUGIN_TIMEOUT,
       });
       cy.get('[data-test-subj="indicesComboBox"]').contains(TESTING_INDEX_A, {
-        timeout: 20000,
+        timeout: ALERTING_PLUGIN_TIMEOUT,
       });
       cy.get('[data-test-subj="indicesComboBox"]').contains(TESTING_INDEX_B, {
-        timeout: 20000,
+        timeout: ALERTING_PLUGIN_TIMEOUT,
       });
 
       // Click the update button
       cy.get('button').contains('Update').last().click({ force: true });
 
       // Confirm we're on the Monitor Details page by searching for the History element
-      cy.contains('History', { timeout: 20000 });
+      cy.contains('History', { timeout: ALERTING_PLUGIN_TIMEOUT });
     });
   });
 
@@ -357,7 +366,7 @@ describe('Query-Level Monitors', () => {
 
       // Confirm we can see the correct number of rows in the trigger list by checking <caption> element
       cy.contains(`This table contains ${triggers.length} rows`, {
-        timeout: 20000,
+        timeout: ALERTING_PLUGIN_TIMEOUT,
       });
 
       // Click Edit button
@@ -421,11 +430,11 @@ describe('Query-Level Monitors', () => {
       cy.get('[data-test-subj="frequency_field"]').contains('By interval');
 
       cy.get('[data-test-subj="interval_interval_field"]', {
-        timeout: 20000,
+        timeout: ALERTING_PLUGIN_TIMEOUT,
       }).should('have.value', 7);
 
       cy.get('[data-test-subj="interval_unit_field"]', {
-        timeout: 20000,
+        timeout: ALERTING_PLUGIN_TIMEOUT,
       }).contains('Days');
     });
 
@@ -454,11 +463,11 @@ describe('Query-Level Monitors', () => {
       );
 
       cy.get('[data-test-subj="customCron_cronExpression_field"]', {
-        timeout: 20000,
+        timeout: ALERTING_PLUGIN_TIMEOUT,
       }).contains('30 11 * * 1-5');
 
       cy.get('[data-test-subj="timezoneComboBox"]', {
-        timeout: 20000,
+        timeout: ALERTING_PLUGIN_TIMEOUT,
       }).contains('US/Pacific');
     });
   });

--- a/cypress/utils/plugins/alerting-dashboards-plugin/constants.js
+++ b/cypress/utils/plugins/alerting-dashboards-plugin/constants.js
@@ -17,3 +17,5 @@ export const ALERTING_API = {
 };
 
 export const ALERTING_PLUGIN_NAME = 'alerting';
+
+export const ALERTING_PLUGIN_TIMEOUT = 60000;


### PR DESCRIPTION
### Description
Manually cherry-picked PR #1093 

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
