### PR TITLE
[Alerting][2.13] Improve acknowledge alerts tests

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/acknowledge_alerts_modal_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/acknowledge_alerts_modal_spec.js
@@ -41,8 +41,14 @@ describe('AcknowledgeAlertsModal', () => {
   });
 
   beforeEach(() => {
+    const getMonitorsUrl = new RegExp('.*api/alerting/monitors/_search.*');
+    cy.intercept(getMonitorsUrl).as('searchMonitors');
+
     // Reloading the page to close any modals that were not closed by other tests that had failures.
     cy.visit(`${BASE_PATH}/app/${ALERTING_PLUGIN_NAME}#/dashboard`);
+
+    // Wait for the monitor search call to finish before checking for the monitors below
+    cy.wait('@searchMonitors');
 
     // Confirm dashboard is displaying rows for the test monitors.
     cy.contains(BUCKET_MONITOR, { timeout: ALERTING_PLUGIN_TIMEOUT });


### PR DESCRIPTION
### Description
Adding intercept to ensure monitor search call finishes after page load before we check for the monitor value and fail.

### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/910

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
