### PR TITLE
Add Discover Table Tests

### DIFF
--- a/cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_with_nested_field/data.json.txt
+++ b/cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_with_nested_field/data.json.txt
@@ -1,0 +1,43 @@
+{
+    "type": "doc",
+    "value": {
+        "id": "0",
+        "index": "nestedindex",
+        "source": {
+            "products": [{
+                "base_price": 31.14,
+                "discount_percentage": 5,
+                "quantity": 1,
+                "manufacturer": "Virora"
+            }, {
+                "base_price": 35.69,
+                "discount_percentage": 10,
+                "quantity": 3,
+                "manufacturer": "Oceanavigations"
+            }],
+            "timestamp": "2015-09-21T06:09:20.045Z"
+        }
+    }
+}
+
+{
+    "type": "doc",
+    "value": {
+        "id": "1",
+        "index": "nestedindex",
+        "source": {
+            "products": [{
+                "base_price": 28.99,
+                "discount_percentage": 0,
+                "quantity": 1,
+                "manufacturer": "Tigress Enterprises"
+            }, {
+                "base_price": 32.99,
+                "discount_percentage": 0,
+                "quantity": 1,
+                "manufacturer": "Oceanavigations"
+            }],
+            "timestamp": "2015-09-21T21:13:02.070Z"
+        }
+    }
+}

--- a/cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_with_nested_field/mappings.json.txt
+++ b/cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_with_nested_field/mappings.json.txt
@@ -1,0 +1,45 @@
+{
+  "type": "index",
+  "value": {
+    "index": "nestedindex",
+    "mappings": {
+      "properties": {
+        "products": {
+          "type": "nested",
+          "properties": {
+            "base_price": {
+              "type": "float"
+            },
+            "discount_percentage": {
+              "type": "long"
+            },
+            "manufacturer": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "quantity": {
+              "type": "long"
+            }
+          }
+        },
+        "timestamp": {
+          "type": "date"
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "replication": {
+          "type": "DOCUMENT"
+        },
+        "number_of_shards": "1",
+        "number_of_replicas": "1"
+      }
+    }
+  }
+}

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
@@ -26,17 +26,6 @@ const indexSet = [
 
 describe('discover app', { scrollBehavior: false }, () => {
   before(() => {
-    if (Cypress.env('SECURITY_ENABLED')) {
-      /**
-       * Security plugin is using private tenant as default.
-       * So here we'd need to set global tenant as default manually.
-       */
-      cy.changeDefaultTenant({
-        multitenancy_enabled: true,
-        private_tenant_enabled: true,
-        default_tenant: 'global',
-      });
-    }
     CURRENT_TENANT.newTenant = 'global';
     // import logstash functional
     testFixtureHandler.importJSONDocIfNeeded(

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_advanced_settings.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_advanced_settings.spec.js
@@ -1,0 +1,483 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  MiscUtils,
+  TestFixtureHandler,
+} from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
+
+const miscUtils = new MiscUtils(cy);
+const testFixtureHandler = new TestFixtureHandler(
+  cy,
+  Cypress.env('openSearchUrl')
+);
+
+const indexSet = [
+  'logstash-2015.09.22',
+  'logstash-2015.09.21',
+  'logstash-2015.09.20',
+];
+
+// Setting up the page
+describe('discover_advanced_setting', () => {
+  before(() => {
+    CURRENT_TENANT.newTenant = 'global';
+    // import logstash functional
+    testFixtureHandler.importJSONDocIfNeeded(
+      indexSet,
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/logstash/logstash.mappings.json.txt',
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/logstash/logstash.json.txt'
+    );
+
+    testFixtureHandler.importJSONMapping(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.mappings.json.txt'
+    );
+
+    testFixtureHandler.importJSONDoc(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.json.txt'
+    );
+
+    testFixtureHandler.importJSONMapping(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_with_nested_field/mappings.json.txt'
+    );
+
+    testFixtureHandler.importJSONDoc(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_with_nested_field/data.json.txt'
+    );
+
+    cy.setAdvancedSetting({
+      defaultIndex: 'logstash-*',
+    });
+
+    cy.createIndexPattern(
+      'nestedindex',
+      {
+        title: 'nestedindex*',
+        timeFieldName: 'timestamp',
+      },
+      {
+        securitytenant: ['global'],
+      }
+    );
+
+    // Go to the Discover page
+    miscUtils.visitPage(
+      `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+    );
+    cy.waitForSearch();
+  });
+
+  describe('maxHeight advanced setting for legacy table', () => {
+    it('checks if the table respects maxHeight setting of no truncation', function () {
+      cy.setAdvancedSetting({
+        'truncate:maxHeight': 0,
+      });
+      cy.reload();
+
+      cy.get('.truncate-by-height')
+        .first()
+        .should('have.css', 'max-height', 'none');
+    });
+
+    it('checks if the table respects maxHeight setting of truncation', function () {
+      cy.setAdvancedSetting({
+        'truncate:maxHeight': 130,
+      });
+      cy.reload();
+
+      cy.get('.truncate-by-height')
+        .first()
+        .should('have.css', 'max-height', '130px');
+    });
+  });
+
+  describe('Default Sort Order advanced setting', () => {
+    it('check Default Sort Order Descending is respected in new table', function () {
+      cy.setAdvancedSetting({
+        'discover:sort:defaultOrder': 'desc',
+      });
+      cy.reload();
+      cy.switchDiscoverTable('new');
+
+      cy.get('.euiDataGridRowCell--date')
+        .eq(0)
+        .invoke('text')
+        .then((date1) => {
+          cy.get('.euiDataGridRowCell--date')
+            .eq(99)
+            .invoke('text')
+            .then((date2) => {
+              expect(new Date(date1.slice(0, -18))).greaterThan(
+                new Date(date2.slice(0, -20))
+              );
+            });
+        });
+    });
+
+    it('check Default Sort Order Ascending is respected in new table', function () {
+      cy.setAdvancedSetting({
+        'discover:sort:defaultOrder': 'asc',
+      });
+      cy.reload();
+      cy.switchDiscoverTable('new');
+
+      cy.get('.euiDataGridRowCell--date')
+        .eq(0)
+        .invoke('text')
+        .then((date1) => {
+          cy.get('.euiDataGridRowCell--date')
+            .eq(99)
+            .invoke('text')
+            .then((date2) => {
+              expect(new Date(date1.slice(0, -18))).lessThan(
+                new Date(date2.slice(0, -20))
+              );
+            });
+        });
+    });
+
+    it('check Default Sort Order Descending is respected in legacy table', function () {
+      cy.setAdvancedSetting({
+        'discover:sort:defaultOrder': 'desc',
+      });
+      cy.reload();
+
+      cy.get('[data-test-subj="docTableField"]')
+        .eq(0)
+        .invoke('text')
+        .then((date1) => {
+          cy.get('[data-test-subj="docTableField"]')
+            .eq(4)
+            .invoke('text')
+            .then((date2) => {
+              expect(new Date(date1)).greaterThan(new Date(date2));
+            });
+        });
+    });
+
+    it('check Default Sort Order Ascending is respected in legacy table', function () {
+      cy.setAdvancedSetting({
+        'discover:sort:defaultOrder': 'asc',
+      });
+      cy.reload();
+
+      cy.get('[data-test-subj="docTableField"]')
+        .eq(0)
+        .invoke('text')
+        .then((date1) => {
+          cy.get('[data-test-subj="docTableField"]')
+            .eq(4)
+            .invoke('text')
+            .then((date2) => {
+              expect(new Date(date1)).lessThan(new Date(date2));
+            });
+        });
+    });
+
+    after(() => {
+      cy.setAdvancedSetting({
+        'discover:sort:defaultOrder': 'desc',
+      });
+      cy.reload();
+    });
+  });
+
+  describe('Number of rows advanced setting', () => {
+    before(() => {
+      cy.setAdvancedSetting({
+        'discover:sampleSize': 5,
+      });
+      cy.reload();
+      cy.switchDiscoverTable('new');
+    });
+
+    it('check new table respects Number of rows setting', function () {
+      cy.get('[aria-label="Inspect document details"]').should(
+        'have.length',
+        5
+      );
+    });
+
+    it('check legacy table respects Number of rows setting', function () {
+      cy.switchDiscoverTable('legacy');
+      cy.get('[aria-label="Next"]').should('have.length', 5);
+    });
+
+    after(() => {
+      cy.setAdvancedSetting({
+        'discover:sampleSize': 500,
+      });
+      cy.reload();
+    });
+  });
+
+  describe('Number of terms advanced setting', () => {
+    before(() => {
+      cy.setAdvancedSetting({
+        'discover:aggs:terms:size': 5,
+      });
+      cy.reload();
+    });
+
+    it('check if table respects Number of terms setting', function () {
+      cy.get('[data-test-subj="fieldToggle-machine.ram"]').click();
+      cy.get('[data-test-subj="field-machine.ram-showDetails"]')
+        .click()
+        .then(() => {
+          cy.get('[data-test-subj="fieldVisualize-machine.ram"]').click();
+          cy.get('[class="series histogram"]')
+            .find('[data-label="Count"]')
+            .should('have.length', 5);
+        });
+    });
+
+    after(() => {
+      cy.setAdvancedSetting({
+        'discover:aggs:terms:size': 20,
+      });
+      cy.reload();
+    });
+  });
+
+  describe('hideTimeColumn advanced setting', () => {
+    before(() => {
+      cy.setAdvancedSetting({
+        'doc_table:hideTimeColumn': true,
+      });
+    });
+
+    it('check time is not added on removing last column when hideTimeColumn is true in new table', function () {
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForSearch();
+      cy.switchDiscoverTable('new');
+      cy.get('[data-test-subj="dataGridHeaderCell-@timestamp"]').should(
+        'not.exist'
+      );
+      cy.get('[data-test-subj="fieldToggle-agent"]').click();
+      cy.get('[data-test-subj="fieldToggle-agent"]').click();
+      cy.get('[data-test-subj="dataGridHeaderCell-@timestamp"]').should(
+        'not.exist'
+      );
+    });
+
+    it('check time is not added on removing last column when hideTimeColumn is true in legacy table', function () {
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForSearch();
+      cy.get('[data-test-subj="dataGridHeaderCell-@timestamp"]').should(
+        'not.exist'
+      );
+      cy.get('[data-test-subj="fieldToggle-agent"]').click();
+      cy.get('[data-test-subj="fieldToggle-agent"]').click();
+      cy.get('[data-test-subj="dataGridHeaderCell-@timestamp"]').should(
+        'not.exist'
+      );
+    });
+
+    after(() => {
+      cy.setAdvancedSetting({
+        'doc_table:hideTimeColumn': false,
+      });
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForSearch();
+    });
+  });
+
+  describe('doc_table:highlight advanced setting', () => {
+    before(() => {
+      // Selecting a field and adding a search filter for a value
+      cy.get('[data-test-subj="fieldToggle-index"]')
+        .click()
+        .then(() => {
+          cy.get('[data-test-subj="field-index-showDetails"]').click();
+          cy.get('[data-test-subj="plus-index-logstash-2015.09.22"]').click();
+        });
+    });
+
+    it('check new table respects doc_table:highlight setting', function () {
+      // check if we have highlighted fields
+      cy.setAdvancedSetting({
+        'doc_table:highlight': false,
+      });
+      cy.reload();
+      cy.switchDiscoverTable('new');
+      cy.get('mark').should('not.exist');
+
+      // reset the setting to default value
+      cy.setAdvancedSetting({
+        'doc_table:highlight': true,
+      });
+      cy.reload();
+      cy.switchDiscoverTable('new');
+      cy.get('mark').should('exist');
+    });
+
+    it('check legacy table respects doc_table:highlight setting', function () {
+      // check if we have highlighted fields
+      cy.setAdvancedSetting({
+        'doc_table:highlight': false,
+      });
+      cy.reload();
+      // cy.switchDiscoverTable("legacy");
+      cy.get('mark').should('not.exist');
+
+      // reset the setting to default value
+      cy.setAdvancedSetting({
+        'doc_table:highlight': true,
+      });
+      cy.reload();
+
+      cy.get('mark').should('exist');
+    });
+
+    after(() => {
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForSearch();
+    });
+  });
+
+  describe('defaultColumns advanced setting', () => {
+    before(() => {
+      cy.get('[data-test-subj="comboBoxSearchInput"]')
+        .type('logstash')
+        .then(() => {
+          cy.waitForSearch();
+          cy.get('[title="logstash-*"]').trigger('click');
+        });
+    });
+
+    it('check defaultcolumns setting is respected in new table', function () {
+      cy.setAdvancedSetting({
+        defaultColumns: ['host', 'agent'],
+      });
+      cy.reload();
+      cy.switchDiscoverTable('new');
+      cy.get('[data-test-subj="dataGridHeaderCell-agent"]').should(
+        'be.visible'
+      );
+      cy.get('[data-test-subj="dataGridHeaderCell-host"]').should('be.visible');
+    });
+
+    it('check defaultcolumns setting is respected in legacy table', function () {
+      cy.setAdvancedSetting({
+        defaultColumns: ['host', 'agent'],
+      });
+      cy.reload();
+      cy.get('[data-test-subj="docTableHeader-agent"]').should('be.visible');
+      cy.get('[data-test-subj="docTableHeader-host"]').should('be.visible');
+    });
+
+    after(() => {
+      cy.setAdvancedSetting({
+        defaultColumns: ['_source'],
+      });
+
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForSearch();
+    });
+  });
+
+  describe('searchOnPageLoad advanced setting', () => {
+    before(() => {
+      cy.setAdvancedSetting({
+        'discover:searchOnPageLoad': false,
+      });
+      cy.reload();
+    });
+
+    it('check refresh data button is displayed when searchOnPageLoad is set as false', function () {
+      cy.get('.euiButton__text').contains('Refresh data').should('exist');
+    });
+
+    after(() => {
+      cy.setAdvancedSetting({
+        'discover:searchOnPageLoad': true,
+      });
+      cy.reload();
+    });
+  });
+
+  describe('modifyColumnsOnSwitch advanced setting', () => {
+    before(() => {
+      cy.setAdvancedSetting({
+        'discover:modifyColumnsOnSwitch': false,
+      });
+    });
+
+    it.skip('check columns still available after switching data sources in legacy table', function () {
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForSearch();
+      cy.get('[data-test-subj="fieldToggle-agent"]').click();
+
+      // Now switching the data sources
+      cy.get('[data-test-subj="comboBoxSearchInput"]')
+        .type('nestedindex')
+        .then(() => {
+          cy.get('[title="nestedindex*"]')
+            .trigger('click')
+            .then(() => {
+              cy.wait(300);
+              cy.get('[data-test-subj="docTableHeader-agent"]').should(
+                'be.visible'
+              );
+              cy.get('[data-test-subj="docTableField"]')
+                .contains('-')
+                .should('exist');
+            });
+        });
+
+      /*
+       */
+    });
+
+    it('check columns still available after switching data sources in new table', function () {
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForSearch();
+      cy.switchDiscoverTable('new');
+
+      cy.get('[data-test-subj="fieldToggle-agent"]').click();
+
+      // Now switching the data sources
+      cy.get('[data-test-subj="comboBoxSearchInput"]')
+        .type('nestedindex')
+        .then(() => {
+          cy.waitForSearch();
+          cy.get('[title="nestedindex*"]')
+            .trigger('click')
+            .then(() => {
+              cy.get('[data-test-subj="dataGridHeaderCell-agent"]').should(
+                'be.visible'
+              );
+              cy.get('[data-test-subj="dataGridRowCell"]')
+                .contains('-')
+                .should('exist');
+            });
+        });
+    });
+
+    after(() => {
+      cy.setAdvancedSetting({
+        'discover:modifyColumnsOnSwitch': true,
+      });
+    });
+  });
+
+  after(() => {
+    cy.deleteIndexPattern('nestedindex');
+  });
+});

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_table.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_table.spec.js
@@ -1,0 +1,613 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  MiscUtils,
+  TestFixtureHandler,
+} from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { cloneDeep } from 'lodash';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
+
+const miscUtils = new MiscUtils(cy);
+const testFixtureHandler = new TestFixtureHandler(
+  cy,
+  Cypress.env('openSearchUrl')
+);
+
+const indexSet = [
+  'logstash-2015.09.22',
+  'logstash-2015.09.21',
+  'logstash-2015.09.20',
+];
+
+// Setting up the page
+describe('discover_table', () => {
+  before(() => {
+    // import logstash functional
+    CURRENT_TENANT.newTenant = 'global';
+    testFixtureHandler.importJSONDocIfNeeded(
+      indexSet,
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/logstash/logstash.mappings.json.txt',
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/logstash/logstash.json.txt'
+    );
+
+    testFixtureHandler.importJSONMapping(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.mappings.json.txt'
+    );
+
+    testFixtureHandler.importJSONDoc(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.json.txt'
+    );
+
+    testFixtureHandler.importJSONMapping(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_with_nested_field/mappings.json.txt'
+    );
+
+    testFixtureHandler.importJSONDoc(
+      'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_with_nested_field/data.json.txt'
+    );
+
+    cy.setAdvancedSetting({
+      defaultIndex: 'logstash-*',
+    });
+
+    // Go to the Discover page
+    miscUtils.visitPage(
+      `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+    );
+    cy.waitForSearch();
+  });
+
+  describe('auto line wrapping in legacy table', () => {
+    it('auto line wrapping in legacy table', function () {
+      // last element is _scrore if there is wrapping this field won't be present
+      // So we check for the presence of the _score element in the legacy table
+
+      cy.get('.euiDescriptionList__title').should('contain.text', '_score');
+    });
+  });
+
+  describe('dynamic height of row in new table', () => {
+    before(() => {
+      cy.switchDiscoverTable('new');
+      cy.waitForLoader();
+    });
+
+    it('checks if height of new table changes with change to line count property ', function () {
+      cy.get('[data-test-subj="dataGridRowCell"]')
+        .first()
+        .invoke('height') // Get Row Height Before update
+        .then((res) => {
+          cy.get('.euiButtonEmpty')
+            .contains('Display')
+            .click()
+            .then(() => {
+              cy.get('[type="number"]').type('{selectall}').type('2'); // Update the line count value
+            });
+
+          cy.get('[data-test-subj="dataGridRowCell"]')
+            .first()
+            .invoke('height')
+            .should('be.gt', res); // Check if the new height is greater than previus height
+        });
+    });
+  });
+
+  describe('expand multiple documents in legacy table', () => {
+    before(() => {
+      cy.switchDiscoverTable('legacy');
+    });
+
+    it('checks if multiple documents can be expanded in legacy table', function () {
+      // expanding a document in the table
+      cy.get('[data-test-subj="docTableExpandToggleColumn"]')
+        .find('[type="button"]')
+        .eq(2)
+        .click();
+
+      // expanding a document in the table
+      cy.get('[data-test-subj="docTableExpandToggleColumn"]')
+        .find('[type="button"]')
+        .eq(3)
+        .click();
+
+      // checking the number of exapnded documents visible on screen
+      cy.get('[data-test-subj="tableDocViewRow-_index"]').should(
+        'have.length',
+        2
+      );
+    });
+  });
+
+  describe('data source selector', () => {
+    before(() => {
+      // Creating additional index patterns
+      // logstash index pattern
+
+      cy.createIndexPattern(
+        'logstash-sample-1',
+        {
+          title: 'logstash-sample-1*',
+          timeFieldName: 'timestamp',
+        },
+        {
+          securitytenant: ['global'],
+        }
+      );
+      cy.createIndexPattern(
+        'logstash-sample-2',
+        {
+          title: 'logstash-sample-2*',
+          timeFieldName: 'timestamp',
+        },
+        {
+          securitytenant: ['global'],
+        }
+      );
+      cy.wait(5000); // Intentional Wait
+      cy.reload();
+    });
+    it('check data source selector options are ordered', function () {
+      const indexPatterns = [];
+
+      cy.get('[data-test-subj="comboBoxSearchInput"]')
+        .type('l')
+        .then(() => {
+          cy.get('[type="DEFAULT_INDEX_PATTERNS"]')
+            .each((res) => {
+              indexPatterns.push(res.text());
+            })
+            .then(() => {
+              const sortedIndexPatterns = cloneDeep(indexPatterns);
+              sortedIndexPatterns.sort();
+
+              console.log(sortedIndexPatterns);
+
+              cy.wrap(indexPatterns).should('deep.equal', sortedIndexPatterns);
+            });
+        });
+    });
+
+    it('check filtering in data source selector ', function () {
+      cy.get('[data-test-subj="comboBoxSearchInput"]')
+        .clear()
+        .type('logstash-sample')
+        .then(() => {
+          cy.get('[type="DEFAULT_INDEX_PATTERNS"]').should('have.length', 2);
+        });
+    });
+
+    after(() => {
+      cy.deleteIndexPattern('logstash-sample-1');
+      cy.deleteIndexPattern('logstash-sample-2');
+    });
+  });
+
+  describe('left navigation display', () => {
+    before(() => {
+      cy.switchDiscoverTable('new');
+    });
+    it('check _source is available as default selected field', function () {
+      cy.get('[data-test-subj="fieldList-selected"]').should(
+        'contain.text',
+        '_source'
+      );
+    });
+    it('check timestamp is not added to selected field when a column is added', function () {
+      // Click to add fields
+      cy.get('[data-test-subj="fieldToggle-_id"]').click();
+      cy.get('[data-test-subj="fieldToggle-agent"]').click();
+
+      // Check that the selected field don't contain timestamp
+      cy.get('[data-test-subj="fieldList-selected"]').should(
+        'not.contain.text',
+        '@timestamp'
+      );
+    });
+    it('check timestamp is not added to selected field when a column is removed', function () {
+      cy.get('[data-test-subj="fieldToggle-_id"]').first().click();
+
+      // Check that the selected field don't contain timestamp
+      cy.get('[data-test-subj="fieldList-selected"]').should(
+        'not.contain.text',
+        '@timestamp'
+      );
+    });
+    it('check _source gets restored when all selected columns are removed', function () {
+      cy.get('[data-test-subj="fieldToggle-agent"]').first().click(); // toggle the previously selected fields
+
+      // Now the field selected should get defaulted to _source
+      cy.get('[data-test-subj="fieldList-selected"]').should('have.length', 1);
+      cy.get('[data-test-subj="fieldList-selected"]').should(
+        'contain.text',
+        '_source'
+      );
+    });
+    it('check field is removed from available fields and added to selected fields when the field is selected', function () {
+      // Field present in Available Field Section
+      cy.get('[data-test-subj="fieldList-unpopular"]')
+        .find('[data-test-subj="field-host"]')
+        .should('exist');
+
+      // Toggle to display the field
+      cy.get('[data-test-subj="fieldList-unpopular"]')
+        .find('[data-test-subj="fieldToggle-host"]')
+        .click();
+
+      // Check to ensure the field is no longer present in Available Field
+      cy.get('[data-test-subj="fieldList-unpopular"]')
+        .find('[data-test-subj="field-host"]')
+        .should('not.exist');
+      // Check the field is present in the Selected Field Secition
+      cy.get('[data-test-subj="fieldList-selected"]').should(
+        'contain.text',
+        'host'
+      );
+
+      // Reseting the toggled Field
+      cy.get('[data-test-subj="fieldList-selected"]')
+        .find('[data-test-subj="fieldToggle-host"]')
+        .click();
+    });
+
+    it('check collapsablity of left navigation display', function () {
+      cy.get('[data-test-subj="euiResizableButton"]')
+        .trigger('click')
+        .then(() => {
+          cy.get('[aria-label="Press to toggle this panel"]')
+            .trigger('click')
+            .then(() => {
+              cy.get('[data-test-subj="comboBoxSearchInput"]').should(
+                'not.be.visible'
+              );
+            });
+        });
+    });
+
+    it('check nested field are available in left navigation pane', function () {
+      // Create an Index pattern
+      cy.createIndexPattern(
+        'nestedindex',
+        {
+          title: 'nestedindex*',
+          timeFieldName: 'timestamp',
+        },
+        {
+          securitytenant: ['global'],
+        }
+      );
+      cy.reload();
+
+      cy.get('[data-test-subj="comboBoxSearchInput"]')
+        .type('nestedindex')
+        .then(() => {
+          cy.waitForSearch();
+          cy.get('[title="nestedindex*"]')
+            .trigger('click')
+            .then(() => {
+              // validate the presence of nested fields in left navigation pane
+              cy.get('[data-test-subj="fieldList-unpopular"]')
+                .find('[data-test-subj="field-products.base_price"]')
+                .should('exist');
+              cy.get('[data-test-subj="fieldList-unpopular"]')
+                .find('[data-test-subj="field-products.quantity"]')
+                .should('exist');
+              cy.get('[data-test-subj="fieldList-unpopular"]')
+                .find('[data-test-subj="field-products.discount_percentage"]')
+                .should('exist');
+              cy.get('[data-test-subj="fieldList-unpopular"]')
+                .find('[data-test-subj="field-products.manufacturer"]')
+                .should('exist');
+            });
+        });
+    });
+  });
+
+  describe('Saved Search in new table', () => {
+    before(() => {
+      cy.switchDiscoverTable('new');
+    });
+
+    it('check opening a Saved Search does not cause a page reload', function () {
+      cy.get('[data-test-subj="superDatePickerstartDatePopoverButton"]')
+        .invoke('text')
+        .then((fromDate) => {
+          cy.get('[data-test-subj="superDatePickerendDatePopoverButton"]')
+            .invoke('text')
+            .then((endDate) => {
+              cy.get('[data-test-subj="discoverOpenButton"]').click();
+              cy.get(
+                '[data-test-subj="savedObjectTitleA-Saved-Search"]'
+              ).click();
+              cy.get('[data-test-subj="superDatePickerstartDatePopoverButton"]')
+                .invoke('text')
+                .should('be.eq', fromDate);
+              cy.get('[data-test-subj="superDatePickerendDatePopoverButton"]')
+                .invoke('text')
+                .should('be.eq', endDate);
+            });
+        });
+    });
+
+    after(() => {
+      // resetting the visited page
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForSearch();
+      cy.switchDiscoverTable('legacy');
+    });
+  });
+
+  describe('Infinity Scroll in legacy table', () => {
+    before(() => {
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForSearch();
+    });
+    describe('Legacy Table', () => {
+      it.skip('check scroll down adds 50 entries at a time', function () {
+        // Each row of the table has 2 instance of docTableExpandToggleColumn element
+        // Therefore row count is half of the count of docTableExpandToggleColumn element
+        cy.get('[data-test-subj="docTableExpandToggleColumn"]').should(
+          'have.length',
+          100
+        );
+
+        // scrolling to the end
+        cy.get('[data-test-subj="discoverDocTableFooter"]')
+          .scrollIntoView({ duration: 1000 })
+          .then(() => {
+            cy.get('[data-test-subj="docTableExpandToggleColumn"]').should(
+              'have.length',
+              200
+            );
+          });
+      });
+
+      it.skip('check maximum number of documents loaded', function () {
+        // Scrolling the page 11 times including the previous scroll
+        for (let i = 0; i < 10; i++) {
+          cy.get('[data-test-subj="discoverDocTableFooter"]').scrollIntoView({
+            duration: 100,
+          });
+          cy.wait(300); // Intentional Wait
+        }
+
+        // scrolling to the end
+        cy.get('[data-test-subj="docTableExpandToggleColumn"]').should(
+          'have.length',
+          1000
+        );
+      });
+
+      it('check functionality of Back to top button', function () {
+        cy.get('[data-test-subj="discoverDocTableFooter"]')
+          .scrollIntoView({ duration: 1000 })
+          .then(() => {
+            cy.get('[data-test-subj="docTableField"]')
+              .contains('Sep 22, 2015 @ 16:50:13.253')
+              .should('not.be.visible');
+
+            cy.get('[type="button"]')
+              .contains('Back to top.')
+              .click()
+              .then(() => {
+                // First row should be visible if we navigated to top
+                cy.get('[data-test-subj="docTableField"]')
+                  .contains('Sep 22, 2015 @ 16:50:13.253')
+                  .should('be.visible');
+              });
+          });
+      });
+    });
+  });
+  describe('AutoSize table', () => {
+    describe('Legacy Table', () => {
+      it('check table Auto Size with change in time range', function () {
+        cy.get('[aria-label="Next"]')
+          .its('length')
+          .then((noEntries) => {
+            cy.setTopNavDate(
+              'Sep 22, 2015 @ 14:00:00.000',
+              'Sep 22, 2015 @ 18:00:00.000'
+            );
+            cy.waitForLoader();
+            cy.get('[aria-label="Next"]')
+              .its('length')
+              .should('be.lessThan', noEntries);
+          });
+      });
+
+      it('check table Auto Size with filter', function () {
+        cy.get('[aria-label="Next"]')
+          .its('length')
+          .then((noEntries) => {
+            cy.get('[data-test-subj="field-extension-showDetails"]')
+              .click()
+              .then(() => {
+                cy.get('[data-test-subj="plus-extension-gif"]')
+                  .click()
+                  .then(() => {
+                    cy.wait(2000);
+                    cy.get('[aria-label="Next"]')
+                      .its('length')
+                      .should('be.lessThan', noEntries);
+                  });
+              });
+          });
+      });
+
+      after(() => {
+        miscUtils.visitPage(
+          `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+        );
+        cy.waitForSearch();
+      });
+    });
+    describe('New Table', () => {
+      before(() => {
+        cy.switchDiscoverTable('new');
+      });
+
+      it('check table Auto Size with change in time range', function () {
+        cy.get('[aria-label="Inspect document details"]')
+          .its('length')
+          .then((noEntries) => {
+            cy.setTopNavDate(
+              'Sep 22, 2015 @ 14:00:00.000',
+              'Sep 22, 2015 @ 18:00:00.000'
+            );
+            cy.waitForLoader();
+            cy.get('[aria-label="Inspect document details"]')
+              .its('length')
+              .should('be.lessThan', noEntries);
+          });
+      });
+
+      it('check table Auto Size with filter', function () {
+        cy.get('[aria-label="Inspect document details"]')
+          .its('length')
+          .then((noEntries) => {
+            cy.get('[data-test-subj="field-extension-showDetails"]')
+              .trigger('click')
+              .then(() => {
+                cy.get('[data-test-subj="plus-extension-gif"]')
+                  .trigger('click')
+                  .then(() => {
+                    cy.switchDiscoverTable('new');
+                    cy.get('[aria-label="Inspect document details"]')
+                      .its('length')
+                      .should('be.lessThan', noEntries);
+                  });
+              });
+          });
+      });
+
+      after(() => {
+        miscUtils.visitPage(
+          `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+        );
+        cy.waitForSearch();
+      });
+    });
+  });
+
+  after(() => {
+    cy.reload();
+    cy.deleteIndexPattern('nestedindex');
+    cy.deleteIndex('nestedindex');
+    miscUtils.visitPage(
+      `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+    );
+    cy.waitForSearch();
+  });
+});
+
+describe('Saved Queries', () => {
+  it('check creating saved query', () => {
+    // Creating a saved Query
+    miscUtils.visitPage(
+      `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+    );
+    cy.waitForSearch();
+
+    cy.get('[data-test-subj="saved-query-management-popover-button"]').click();
+
+    cy.get('[data-test-subj="saved-query-management-save-button"]')
+      .click()
+      .then(() => {
+        cy.get('[data-test-subj="saveQueryFormTitle"]')
+          .clear()
+          .type('Sample Saved Query');
+
+        cy.get('[data-test-subj="savedQueryFormSaveButton"]').click();
+      });
+
+    // Verifiy the saved Query
+    cy.get('[data-test-subj="saved-query-management-popover-button"]').click();
+
+    cy.get('[type="button"]').should('contain.text', 'Sample Saved Query');
+  });
+
+  it('check deleting saved query', () => {
+    if (Cypress.env('SECURITY_ENABLED')) {
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForLoader();
+      cy.waitForSearch();
+    } else {
+      cy.reload();
+    }
+    cy.get('[data-test-subj="saved-query-management-popover-button"]').click();
+
+    cy.get('[class="euiListGroupItem__button"]').trigger('mouseover');
+
+    cy.get(
+      '[data-test-subj="delete-saved-query-Sample Saved Query-button"]'
+    ).click({ force: true });
+
+    cy.get('[data-test-subj="confirmModalConfirmButton"]').click({
+      force: true,
+    });
+
+    cy.get('[data-test-subj="saved-query-management-popover-button"]').click();
+
+    cy.get('[type="button"]').should('not.contain.text', 'Sample Saved Query');
+  });
+});
+
+describe('Saved Search Embeddables', () => {
+  describe('Legacy Table', () => {
+    before(() => {
+      miscUtils.visitPage(
+        `app/data-explorer/discover#/?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      cy.waitForSearch();
+      cy.get('[data-test-subj="discoverSaveButton"]')
+        .click()
+        .then(() => {
+          cy.get('[data-test-subj="savedObjectTitle"]')
+            .clear()
+            .type('Legacy Saved Search');
+          cy.get('[data-test-subj="confirmSaveSavedObjectButton"]').click();
+        });
+      cy.get('[data-test-subj="savedObjectSaveModal"]').should('not.exist');
+    });
+    it('check adding legacy table saved search embeddable in dashboard', function () {
+      // navigate to dashboard page
+      miscUtils.visitPage(
+        `/app/dashboards#/create?_g=(filters:!(),time:(from:'2015-09-19T13:31:44.000Z',to:'2015-09-24T01:31:44.000Z'))`
+      );
+      // click on add
+      cy.get('[data-test-subj="dashboardAddPanelButton"]').click();
+      cy.get('[data-test-subj="savedObjectTitleLegacy-Saved-Search"]').click();
+      cy.get('[data-test-subj="euiFlyoutCloseButton"]').click();
+      cy.get('[data-test-subj="docTableHeader-@timestamp"]').should(
+        'be.visible'
+      );
+      cy.get('[data-test-subj="docTableHeader-_source"]').should('be.visible');
+    });
+
+    it('check sort order is retained in legacy table saved search embeddable', function () {
+      cy.get('[data-test-subj="docTableField"]')
+        .eq(0)
+        .invoke('text')
+        .then((firstDate) => {
+          cy.get('[data-test-subj="docTableField"]')
+            .eq(2)
+            .invoke('text')
+            .then((secondDate) => {
+              expect(new Date(secondDate)).lessThan(new Date(firstDate));
+            });
+        });
+    });
+  });
+
+  after(() => {
+    cy.deleteSavedObjectByType('search');
+  });
+});

--- a/cypress/utils/dashboards/data_explorer/commands.js
+++ b/cypress/utils/dashboards/data_explorer/commands.js
@@ -137,16 +137,15 @@ Cypress.Commands.add('deleteSaveQuery', (name) => {
 Cypress.Commands.add('switchDiscoverTable', (name) => {
   cy.getElementByTestId('discoverOptionsButton')
     .then(($button) => {
-      cy.wrap($button).click();
+      cy.wrap($button).click({ force: true });
 
       cy.getElementByTestId('discoverOptionsLegacySwitch').then(
         ($switchButton) => {
-          const isLegacyChecked = $switchButton.checked;
-          if (name === 'new' && !isLegacyChecked) {
-            cy.wrap($switchButton).click();
+          if (name === 'new') {
+            cy.wrap($switchButton).click({ force: true });
           }
-          if (name === 'legacy' && isLegacyChecked) {
-            cy.wrap($switchButton).click();
+          if (name === 'legacy') {
+            cy.wrap($switchButton).click({ force: true });
           }
           cy.waitForLoader();
         }


### PR DESCRIPTION
### Description

This adds functional tests for the issues described in https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6280.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5713

Issues Still Pending (Sub Issues within the Test Suite are mentioned within brackets)

1. **Function Test Suite 2: Copy data without extra data:** No easy way to test copying data to clipboard in cypress
2. **Function Test Suite 5: Left Navigation Display (Should display Unknown type field properly in left navigation):** Niche scenario
3. **Function Test Suite 6: Saved Search Embeddable in Dashboard (When load a saved search in dashboard, sort should be loaded properly Issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5933)** : Issue still open hence couldn't be tested
4. **Function Test Suite 10: Saved query (From index manage page (saved object), click a saved query object created from Discover/Dashboard/Vis can load Discover with proper query and filter Issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5942)** : Issue Still open hence can't be tested

The test suites are divided across two files discover_table and discover_advanced_settings. All the functional tests related to the Advanced Settings are grouped in discover_advanced_setting while the rest are part of discover_table settings.

**Tests when run without security**

https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/38322563/b7d4ead2-99e2-45e0-a7eb-79d545a01e8a

https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/38322563/8a636136-6473-4c46-ada7-0ef06a67ad51



**Tests when run with security**

https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/38322563/35cae8a4-70b8-4d97-8154-252f44c2e9ce


https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/38322563/1eded379-9e6c-4cb9-9074-9cd02493e4a1




### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
