### PR TITLE
[OSD] Skip cypress tests for data explorer with security enabled

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -21,6 +21,9 @@
     "DATASOURCE_MANAGEMENT_ENABLED": false,
     "ML_COMMONS_DASHBOARDS_ENABLED": true,
     "WAIT_FOR_LOADER_BUFFER_MS": 0,
-    "DASHBOARDS_ASSISTANT_ENABLED": false
+    "DASHBOARDS_ASSISTANT_ENABLED": false,
+    "browserPermissions": {
+      "clipboard": "allow"
+    }
   }
 }

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
@@ -52,51 +52,58 @@ describe('shared links', () => {
     cy.waitForSearch();
   });
 
-  describe('shared links with state in query', () => {
-    it('should allow for copying the snapshot URL', function () {
-      const url = `http://localhost:5601/app/data-explorer/discover#/?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'logstash-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))&_q=(filters:!(),query:(language:kuery,query:''))`;
-      cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
-      cy.getElementByTestId('copyShareUrlButton')
-        .invoke('attr', 'data-share-url')
-        .should('eq', url)
-        .then((url) => {
-          cy.log(url);
-          cy.request(url).its('status').should('eq', 200);
-        });
+  if (!Cypress.env('SECURITY_ENABLED')) {
+    describe('shared links with state in query', () => {
+      // Skip the test if security is enabled url adds tenancy and changes the query string making it difficult to verify the URL
+      it('should allow for copying the snapshot URL', function () {
+        const url = `http://localhost:5601/app/data-explorer/discover#/?_a=(discover:(columns:!(_source),isDirty:!f,sort:!()),metadata:(indexPattern:'logstash-*',view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))&_q=(filters:!(),query:(language:kuery,query:''))`;
+        cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
+        cy.getElementByTestId('copyShareUrlButton')
+          .invoke('attr', 'data-share-url')
+          .should('eq', url)
+          .then((url) => {
+            cy.log(url);
+            cy.request(url).its('status').should('eq', 200);
+          });
+      });
+
+      it('should allow for copying the snapshot URL as a short URL', function () {
+        cy.getElementByTestId('useShortUrl')
+          .should('be.visible')
+          .invoke('attr', 'aria-checked', 'true');
+        cy.wait(1000);
+        // For some reasons, after making the toggle true, the data-share-url do not get updated in the cypress test
+        // Thus only testing if the button is clickable, instead of comparing the actual URL
+        cy.getElementByTestId('copyShareUrlButton')
+          .should('be.visible')
+          .click();
+      });
+
+      it('should allow for copying the saved object URL', function () {
+        const url =
+          'http://localhost:5601/app/data-explorer/discover/#/view/ab12e3c0-f231-11e6-9486-733b1ac9221a?_g=%28filters%3A%21%28%29%2CrefreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2Ctime%3A%28from%3A%272015-09-19T13%3A31%3A44.000Z%27%2Cto%3A%272015-09-24T01%3A31%3A44.000Z%27%29%29';
+
+        cy.getElementByTestId('exportAsSavedObject')
+          .get('.euiRadio__input')
+          .should('be.disabled');
+
+        // Load a save search
+        cy.loadSaveSearch('A Saved Search');
+
+        cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
+        cy.getElementByTestId('exportAsSavedObject')
+          .should('be.visible')
+          .click();
+        cy.getElementByTestId('copyShareUrlButton')
+          .invoke('attr', 'data-share-url')
+          .should('eq', url)
+          .then((url) => {
+            cy.log(url);
+            cy.request(url).its('status').should('eq', 200);
+          });
+      });
     });
-
-    it('should allow for copying the snapshot URL as a short URL', function () {
-      cy.getElementByTestId('useShortUrl')
-        .should('be.visible')
-        .invoke('attr', 'aria-checked', 'true');
-      cy.wait(1000);
-      // For some reasons, after making the toggle true, the data-share-url do not get updated in the cypress test
-      // Thus only testing if the button is clickable, instead of comparing the actual URL
-      cy.getElementByTestId('copyShareUrlButton').should('be.visible').click();
-    });
-
-    it('should allow for copying the saved object URL', function () {
-      const url =
-        'http://localhost:5601/app/data-explorer/discover/#/view/ab12e3c0-f231-11e6-9486-733b1ac9221a?_g=%28filters%3A%21%28%29%2CrefreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2Ctime%3A%28from%3A%272015-09-19T13%3A31%3A44.000Z%27%2Cto%3A%272015-09-24T01%3A31%3A44.000Z%27%29%29';
-
-      cy.getElementByTestId('exportAsSavedObject')
-        .get('.euiRadio__input')
-        .should('be.disabled');
-
-      // Load a save search
-      cy.loadSaveSearch('A Saved Search');
-
-      cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
-      cy.getElementByTestId('exportAsSavedObject').should('be.visible').click();
-      cy.getElementByTestId('copyShareUrlButton')
-        .invoke('attr', 'data-share-url')
-        .should('eq', url)
-        .then((url) => {
-          cy.log(url);
-          cy.request(url).its('status').should('eq', 200);
-        });
-    });
-  });
+  }
 
   describe('shared links with state in sessionStorage', () => {
     before(() => {
@@ -136,22 +143,26 @@ describe('shared links', () => {
         });
     });
 
-    it('should allow for copying the saved object URL', function () {
-      cy.getElementByTestId('exportAsSavedObject')
-        .get('.euiRadio__input')
-        .should('be.disabled');
+    if (!Cypress.env('SECURITY_ENABLED')) {
+      it('should allow for copying the saved object URL', function () {
+        cy.getElementByTestId('exportAsSavedObject')
+          .get('.euiRadio__input')
+          .should('be.disabled');
 
-      // Load a save search
-      cy.loadSaveSearch('A Saved Search');
+        // Load a save search
+        cy.loadSaveSearch('A Saved Search');
 
-      cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
-      cy.getElementByTestId('exportAsSavedObject').should('be.visible').click();
-      cy.getElementByTestId('copyShareUrlButton')
-        .invoke('attr', 'data-share-url')
-        .then((url) => {
-          cy.log(url);
-          cy.request(url).its('status').should('eq', 200);
-        });
-    });
+        cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
+        cy.getElementByTestId('exportAsSavedObject')
+          .should('be.visible')
+          .click();
+        cy.getElementByTestId('copyShareUrlButton')
+          .invoke('attr', 'data-share-url')
+          .then((url) => {
+            cy.log(url);
+            cy.request(url).its('status').should('eq', 200);
+          });
+      });
+    }
   });
 });

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/dashboard_share_copy_link_test.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/dashboard_share_copy_link_test.js
@@ -28,8 +28,9 @@ if (Cypress.env('SECURITY_ENABLED')) {
             // Assert that the clipboard has data
             expect(clipboardData).to.have.length.greaterThan(0);
 
-            cy.visit(clipboardData);
-            cy.waitForLoader();
+            // TODO: tries to re-route with a different origin
+            // cy.visit(clipboardData);
+            // cy.waitForLoader();
 
             // Now on copied URL page
           });


### PR DESCRIPTION
### Description

When security is enabled the url contains the tenancy. For example, 
```
localhost:5601/app/dashboards?security_tenant=private
```

Which will fail tests that verify URLs if written without security plugin and tenancy enabled. Also with the security plugin enabled then the query string is masked. Which will make it more difficult to verify URL tests without checking the expecting elements within the app. So to mitigate this we will just check the URLs only if security is not enabled but keep the tests running if enabled.

Also includes browserPermissions as one of the tests would pop up and asks but needs permission. Also commented on the cy.visit. Depending on how the tests are executed this could be a re-navigate on origin. But since it just focuses on visiting but fails the tests when it does visit but not validate anything on the location then commented out. 

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5633

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
