### PR TITLE
[Discover] set local storage directly for large string spec

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/large_string.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/large_string.spec.js
@@ -40,11 +40,16 @@ describe('test large strings', () => {
     });
   });
 
+  beforeEach(() => {
+    cy.window().then((win) =>
+      win.localStorage.setItem('discover:newExpereince', true)
+    );
+  });
+
   it('verify the large string book present', function () {
     // Go to the Discover page
     miscUtils.visitPage('app/data-explorer/discover#/');
     cy.waitForLoader();
-    cy.switchDiscoverTable('new');
 
     const ExpectedDoc = 'Project Gutenberg EBook of Hamlet';
 
@@ -67,7 +72,6 @@ describe('test large strings', () => {
 
     it('search Newsletter should show the correct hit count in datagrid table', function () {
       cy.log('test Newsletter keyword is searched');
-      cy.switchDiscoverTable('new');
       const expectedHitCount = '1';
       const query = 'Newsletter';
       cy.setTopNavQuery(query);


### PR DESCRIPTION
### Description

Other test utilize the helper function and not seeing the particular need for this test to ensure it switches. But by doing this avoid whatever is taking focus of the popover that lets the test first click the button but before cypress test runner clicks the switch.

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
