### PR TITLE
[2.13] Switch to Private Tenant for Gantt Charts Tests

### DIFF
--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -63,7 +63,7 @@ describe('Dump test data', () => {
       body: JSON.stringify({ attributes: { title: 'jaeger' } }),
     });
     devToolsRequest('.kibana*/_refresh', 'POST');
-    // cy.wait('@dumpDataRequest');
+    cy.wait('@dumpDataRequest');
   });
 });
 

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -123,7 +123,7 @@ describe('Configure panel settings', { defaultCommandTimeout: 20000 }, () => {
   beforeEach(() => {
     cy.visit(`${BASE_PATH}/app/visualize#`);
     cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
-    cy.contains(GANTT_VIS_NAME).click({ force: true });
+    cy.contains(GANTT_VIS_NAME).should('exist').click({ force: true });
     cy.contains('Panel settings').click({ force: true });
   });
 

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -30,7 +30,6 @@ describe('Dump test data', () => {
       });
     }
     CURRENT_TENANT.newTenant = 'private';
-    cy.intercept('**').as('dumpDataRequest');
     const dumpDataSet = (ndjson, index) =>
       cy.request({
         method: 'POST',
@@ -63,7 +62,6 @@ describe('Dump test data', () => {
       body: JSON.stringify({ attributes: { title: 'jaeger' } }),
     });
     devToolsRequest('.kibana*/_refresh', 'POST');
-    cy.wait('@dumpDataRequest');
   });
 });
 

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -9,6 +9,7 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 import dayjs from 'dayjs';
 import { BASE_PATH } from '../../../utils/constants';
 import { CURRENT_TENANT } from '../../../utils/commands';
+import { devToolsRequest } from '../../../utils/helpers';
 
 dayjs.extend(customParseFormat);
 
@@ -21,10 +22,7 @@ const DEFAULT_SIZE = 10;
 describe('Dump test data', () => {
   it('Indexes test data for gantt chart', () => {
     if (Cypress.env('SECURITY_ENABLED')) {
-      /**
-       * Security plugin is using private tenant as default.
-       * So here we'd need to set global tenant as default manually.
-       */
+      // Set default tenant to private to avoid tenant popup
       cy.changeDefaultTenant({
         multitenancy_enabled: true,
         private_tenant_enabled: true,
@@ -32,6 +30,7 @@ describe('Dump test data', () => {
       });
     }
     CURRENT_TENANT.newTenant = 'private';
+    cy.intercept('**').as('dumpDataRequest');
     const dumpDataSet = (ndjson, index) =>
       cy.request({
         method: 'POST',
@@ -63,6 +62,8 @@ describe('Dump test data', () => {
       },
       body: JSON.stringify({ attributes: { title: 'jaeger' } }),
     });
+    devToolsRequest('.kibana*/_refresh', 'POST');
+    // cy.wait('@dumpDataRequest');
   });
 });
 

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -83,7 +83,10 @@ describe(
     beforeEach(() => {
       CURRENT_TENANT.newTenant = 'private';
       cy.visit(`${BASE_PATH}/app/visualize#`);
+      cy.intercept('**').as('searchRequest');
       cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
+      cy.wait('@searchRequest');
+      cy.wait(5000);
       cy.get('[data-test-subj="itemsInMemTable"]')
         .contains(GANTT_VIS_NAME)
         .click({

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -20,6 +20,17 @@ const DEFAULT_SIZE = 10;
 
 describe('Dump test data', () => {
   it('Indexes test data for gantt chart', () => {
+    if (Cypress.env('SECURITY_ENABLED')) {
+      /**
+       * Security plugin is using private tenant as default.
+       * So here we'd need to set global tenant as default manually.
+       */
+      cy.changeDefaultTenant({
+        multitenancy_enabled: true,
+        private_tenant_enabled: true,
+        default_tenant: 'private',
+      });
+    }
     CURRENT_TENANT.newTenant = 'private';
     const dumpDataSet = (ndjson, index) =>
       cy.request({

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -20,7 +20,7 @@ const DEFAULT_SIZE = 10;
 
 describe('Dump test data', () => {
   it('Indexes test data for gantt chart', () => {
-    CURRENT_TENANT.newTenant = 'global';
+    CURRENT_TENANT.newTenant = 'private';
     const dumpDataSet = (ndjson, index) =>
       cy.request({
         method: 'POST',
@@ -56,9 +56,6 @@ describe('Dump test data', () => {
 });
 
 describe('Save a gantt chart', { defaultCommandTimeout: 20000 }, () => {
-  before(() => {
-    CURRENT_TENANT.newTenant = 'global';
-  });
   beforeEach(() => {
     cy.visit(`${BASE_PATH}/app/visualize#`);
   });
@@ -83,10 +80,8 @@ describe(
   'Render and configure a gantt chart',
   { defaultCommandTimeout: 20000 },
   () => {
-    before(() => {
-      CURRENT_TENANT.newTenant = 'global';
-    });
     beforeEach(() => {
+      CURRENT_TENANT.newTenant = 'private';
       cy.visit(`${BASE_PATH}/app/visualize#`);
       cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
       cy.contains(GANTT_VIS_NAME).click({ force: true });
@@ -125,9 +120,6 @@ describe(
 );
 
 describe('Configure panel settings', { defaultCommandTimeout: 20000 }, () => {
-  before(() => {
-    CURRENT_TENANT.newTenant = 'global';
-  });
   beforeEach(() => {
     cy.visit(`${BASE_PATH}/app/visualize#`);
     cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
@@ -251,9 +243,6 @@ describe(
   'Add gantt chart to dashboard',
   { defaultCommandTimeout: 20000 },
   () => {
-    before(() => {
-      CURRENT_TENANT.newTenant = 'global';
-    });
     it('Adds gantt chart to dashboard', () => {
       cy.visit(`${BASE_PATH}/app/dashboards#/create`);
       cy.contains('Add an existing').click({ force: true });

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -129,6 +129,7 @@ describe('Configure panel settings', { defaultCommandTimeout: 20000 }, () => {
     cy.intercept('**').as('searchRequest');
     cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
     cy.wait('@searchRequest');
+    cy.wait(5000);
     cy.contains(GANTT_VIS_NAME).should('exist').click();
     cy.contains('Panel settings').click({ force: true });
   });

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -129,7 +129,7 @@ describe('Configure panel settings', { defaultCommandTimeout: 20000 }, () => {
     cy.intercept('**').as('searchRequest');
     cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
     cy.wait('@searchRequest');
-    cy.contains(GANTT_VIS_NAME).should('exist').click({ force: true });
+    cy.contains(GANTT_VIS_NAME).should('exist').click();
     cy.contains('Panel settings').click({ force: true });
   });
 

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -84,7 +84,11 @@ describe(
       CURRENT_TENANT.newTenant = 'private';
       cy.visit(`${BASE_PATH}/app/visualize#`);
       cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
-      cy.contains(GANTT_VIS_NAME).click({ force: true });
+      cy.get('[data-test-subj="itemsInMemTable"]')
+        .contains(GANTT_VIS_NAME)
+        .click({
+          force: true,
+        });
     });
 
     it('Renders no data message', () => {

--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -126,7 +126,9 @@ describe(
 describe('Configure panel settings', { defaultCommandTimeout: 20000 }, () => {
   beforeEach(() => {
     cy.visit(`${BASE_PATH}/app/visualize#`);
+    cy.intercept('**').as('searchRequest');
     cy.get('.euiFieldSearch').focus().type(GANTT_VIS_NAME);
+    cy.wait('@searchRequest');
     cy.contains(GANTT_VIS_NAME).should('exist').click({ force: true });
     cy.contains('Panel settings').click({ force: true });
   });


### PR DESCRIPTION
### Description

Duplicate of #1194 to attempt on `2.13` since OS is more stable.
Since #1187 was merged in while the failures were unresolved, opening this one to fix failures. Setting to draft initially so it doesn't get merged before finished again. Following #1033 example of setting tenants

**Needs `backport 2.x` and `backport main` labels. Must go in _after_ #1190 and #1191**

### Issues Resolved

[#354](https://github.com/opensearch-project/dashboards-visualizations/issues/354)

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
