### PR TITLE
Switch to Private Tenant for Gantt Charts Tests

### DIFF
--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -57,18 +57,6 @@ describe('Dump test data', () => {
 
 describe('Save a gantt chart', { defaultCommandTimeout: 20000 }, () => {
   beforeEach(() => {
-    if (Cypress.env('SECURITY_ENABLED')) {
-      /**
-       * Security plugin is using private tenant as default.
-       * So here we'd need to set global tenant as default manually.
-       */
-      cy.changeDefaultTenant({
-        multitenancy_enabled: true,
-        private_tenant_enabled: true,
-        default_tenant: 'private',
-      });
-    }
-    CURRENT_TENANT.newTenant = 'private';
     cy.visit(`${BASE_PATH}/app/visualize#`);
   });
 
@@ -93,17 +81,6 @@ describe(
   { defaultCommandTimeout: 20000 },
   () => {
     beforeEach(() => {
-      if (Cypress.env('SECURITY_ENABLED')) {
-        /**
-         * Security plugin is using private tenant as default.
-         * So here we'd need to set global tenant as default manually.
-         */
-        cy.changeDefaultTenant({
-          multitenancy_enabled: true,
-          private_tenant_enabled: true,
-          default_tenant: 'private',
-        });
-      }
       CURRENT_TENANT.newTenant = 'private';
       cy.visit(`${BASE_PATH}/app/visualize#`);
       cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
@@ -144,18 +121,6 @@ describe(
 
 describe('Configure panel settings', { defaultCommandTimeout: 20000 }, () => {
   beforeEach(() => {
-    if (Cypress.env('SECURITY_ENABLED')) {
-      /**
-       * Security plugin is using private tenant as default.
-       * So here we'd need to set global tenant as default manually.
-       */
-      cy.changeDefaultTenant({
-        multitenancy_enabled: true,
-        private_tenant_enabled: true,
-        default_tenant: 'private',
-      });
-    }
-    CURRENT_TENANT.newTenant = 'private';
     cy.visit(`${BASE_PATH}/app/visualize#`);
     cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
     cy.contains(GANTT_VIS_NAME).click({ force: true });

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -20,7 +20,7 @@ const DEFAULT_SIZE = 10;
 
 describe('Dump test data', () => {
   it('Indexes test data for gantt chart', () => {
-    CURRENT_TENANT.newTenant = 'global';
+    CURRENT_TENANT.newTenant = 'private';
     const dumpDataSet = (ndjson, index) =>
       cy.request({
         method: 'POST',
@@ -56,10 +56,19 @@ describe('Dump test data', () => {
 });
 
 describe('Save a gantt chart', { defaultCommandTimeout: 20000 }, () => {
-  before(() => {
-    CURRENT_TENANT.newTenant = 'global';
-  });
   beforeEach(() => {
+    if (Cypress.env('SECURITY_ENABLED')) {
+      /**
+       * Security plugin is using private tenant as default.
+       * So here we'd need to set global tenant as default manually.
+       */
+      cy.changeDefaultTenant({
+        multitenancy_enabled: true,
+        private_tenant_enabled: true,
+        default_tenant: 'private',
+      });
+    }
+    CURRENT_TENANT.newTenant = 'private';
     cy.visit(`${BASE_PATH}/app/visualize#`);
   });
 
@@ -83,10 +92,19 @@ describe(
   'Render and configure a gantt chart',
   { defaultCommandTimeout: 20000 },
   () => {
-    before(() => {
-      CURRENT_TENANT.newTenant = 'global';
-    });
     beforeEach(() => {
+      if (Cypress.env('SECURITY_ENABLED')) {
+        /**
+         * Security plugin is using private tenant as default.
+         * So here we'd need to set global tenant as default manually.
+         */
+        cy.changeDefaultTenant({
+          multitenancy_enabled: true,
+          private_tenant_enabled: true,
+          default_tenant: 'private',
+        });
+      }
+      CURRENT_TENANT.newTenant = 'private';
       cy.visit(`${BASE_PATH}/app/visualize#`);
       cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
       cy.contains(GANTT_VIS_NAME).click({ force: true });
@@ -125,10 +143,19 @@ describe(
 );
 
 describe('Configure panel settings', { defaultCommandTimeout: 20000 }, () => {
-  before(() => {
-    CURRENT_TENANT.newTenant = 'global';
-  });
   beforeEach(() => {
+    if (Cypress.env('SECURITY_ENABLED')) {
+      /**
+       * Security plugin is using private tenant as default.
+       * So here we'd need to set global tenant as default manually.
+       */
+      cy.changeDefaultTenant({
+        multitenancy_enabled: true,
+        private_tenant_enabled: true,
+        default_tenant: 'private',
+      });
+    }
+    CURRENT_TENANT.newTenant = 'private';
     cy.visit(`${BASE_PATH}/app/visualize#`);
     cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
     cy.contains(GANTT_VIS_NAME).click({ force: true });
@@ -251,9 +278,6 @@ describe(
   'Add gantt chart to dashboard',
   { defaultCommandTimeout: 20000 },
   () => {
-    before(() => {
-      CURRENT_TENANT.newTenant = 'global';
-    });
     it('Adds gantt chart to dashboard', () => {
       cy.visit(`${BASE_PATH}/app/dashboards#/create`);
       cy.contains('Add an existing').click({ force: true });


### PR DESCRIPTION
### Description
Since #1187 was merged in while the failures were unresolved, opening this one to fix failures. Setting to draft initially so it doesn't get merged before finished again. Following #1033 example of setting tenants

**Needs `backport 2.x` and `backport 2.13` labels. Must go in _after_ #1190 and #1191**

### Issues Resolved

[#354](https://github.com/opensearch-project/dashboards-visualizations/issues/354)

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
