### PR TITLE
Restore video recording on Windows with DISABLE_VIDEO parameter

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -216,9 +216,8 @@ fi
 # We need to ensure the cypress tests are the last execute process to
 # the error code gets passed to the CI.
 
-if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "win32" ]; then
-    echo "Disable video recording in Windows due to ffmpeg missing libs in Windows Docker Container"
-    echo "TODO: https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/1068"
+if [ "$DISABLE_VIDEO" = "true" ]; then
+    echo "Disable video recording when running tests in Cypress"
     jq '. + {"video": false}' cypress.json > cypress_new.json # jq does not allow reading and writing on same file
     mv -v cypress_new.json cypress.json
 fi


### PR DESCRIPTION
### Description

Restore video recording on Windows with DISABLE_VIDEO parameter

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/4427

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
