### PR TITLE
Use @puppeteer/browsers to lock chromium version to 112

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -99,7 +99,10 @@ PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 # User can send custom browser path through env variable
 if [ -z "$BROWSER_PATH" ]
 then
-  BROWSER_PATH="chromium"
+    # Lock chrome version using @puppeteer/browsers so it is independent of Operating Systems
+    # chromium@1108766 is version 112 with revision r1108766
+    # Please keep this version until cypress upgrade or test will freeze: https://github.com/opensearch-project/opensearch-build/issues/4241
+    BROWSER_PATH=`echo y | npx @puppeteer/browsers@2.0.1 install chromium@1108766 | cut -d ' ' -f2`
 fi
 
 . ./test_finder.sh


### PR DESCRIPTION
### Description

Use @puppeteer/browsers to lock chromium version to 112

### Issues Resolved

https://github.com/opensearch-project/opensearch-build/issues/4459

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
