### PR TITLE
Refactor 6_notebooks.spec.js

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -137,12 +137,10 @@ describe('Testing notebook actions', () => {
 describe('Test reporting integration if plugin installed', () => {
   beforeEach(() => {
     let notebookName = makeTestNotebook();
-    cy.get('h1[data-test-subj="notebookTitle"]')
-      .contains(notebookName)
-      .should('exist');
     cy.get('body').then(($body) => {
       skipOn($body.find('#reportingActionsButton').length <= 0);
     });
+    makePopulatedParagraph();
     cy.wrap({ name: notebookName }).as('notebook');
   });
 
@@ -152,7 +150,6 @@ describe('Test reporting integration if plugin installed', () => {
   });
 
   it('Create in-context PDF report from notebook', () => {
-    makePopulatedParagraph();
     cy.get('#reportingActionsButton').click();
     cy.get('button.euiContextMenuItem:nth-child(1)')
       .contains('Download PDF')
@@ -161,7 +158,6 @@ describe('Test reporting integration if plugin installed', () => {
   });
 
   it('Create in-context PNG report from notebook', () => {
-    makePopulatedParagraph();
     cy.get('#reportingActionsButton').click();
     cy.get('button.euiContextMenuItem:nth-child(2)')
       .contains('Download PNG')
@@ -170,7 +166,6 @@ describe('Test reporting integration if plugin installed', () => {
   });
 
   it('Create on-demand report definition from context menu', () => {
-    makePopulatedParagraph();
     cy.get('#reportingActionsButton').click();
     cy.get('button.euiContextMenuItem:nth-child(3)')
       .contains('Create report definition')
@@ -184,7 +179,6 @@ describe('Test reporting integration if plugin installed', () => {
   });
 
   it('View reports homepage from context menu', () => {
-    makePopulatedParagraph();
     cy.get('#reportingActionsButton').click();
     cy.get('button.euiContextMenuItem:nth-child(4)')
       .contains('View reports')

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -111,9 +111,10 @@ describe('Testing notebook actions', () => {
     cy.wrap({ name: notebookName }).as('notebook');
   });
 
-  afterEach(function () {
-    //      ^^^^^^^^ Cannot use arrow callback to access beforeEach wrapper state
-    deleteNotebook(this.notebook.name);
+  afterEach(() => {
+    cy.get('@notebook').then((notebook) => {
+      deleteNotebook(notebook.name);
+    });
   });
 
   it('Creates a code paragraph', () => {
@@ -144,9 +145,10 @@ describe('Test reporting integration if plugin installed', () => {
     cy.wrap({ name: notebookName }).as('notebook');
   });
 
-  afterEach(function () {
-    //      ^^^^^^^^ Cannot use arrow callback to access beforeEach wrapper state
-    deleteNotebook(this.notebook.name);
+  afterEach(() => {
+    cy.get('@notebook').then((notebook) => {
+      deleteNotebook(notebook.name);
+    });
   });
 
   it('Create in-context PDF report from notebook', () => {

--- a/cypress/utils/plugins/observability-dashboards/constants.js
+++ b/cypress/utils/plugins/observability-dashboards/constants.js
@@ -62,9 +62,10 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
   cy.get('.euiTab__content').contains('Absolute').click();
   cy.get('input[data-test-subj="superDatePickerAbsoluteDateInput"]', {
     timeout: TIMEOUT_DELAY,
-  })
-    .focus()
-    .type('{selectall}' + startTime, { force: true });
+  }).focus();
+  cy.get('input[data-test-subj="superDatePickerAbsoluteDateInput"]', {
+    timeout: TIMEOUT_DELAY,
+  }).type('{selectall}' + startTime, { force: true });
   if (setEndTime) {
     cy.wait(delayTime);
     cy.get(
@@ -74,16 +75,16 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
     cy.get('.euiTab__content').contains('Absolute').click();
     cy.get('input[data-test-subj="superDatePickerAbsoluteDateInput"]', {
       timeout: TIMEOUT_DELAY,
-    })
-      .focus()
-      .type('{selectall}' + endTime, { force: true });
+    }).focus();
+    cy.get('input[data-test-subj="superDatePickerAbsoluteDateInput"]', {
+      timeout: TIMEOUT_DELAY,
+    }).type('{selectall}' + endTime, { force: true });
   }
   if (refresh) cy.get('.euiButton__text').contains('Refresh').click();
   cy.wait(delayTime);
 };
 
 // notebooks
-export const TEST_NOTEBOOK = 'Test Notebook';
 export const SAMPLE_URL =
   'https://github.com/opensearch-project/sql/tree/main/sql-jdbc';
 export const MARKDOWN_TEXT = `%md
@@ -301,9 +302,10 @@ export const moveToEditPage = () => {
 export const changeTimeTo24 = (timeUnit) => {
   cy.get('[data-test-subj="superDatePickerToggleQuickMenuButton"]', {
     timeout: TIMEOUT_DELAY,
-  })
-    .trigger('mouseover')
-    .click();
+  }).trigger('mouseover');
+  cy.get('[data-test-subj="superDatePickerToggleQuickMenuButton"]', {
+    timeout: TIMEOUT_DELAY,
+  }).click();
   cy.wait(delayTime);
   cy.get('[aria-label="Time unit"]', { timeout: TIMEOUT_DELAY }).select(
     timeUnit


### PR DESCRIPTION
### Description

Coming from the autocut issue https://github.com/opensearch-project/dashboards-observability/issues/1579: the tests for notebooks are failing in 2.13. This test suite has been flaky for a while, and it looked like the reason this one was failing was because some other delete action was interfering with the test (it was looking for a notebook but there was an empty notebook state).

This PR completely refactors these tests to be mutually independent: every test gets its own notebook with a randomized name, and each notebook has its own teardown. This should help avoid all the weird interdependent flakiness from before with this suite.

Needs backporting to 2.x and 2.13.

### Issues Resolved

https://github.com/opensearch-project/dashboards-observability/issues/1579

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
