### PR TITLE
[Multiple Datasource]Fix failed test cases caused by switching from EuiSelect to EuiSuperSelect

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/datasource-management-plugin/1_create_datasource.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/datasource-management-plugin/1_create_datasource.spec.js
@@ -7,15 +7,21 @@ import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-tes
 import {
   OSD_TEST_DOMAIN_ENDPOINT_URL,
   OSD_INVALID_ENDPOINT_URL,
+  DATASOURCE_DELAY,
+  REGION,
+  ACCESS_KEY,
+  SECRET_KEY,
+  AUTH_TYPE_BASIC_AUTH,
+  AUTH_TYPE_NO_AUTH,
+  AUTH_TYPE_SIGV4,
+  SERVICE_TYPE_OPENSEARCH,
+  SERVICE_TYPE_OPENSEARCH_SERVERLESS,
 } from '../../../../utils/dashboards/datasource-management-dashboards-plugin/constants';
 
 const miscUtils = new MiscUtils(cy);
 // Get environment variables
 const username = Cypress.env('username');
 const password = Cypress.env('password');
-const REGION = 'us-east-1';
-const ACCESS_KEY = 'accessKey';
-const SECRET_KEY = 'secretKey';
 
 if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
   describe('Create datasources', () => {
@@ -48,22 +54,18 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
 
     describe('Datasource can be created successfully', () => {
       it('with no auth and all required inputs', () => {
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
-          'be.disabled'
-        );
+        cy.getElementByTestId('createDataSourceButton').should('be.disabled');
         cy.get('[name="dataSourceTitle"]').type('test_noauth');
         cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL);
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'no_auth'
-        );
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
-          'be.enabled'
-        );
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_NO_AUTH}]`).click();
+
+        cy.getElementByTestId('createDataSourceButton').should('be.enabled');
         cy.get('[name="dataSourceDescription"]').type(
           'cypress test no auth data source'
         );
 
-        cy.get('[data-test-subj="createDataSourceButton"]').click();
+        cy.getElementByTestId('createDataSourceButton').click();
         cy.wait('@createDataSourceRequest').then((interception) => {
           expect(interception.response.statusCode).to.equal(200);
         });
@@ -74,27 +76,24 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
 
       it('with basic auth and all required inputs', () => {
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
-          'be.disabled'
-        );
+        cy.getElementByTestId('createDataSourceButton').should('be.disabled');
         cy.get('[name="dataSourceTitle"]').type('test_auth');
         cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL);
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'username_password'
-        );
-        cy.get('[data-test-subj="createDataSourceFormUsernameField"]').type(
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click()
+          .wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormUsernameField').type(
           username
         );
-        cy.get('[data-test-subj="createDataSourceFormPasswordField"]').type(
+        cy.getElementByTestId('createDataSourceFormPasswordField').type(
           password
         );
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
-          'be.enabled'
-        );
+        cy.getElementByTestId('createDataSourceButton').should('be.enabled');
         cy.get('[name="dataSourceDescription"]').type(
           'cypress test basic auth data source'
         );
-        cy.get('[data-test-subj="createDataSourceButton"]').click();
+        cy.getElementByTestId('createDataSourceButton').click();
         cy.wait('@createDataSourceRequest').then((interception) => {
           expect(interception.response.statusCode).to.equal(200);
         });
@@ -105,34 +104,30 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
 
       it('with sigV4 and all required inputs to connect to OpenSearch Service', () => {
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
-          'be.disabled'
-        );
+        cy.getElementByTestId('createDataSourceButton').should('be.disabled');
         cy.get('[name="dataSourceTitle"]').type('test_sigv4_es');
         cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL);
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'sigv4'
-        );
-        cy.get('[data-test-subj="createDataSourceFormRegionField"]').type(
-          REGION
-        );
-        cy.get(
-          '[data-test-subj="createDataSourceFormSigV4ServiceTypeSelect"]'
-        ).select('es');
-        cy.get('[data-test-subj="createDataSourceFormAccessKeyField"]').type(
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_SIGV4}]`).click().wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormRegionField').type(REGION);
+        cy.getElementByTestId(
+          'createDataSourceFormSigV4ServiceTypeSelect'
+        ).click();
+        cy.get(`button[id=${SERVICE_TYPE_OPENSEARCH}]`)
+          .click()
+          .wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormAccessKeyField').type(
           ACCESS_KEY
         );
-        cy.get('[data-test-subj="createDataSourceFormSecretKeyField"]').type(
+        cy.getElementByTestId('createDataSourceFormSecretKeyField').type(
           SECRET_KEY
         );
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
-          'be.enabled'
-        );
+        cy.getElementByTestId('createDataSourceButton').should('be.enabled');
         cy.get('[name="dataSourceDescription"]').type(
           'cypress test sigV4 data source'
         );
 
-        cy.get('[data-test-subj="createDataSourceButton"]').click();
+        cy.getElementByTestId('createDataSourceButton').click();
         cy.wait('@createDataSourceRequest').then((interception) => {
           expect(interception.response.statusCode).to.equal(200);
         });
@@ -144,34 +139,29 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
 
       it('with sigV4 and all required inputs to connect to OpenSearch Serverless Service', () => {
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
-          'be.disabled'
-        );
+        cy.getElementByTestId('createDataSourceButton').should('be.disabled');
         cy.get('[name="dataSourceTitle"]').type('test_sigv4_aoss');
         cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL);
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'sigv4'
-        );
-        cy.get('[data-test-subj="createDataSourceFormRegionField"]').type(
-          REGION
-        );
-        cy.get(
-          '[data-test-subj="createDataSourceFormSigV4ServiceTypeSelect"]'
-        ).select('aoss');
-        cy.get('[data-test-subj="createDataSourceFormAccessKeyField"]').type(
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_SIGV4}]`).click().wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormRegionField').type(REGION);
+        cy.getElementByTestId('createDataSourceFormSigV4ServiceTypeSelect')
+          .click()
+          .get(`button[id=${SERVICE_TYPE_OPENSEARCH_SERVERLESS}]`)
+          .click()
+          .wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormAccessKeyField').type(
           ACCESS_KEY
         );
-        cy.get('[data-test-subj="createDataSourceFormSecretKeyField"]').type(
+        cy.getElementByTestId('createDataSourceFormSecretKeyField').type(
           SECRET_KEY
         );
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
-          'be.enabled'
-        );
+        cy.getElementByTestId('createDataSourceButton').should('be.enabled');
         cy.get('[name="dataSourceDescription"]').type(
           'cypress test sigV4 data source (Serverless)'
         );
 
-        cy.get('[data-test-subj="createDataSourceButton"]').click();
+        cy.getElementByTestId('createDataSourceButton').click();
         cy.wait('@createDataSourceRequest').then((interception) => {
           expect(interception.response.statusCode).to.equal(200);
         });
@@ -246,19 +236,21 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
 
     describe('Username validation', () => {
       it('validate that username field does not show when auth type is no auth', () => {
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'no_auth'
-        );
-        cy.get('[data-test-subj="createDataSourceFormUsernameField"]').should(
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_NO_AUTH}]`)
+          .click()
+          .wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormUsernameField').should(
           'not.exist'
         );
       });
 
       it('validate that username is a required field when auth type is username & password', () => {
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'username_password'
-        );
-        cy.get('[data-test-subj="createDataSourceFormUsernameField"]')
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click()
+          .wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormUsernameField')
           .focus()
           .blur();
         cy.get(
@@ -267,10 +259,11 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
 
       it('validate that username field does not show any error when auth type is username & password and field is not empty', () => {
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'username_password'
-        );
-        cy.get('[data-test-subj="createDataSourceFormUsernameField"]')
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click()
+          .wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormUsernameField')
           .type(username)
           .blur();
         cy.get(
@@ -281,19 +274,19 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
 
     describe('Password validation', () => {
       it('validate that password field does not show when auth type is no auth', () => {
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'no_auth'
-        );
-        cy.get('[data-test-subj="createDataSourceFormPasswordField"]').should(
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_NO_AUTH}]`).click();
+        cy.getElementByTestId('createDataSourceFormPasswordField').should(
           'not.exist'
         );
       });
 
       it('validate that password is a required field when auth type is username & password', () => {
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'username_password'
-        );
-        cy.get('[data-test-subj="createDataSourceFormPasswordField"]')
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click()
+          .wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormPasswordField')
           .focus()
           .blur();
         cy.get(
@@ -302,10 +295,11 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
 
       it('validate that password field does not show any error when auth type is username & password and field is not empty', () => {
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'username_password'
-        );
-        cy.get('[data-test-subj="createDataSourceFormPasswordField"]')
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click()
+          .wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormPasswordField')
           .type(password)
           .blur();
         cy.get(
@@ -316,22 +310,18 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
 
     describe('SigV4 AuthType: fields validation', () => {
       it('validate that region is a required field', () => {
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'sigv4'
-        );
-        cy.get('[data-test-subj="createDataSourceFormRegionField"]')
-          .focus()
-          .blur();
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_SIGV4}]`).click().wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormRegionField').focus().blur();
         cy.get(
           'input[data-test-subj="createDataSourceFormRegionField"]:invalid'
         ).should('have.length', 1);
       });
 
       it('validate that accessKey is a required field', () => {
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'sigv4'
-        );
-        cy.get('[data-test-subj="createDataSourceFormAccessKeyField"]')
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_SIGV4}]`).click().wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormAccessKeyField')
           .focus()
           .blur();
         cy.get(
@@ -340,10 +330,9 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
 
       it('validate that secretKey is a required field', () => {
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'sigv4'
-        );
-        cy.get('[data-test-subj="createDataSourceFormSecretKeyField"]')
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_SIGV4}]`).click().wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceFormSecretKeyField')
           .focus()
           .blur();
         cy.get(
@@ -352,12 +341,11 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
 
       it('validate that serviceName is a required field, and with default option rendered', () => {
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'sigv4'
-        );
-        cy.get(
-          '[data-test-subj="createDataSourceFormSigV4ServiceTypeSelect"]'
-        ).should('have.value', 'es');
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_SIGV4}]`).click().wait(DATASOURCE_DELAY);
+        cy.getElementByTestId(
+          'createDataSourceFormSigV4ServiceTypeSelect'
+        ).contains('Amazon OpenSearch Service');
       });
     });
 
@@ -366,9 +354,7 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         miscUtils.visitPage(
           'app/management/opensearch-dashboards/dataSources/create'
         );
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
-          'be.disabled'
-        );
+        cy.getElementByTestId('createDataSourceButton').should('be.disabled');
       });
 
       it('validate if create data source button is disabled when there is any field error', () => {
@@ -377,24 +363,23 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
           'have.length',
           1
         );
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
-          'be.disabled'
-        );
+        cy.getElementByTestId('createDataSourceButton').should('be.disabled');
       });
 
       it('validate if create data source button is not disabled only if there is no any field error', () => {
         cy.get('[name="dataSourceTitle"]').type('test_create_button');
         cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL);
-        cy.get('[data-test-subj="createDataSourceFormAuthTypeSelect"]').select(
-          'no_auth'
-        );
-        cy.get('[data-test-subj="createDataSourceButton"]').should(
+        cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
+        cy.get(`button[id=${AUTH_TYPE_NO_AUTH}]`)
+          .click()
+          .wait(DATASOURCE_DELAY);
+        cy.getElementByTestId('createDataSourceButton').should(
           'not.be.disabled'
         );
       });
 
       it('cancel button should redirect to datasource listing page', () => {
-        cy.get('[data-test-subj="cancelCreateDataSourceButton"]').click();
+        cy.getElementByTestId('cancelCreateDataSourceButton').click();
         cy.location('pathname', { timeout: 6000 }).should(
           'include',
           'app/management/opensearch-dashboards/dataSources'

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/datasource-management-plugin/3_update_datasource.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/datasource-management-plugin/3_update_datasource.spec.js
@@ -9,6 +9,9 @@ import {
   DS_JSON_UNIQUE_VALUES,
   FORCE_CLICK_OPTS,
   TIMEOUT_OPTS,
+  AUTH_TYPE_BASIC_AUTH,
+  AUTH_TYPE_NO_AUTH,
+  AUTH_TYPE_SIGV4,
 } from '../../../../utils/dashboards/datasource-management-dashboards-plugin/constants';
 
 const passwordFieldIdentifier =
@@ -21,9 +24,9 @@ const confirmUpdatedPasswordIdentifier =
 const typeInInputFieldAndBlur = (name, updatedText, identifier) => {
   const locator = identifier || `[name="${name}"]`;
   if (updatedText && updatedText.length) {
-    cy.get(locator).clear().focus().type(updatedText).blur();
+    cy.get(locator).clear(FORCE_CLICK_OPTS).focus().type(updatedText).blur();
   } else {
-    cy.get(locator).clear().focus().blur();
+    cy.get(locator).clear(FORCE_CLICK_OPTS).focus().blur();
   }
 };
 
@@ -152,9 +155,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
       it('should make sure that endpoint field is disabled in all scenarios', () => {
         // credential: Username & password
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'username_password'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click();
         cy.get('input[name="endpoint"]').should('be.disabled');
         cy.get('input[name="endpoint"]').should(
           'have.value',
@@ -162,9 +166,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         );
 
         // credential: No Authentication
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'no_auth'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_NO_AUTH}]`)
+          .click();
         cy.get('input[name="endpoint"]').should('be.disabled');
         cy.get('input[name="endpoint"]').should(
           'have.value',
@@ -172,9 +177,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         );
 
         // credential: sigv4
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'sigv4'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_SIGV4}]`)
+          .click();
         cy.get('input[name="endpoint"]').should('be.disabled');
         cy.get('input[name="endpoint"]').should(
           'have.value',
@@ -183,9 +189,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
       it('should make sure that username field is required for credential: Username & password & hidden when credential: No Authentication', () => {
         // credential: Username & password
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'username_password'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click();
         cy.get('input[name="datasourceUsername"]').should('exist');
         cy.get('input[name="datasourceUsername"]').should('be.empty');
 
@@ -208,16 +215,18 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         );
 
         // credential: No Authentication
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'no_auth'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_NO_AUTH}]`)
+          .click();
         cy.get('input[name="datasourceUsername"]').should('not.exist');
       });
       it('should make sure that password field is required', () => {
         // credential: Username & password
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'username_password'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click();
         cy.getElementByTestId('editDatasourceUpdatePasswordBtn').should(
           'not.exist'
         );
@@ -237,9 +246,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         cy.get('input[type="password"]:valid').should('have.length', 1);
 
         // credential: No Authentication
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'no_auth'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_NO_AUTH}]`)
+          .click();
         cy.get(passwordFieldIdentifier).should('not.exist');
       });
     });
@@ -269,9 +279,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
       it('should change credential to "Username & Password" & save changes with valid form', () => {
         // credential: Username & password
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'username_password'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click();
         // set username
         typeInInputFieldAndBlur(
           'datasourceUsername',
@@ -294,9 +305,8 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
       it('should verify that changes were updated successfully', () => {
         // credential: Username & password
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').should(
-          'have.value',
-          'username_password'
+        cy.getElementByTestId('editDataSourceSelectAuthType').contains(
+          'Username & Password'
         );
         cy.get('[name="datasourceUsername"]').should(
           'have.value',
@@ -368,9 +378,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
       it('should make sure that endpoint field is disabled in all scenarios', () => {
         // credential: No Authentication
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'no_auth'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_NO_AUTH}]`)
+          .click();
         cy.get('input[name="endpoint"]').should('be.disabled');
         cy.get('input[name="endpoint"]').should(
           'have.value',
@@ -378,9 +389,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         );
 
         // credential: Username & password
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'username_password'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click();
         cy.get('input[name="endpoint"]').should('be.disabled');
         cy.get('input[name="endpoint"]').should(
           'have.value',
@@ -390,15 +402,17 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
 
       it('should make sure that username field is hidden when credential: No Authentication & required for credential: Username & password', () => {
         // credential: No Authentication
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'no_auth'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_NO_AUTH}]`)
+          .click();
         cy.get('input[name="datasourceUsername"]').should('not.exist');
 
         // credential: Username & password
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'username_password'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click();
         cy.get('input[name="datasourceUsername"]').should('exist');
         cy.get('input[name="datasourceUsername"]').should(
           'have.value',
@@ -425,18 +439,20 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
       it('should make sure that password field is disabled & Update stored password button is present', () => {
         // credential: No Authentication
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'no_auth'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_NO_AUTH}]`)
+          .click();
         cy.get(passwordFieldIdentifier).should('not.exist');
         cy.getElementByTestId('editDatasourceUpdatePasswordBtn').should(
           'not.exist' // Update stored password button
         );
 
         // credential: Username & password
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'username_password'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
+          .click();
         cy.getElementByTestId('editDatasourceUpdatePasswordBtn').should(
           'exist' // Update stored password button
         );
@@ -446,9 +462,9 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
     });
     describe('validation: Update stores password modal', () => {
       it('should display update password modal', () => {
-        cy.getElementByTestId('editDatasourceUpdatePasswordBtn').click({
-          force: true,
-        });
+        cy.getElementByTestId('editDatasourceUpdatePasswordBtn').click(
+          FORCE_CLICK_OPTS
+        );
         cy.get('.euiModal').should('exist');
         cy.getElementByTestId('updateStoredPasswordConfirmBtn').should(
           'be.disabled'
@@ -521,15 +537,15 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
     });
     describe('Cancel & update password from modal', () => {
       it('should close the update stored password modal', () => {
-        cy.getElementByTestId('updateStoredPasswordCancelBtn').click({
-          force: true,
-        });
+        cy.getElementByTestId('updateStoredPasswordCancelBtn').click(
+          FORCE_CLICK_OPTS
+        );
         cy.get('.euiModal').should('not.exist');
       });
       it('should not remember previous input for updated & confirm updated password fields', () => {
-        cy.getElementByTestId('editDatasourceUpdatePasswordBtn').click({
-          force: true,
-        });
+        cy.getElementByTestId('editDatasourceUpdatePasswordBtn').click(
+          FORCE_CLICK_OPTS
+        );
         cy.get(updatedPasswordIdentifier).should(
           'not.have.value',
           DS_JSON_UNIQUE_VALUES.attributes.auth.credentials.password
@@ -553,9 +569,9 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         cy.getElementByTestId('updateStoredPasswordConfirmBtn').should(
           'be.enabled'
         );
-        cy.getElementByTestId('updateStoredPasswordConfirmBtn').click({
-          force: true,
-        });
+        cy.getElementByTestId('updateStoredPasswordConfirmBtn').click(
+          FORCE_CLICK_OPTS
+        );
         cy.get('.euiModal', TIMEOUT_OPTS).should('not.exist');
         cy.contains('Password updated successfully.', TIMEOUT_OPTS).should(
           'exist'
@@ -565,9 +581,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
     describe('bottom bar: Save Changes -> "Change Credential Type & few fields"', () => {
       it('should change credential to "No Authentication" & save changes with valid form', () => {
         // credential: No Authentication
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'no_auth'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_NO_AUTH}]`)
+          .click();
         typeInInputFieldAndBlur(
           'dataSourceTitle',
           DS_JSON_UNIQUE_VALUES.attributes.title,
@@ -587,9 +604,8 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
           DS_JSON_UNIQUE_VALUES.attributes.title
         );
         // credential: No Authentication
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').should(
-          'have.value',
-          'no_auth'
+        cy.getElementByTestId('editDataSourceSelectAuthType').contains(
+          'No authentication'
         );
         cy.get('[name="datasourceUsername"]').should('not.exist');
         cy.get(passwordFieldIdentifier).should('not.exist');
@@ -602,13 +618,14 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
     describe(`Updating current datasource auth type from "no auth" to "SigV4"`, () => {
       it('should change credential to "SigV4" & render only related fields', () => {
         // verify current auth type is "no auth"
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').should(
-          'have.value',
-          'no_auth'
+        cy.getElementByTestId('editDataSourceSelectAuthType').contains(
+          'No authentication'
         );
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'sigv4'
-        );
+
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_SIGV4}]`)
+          .click();
 
         // username & password fields should be hidden
         cy.get('input[name="datasourceUsername"]').should('not.exist');
@@ -621,7 +638,7 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         cy.getElementByTestId('editDataSourceFormRegionField').should('exist');
         cy.getElementByTestId(
           'editDataSourceFormSigV4ServiceTypeSelect'
-        ).should('have.value', 'es');
+        ).contains('Amazon OpenSearch Service');
         cy.getElementByTestId('editDataSourceFormAccessKeyField').should(
           'exist'
         );
@@ -685,9 +702,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
     describe('bottom bar: Save Changes -> "Change Credential Type to sigv4"', () => {
       it('should change credential to "SigV4" & save changes with valid form', () => {
         // credential: SigV4
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').select(
-          'sigv4'
-        );
+        cy.getElementByTestId('editDataSourceSelectAuthType')
+          .click()
+          .get(`button[id=${AUTH_TYPE_SIGV4}]`)
+          .click();
         // set region
         typeInInputFieldAndBlur(
           '',
@@ -709,9 +727,12 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         );
 
         // set service type
-        cy.getElementByTestId(
-          'editDataSourceFormSigV4ServiceTypeSelect'
-        ).select(DS_JSON_UNIQUE_VALUES.attributes.auth.credentials.service);
+        cy.getElementByTestId('editDataSourceFormSigV4ServiceTypeSelect')
+          .click()
+          .get(
+            `button[id="${DS_JSON_UNIQUE_VALUES.attributes.auth.credentials.service}"]`
+          )
+          .click();
 
         cy.getElementByTestId('datasource-edit-saveButton')
           .should('be.enabled')
@@ -722,9 +743,8 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         ).should('not.exist');
       });
       it('should verify that changes were updated successfully', () => {
-        cy.get('[data-test-subj="editDataSourceSelectAuthType"]').should(
-          'have.value',
-          'sigv4'
+        cy.getElementByTestId('editDataSourceSelectAuthType').contains(
+          'AWS SigV4'
         );
         cy.getElementByTestId('editDataSourceFormRegionField').should(
           'have.value',
@@ -732,10 +752,7 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         );
         cy.getElementByTestId(
           'editDataSourceFormSigV4ServiceTypeSelect'
-        ).should(
-          'have.value',
-          DS_JSON_UNIQUE_VALUES.attributes.auth.credentials.service
-        );
+        ).contains('Amazon OpenSearch Serverless');
         cy.getElementByTestId('editDataSourceFormAccessKeyField').should(
           'be.disabled'
         );

--- a/cypress/utils/dashboards/datasource-management-dashboards-plugin/constants.js
+++ b/cypress/utils/dashboards/datasource-management-dashboards-plugin/constants.js
@@ -14,6 +14,17 @@ export const DS_API = {
 
 export const TIMEOUT_OPTS = { timeout: 60000 };
 export const FORCE_CLICK_OPTS = { force: true };
+export const DATASOURCE_DELAY = 1000;
+// test data
+export const REGION = 'us-east-1';
+export const ACCESS_KEY = 'accessKey';
+export const SECRET_KEY = 'secretKey';
+
+export const AUTH_TYPE_SIGV4 = 'sigv4';
+export const AUTH_TYPE_NO_AUTH = 'no_auth';
+export const AUTH_TYPE_BASIC_AUTH = 'username_password';
+export const SERVICE_TYPE_OPENSEARCH = 'es';
+export const SERVICE_TYPE_OPENSEARCH_SERVERLESS = 'aoss';
 
 /* Mocks */
 
@@ -23,7 +34,7 @@ export const DS_JSON = {
     description: 'test ds_description_update',
     endpoint: OSD_TEST_DOMAIN_ENDPOINT_URL,
     auth: {
-      type: 'no_auth',
+      type: AUTH_TYPE_NO_AUTH,
     },
   },
 };
@@ -34,7 +45,7 @@ export const DS_JSON_2 = {
     description: 'test ds_description_update',
     endpoint: OSD_TEST_DOMAIN_ENDPOINT_URL,
     auth: {
-      type: 'no_auth',
+      type: AUTH_TYPE_NO_AUTH,
     },
   },
 };
@@ -45,14 +56,14 @@ export const DS_JSON_UNIQUE_VALUES = {
     description: '',
     endpoint: OSD_TEST_DOMAIN_ENDPOINT_URL,
     auth: {
-      type: 'no_auth',
+      type: AUTH_TYPE_NO_AUTH,
       credentials: {
         username: 'a',
         password: 'a',
-        region: 'us-east-1',
+        region: REGION,
         accessKey: 'a',
         secretKey: 'a',
-        service: 'aoss',
+        service: SERVICE_TYPE_OPENSEARCH_SERVERLESS,
       },
     },
   },


### PR DESCRIPTION
### Description
- In https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5315, we switched from `EuiSelect` to `EuiSuperSelect`, causing some test cases to fail. This PR addressed these failures, and make sure all related tests can pass
![image](https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/32652829/cd1fbcb7-db8f-4ec4-b2e6-f7d6459a5f2a)

- clean the code by using existing util functions, and constants

### Issues Resolved
#1198 

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
