### PR TITLE
Add download_chromium to integtest.sh for standalone chromium installation

### DIFF
--- a/browser_downloader.sh
+++ b/browser_downloader.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+
+BROWSER_DIR=`dirname $(realpath $0)` && cd $BROWSER_DIR
+
+function download_chromium {
+
+    # Set defaults
+    arch="x64"
+    os="linux"
+    chromium_version="112"
+    chromium_binary="chrome"
+    ARCHTYPE=`uname -m`
+    force=$1
+
+    # Architecture
+    if [ "$ARCHTYPE" = "aarch64" ] || [ "$ARCHTYPE" = "arm64" ]; then
+        arch="arm64"
+    fi
+
+    # Platform
+    if (echo "$OSTYPE" | grep -qi darwin); then
+        os="mac"
+        chromium_binary="Chromium.app/Contents/MacOS/Chromium"
+    elif [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "win32" ]; then
+        os="win"
+        chromium_binary="chrome.exe"
+        BROWSER_DIR=`pwd -W`
+    fi
+
+    # Variables
+    artifact="chromium-$os-$arch.zip"
+    chromium_url="https://ci.opensearch.org/ci/dbc/tools/chromium/$chromium_version/zip/$artifact"
+    chromium_path="$BROWSER_DIR/chromium/chrome-$os/$chromium_binary"
+
+    # Get artifact
+    if [ "$force" = "true" ] || [ ! -f "$chromium_path" ]; then
+        rm -rf chromium
+        mkdir -p chromium
+        cd chromium
+        curl -sSLO $chromium_url
+        unzip -qq $artifact
+        rm $artifact
+    fi
+
+    echo "$chromium_path chromium-$chromium_version os-$os arch-$arch"
+
+    # Verify binary
+    if [ "$os" = "win" ]; then
+        powershell -command "(Get-Item $chromium_path)".VersionInfo
+    else
+        $chromium_path --version
+    fi
+}

--- a/integtest.sh
+++ b/integtest.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+. ./browser_downloader.sh
+
 function usage() {
     echo ""
     echo "This script is used to run integration tests for plugin installed on a remote OpenSearch/Dashboards cluster."
@@ -99,7 +101,9 @@ PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 # User can send custom browser path through env variable
 if [ -z "$BROWSER_PATH" ]
 then
-  BROWSER_PATH="chromium"
+    # chromium@1108766 is version 112 with revision r1108766
+    # Please keep this version until cypress upgrade or test will freeze: https://github.com/opensearch-project/opensearch-build/issues/4241
+    BROWSER_PATH=`download_chromium | head -n 1 | cut -d ' ' -f1`
 fi
 
 . ./test_finder.sh


### PR DESCRIPTION
### Description

Add download_chromium to integtest.sh for standalone chromium installation

### Issues Resolved

Closes: https://github.com/opensearch-project/opensearch-build/issues/4459

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
