### PR TITLE
Add tests for shared links when multi-tenancy is enabled

### DIFF
--- a/cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js
@@ -25,7 +25,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
         'index-pattern1',
         {
           title: 's*',
-          timeFieldName: 'timestamp',
+          timeFieldName: '@timestamp',
         },
         indexPatternGlobalTenantHeaderSetUp
       );
@@ -34,7 +34,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
         'index-pattern2',
         {
           title: 'se*',
-          timeFieldName: 'timestamp',
+          timeFieldName: '@timestamp',
         },
         indexPatternPrivateTenantHeaderSetUp
       );

--- a/cypress/integration/plugins/security-dashboards-plugin/multitenancy_shared_links.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/multitenancy_shared_links.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { STACK_MANAGEMENT_PATH } from '../../../utils/dashboards/constants';
+
+import { switchTenantTo } from './switch_tenant';
+import 'cypress-real-events/support';
+
+Cypress.automation('remote:debugger:protocol', {
+  command: 'Browser.grantPermissions',
+  params: {
+    permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite'],
+    origin: window.location.origin,
+  },
+});
+
+if (Cypress.env('SECURITY_ENABLED')) {
+  describe('Multi Tenancy Tests for Shared Links: ', () => {
+    it('Tests to ensure that copy link includes security tenant as url param', () => {
+      cy.visit(STACK_MANAGEMENT_PATH);
+      cy.waitForLoader();
+      switchTenantTo('private');
+      cy.getElementByTestId('toggleNavButton').click();
+      cy.get('span[title="Discover"]').click();
+      cy.getElementByTestId('shareTopNavButton').click();
+      cy.getElementByTestId('copyShareUrlButton')
+        .realClick()
+        .then(() => {
+          cy.window()
+            .its('navigator.clipboard')
+            .then((clip) => clip.readText())
+            .should('contain', 'security_tenant=');
+        });
+    });
+    it('Tests to ensure that copy link includes security tenant as url param in short url', () => {
+      cy.visit(STACK_MANAGEMENT_PATH);
+      cy.waitForLoader();
+      switchTenantTo('private');
+      cy.getElementByTestId('toggleNavButton').click();
+      cy.get('span[title="Discover"]').click();
+      cy.getElementByTestId('shareTopNavButton').click();
+      cy.getElementByTestId('createShortUrl').click();
+      cy.getElementByTestId('copyShareUrlButton')
+        .realClick()
+        .then(() => {
+          cy.window()
+            .its('navigator.clipboard')
+            .then((clip) => clip.readText())
+            .should('contain', 'security_tenant=');
+        });
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "cypress": "9.5.4",
     "cypress-file-upload": "^5.0.8",
     "cypress-multi-reporters": "^1.5.0",
-    "cypress-real-events": "1.7.6",
+    "cypress-real-events": "^1.12.0",
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-cypress": "^2.12.1",


### PR DESCRIPTION
### Description

Adding tests to go with corresponding PR in the security-dashboards-plugin repo: https://github.com/opensearch-project/security-dashboards-plugin/pull/1804

These tests ensure that the `security_tenant` url param is added onto shared links - both shortened URLs and normal.

### Issues Resolved

- https://github.com/opensearch-project/security-dashboards-plugin/issues/1769

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
