### PR TITLE
[Backport 2.x] rollups/transform: wait for page to render

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/rollups_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/rollups_spec.js
@@ -257,6 +257,10 @@ describe('Rollups', () => {
       // Confirm we have our initial rollup
       cy.contains(ROLLUP_ID);
 
+      // Intercept different rollups requests endpoints to wait before clicking disable and enable buttons
+      cy.intercept(`/api/ism/rollups/${ROLLUP_ID}`).as('getRollup');
+      cy.intercept(`/api/ism/rollups/${ROLLUP_ID}/_stop`).as('stopRollup');
+
       // Click into rollup job details page
       cy.get(`[data-test-subj="rollupLink_${ROLLUP_ID}"]`).click({
         force: true,
@@ -264,21 +268,26 @@ describe('Rollups', () => {
 
       cy.contains(`${ROLLUP_ID}`);
 
-      // Disable button is enabled
-      cy.get(`[data-test-subj="disableButton"]`).should('not.be.disabled');
+      cy.wait('@getRollup').wait(2000);
 
       // Click Disable button
-      cy.get(`[data-test-subj="disableButton"]`).trigger('click', {
-        force: true,
-      });
+      cy.get(`[data-test-subj="disableButton"]`)
+        .should('not.be.disabled')
+        .click({ force: true });
+
+      cy.wait('@stopRollup');
+      cy.wait('@getRollup');
 
       // Confirm we get toaster saying rollup job is disabled
       cy.contains(`${ROLLUP_ID} is disabled`);
 
+      // Extra wait required for page data to load, otherwise "Enable" button will be disabled
+      cy.wait(2000);
+
       // Click Enable button
-      cy.get(`[data-test-subj="enableButton"]`).trigger('click', {
-        force: true,
-      });
+      cy.get(`[data-test-subj="enableButton"]`)
+        .should('not.be.disabled')
+        .click({ force: true });
 
       // Confirm we get toaster saying rollup job is enabled
       cy.contains(`${ROLLUP_ID} is enabled`);

--- a/cypress/integration/plugins/index-management-dashboards-plugin/transforms_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/transforms_spec.js
@@ -239,6 +239,12 @@ describe('Transforms', () => {
       // Confirm we have our initial transform
       cy.contains(TRANSFORM_ID);
 
+      // Intercept different transform requests endpoints to wait before clicking disable and enable buttons
+      cy.intercept(`/api/ism/transforms/${TRANSFORM_ID}`).as('getTransform');
+      cy.intercept(`/api/ism/transforms/${TRANSFORM_ID}/_stop`).as(
+        'stopTransform'
+      );
+
       // Click into transform job details page
       cy.get(`[data-test-subj="transformLink_${TRANSFORM_ID}"]`).click({
         force: true,
@@ -250,24 +256,32 @@ describe('Transforms', () => {
        * appear greyed out and unavailable. Cypress automatically retries,
        * but only after menu is open, doesn't re-render.
        */
-      cy.wait(1000);
+      cy.wait('@getTransform').wait(2000);
 
       // Click into Actions menu
       cy.get(`[data-test-subj="actionButton"]`).click({ force: true });
 
       // Click Disable button
-      cy.get(`[data-test-subj="disableButton"]`).click();
+      cy.get(`[data-test-subj="disableButton"]`)
+        .should('not.be.disabled')
+        .click();
+
+      cy.wait('@stopTransform');
+      cy.wait('@getTransform');
 
       // Confirm we get toaster saying transform job is disabled
       cy.contains(`"${TRANSFORM_ID}" is disabled`);
 
-      cy.wait(1000);
+      // Extra wait required for page data to load, otherwise "Enable" button will be disabled
+      cy.wait(2000);
 
       // Click into Actions menu
       cy.get(`[data-test-subj="actionButton"]`).click({ force: true });
 
       // Click Enable button
-      cy.get(`[data-test-subj="enableButton"]`).click({ force: true });
+      cy.get(`[data-test-subj="enableButton"]`)
+        .should('not.be.disabled')
+        .click({ force: true });
 
       // Confirm we get toaster saying transform job is enabled
       cy.contains(`"${TRANSFORM_ID}" is enabled`);


### PR DESCRIPTION
### Description

Adding intercepts and wait time to mitigate flaky tests.

### Issues Resolved

Resolves https://github.com/opensearch-project/index-management-dashboards-plugin/issues/1011

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
