### PR TITLE
[Alerting][2.13] Delete alerts before and after running tests

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/acknowledge_alerts_modal_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/acknowledge_alerts_modal_spec.js
@@ -21,6 +21,7 @@ describe('AcknowledgeAlertsModal', () => {
   before(() => {
     // Delete any existing monitors
     cy.deleteAllMonitors();
+    cy.deleteAllAlerts();
 
     // Load sample data
     cy.loadSampleEcommerceData();
@@ -221,6 +222,9 @@ describe('AcknowledgeAlertsModal', () => {
   after(() => {
     // Delete all monitors
     cy.deleteAllMonitors();
+
+    // Delete all alerts
+    cy.deleteAllAlerts();
 
     // Delete sample data
     cy.deleteIndexByName(`${ALERTING_INDEX.SAMPLE_DATA_ECOMMERCE}`);


### PR DESCRIPTION
### Description
Delete alerts before and after running tests for the acknowledge alerts spec

### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/910

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
