### PR TITLE
Use global tenant in vis-builder tests

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/basic.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/basic.spec.js
@@ -17,10 +17,12 @@ import {
   VB_PATH_SO_DATA,
   VB_SO_TYPE,
 } from '../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Visualization Builder Base Tests', () => {
     before(() => {
+      CURRENT_TENANT.newTenant = 'global';
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
@@ -18,10 +18,12 @@ import {
   VB_METRIC_VIS_TITLE,
   VB_BAR_VIS_TITLE,
 } from '../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Visualization Builder Dashboard Tests', () => {
     before(() => {
+      CURRENT_TENANT.newTenant = 'global';
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
 

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/experimental.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/experimental.spec.js
@@ -11,10 +11,12 @@ import {
   VB_METRIC_VIS_TITLE,
   VB_PATH_SO_DATA,
 } from '../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../utils/commands';
 
 if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Visualization Builder Experimental settings', () => {
     before(() => {
+      CURRENT_TENANT.newTenant = 'global';
       cy.importSavedObjects(VB_PATH_SO_DATA);
     });
 

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/area.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/area.spec.js
@@ -12,10 +12,12 @@ import {
   VB_PATH_INDEX_DATA,
   VB_PATH_SO_DATA,
 } from '../../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../../utils/commands';
 
 if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Vis Builder: Area Chart', () => {
     before(() => {
+      CURRENT_TENANT.newTenant = 'global';
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/bar.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/bar.spec.js
@@ -12,10 +12,12 @@ import {
   VB_PATH_INDEX_DATA,
   VB_PATH_SO_DATA,
 } from '../../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../../utils/commands';
 
 if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Vis Builder: Bar Chart', () => {
     before(() => {
+      CURRENT_TENANT.newTenant = 'global';
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/line.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/line.spec.js
@@ -12,10 +12,12 @@ import {
   VB_PATH_INDEX_DATA,
   VB_PATH_SO_DATA,
 } from '../../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../../utils/commands';
 
 if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Vis Builder: Line Chart', () => {
     before(() => {
+      CURRENT_TENANT.newTenant = 'global';
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/metric.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/metric.spec.js
@@ -12,10 +12,12 @@ import {
   VB_PATH_INDEX_DATA,
   VB_PATH_SO_DATA,
 } from '../../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../../utils/commands';
 
 if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Vis Builder: Metric Chart', () => {
     before(() => {
+      CURRENT_TENANT.newTenant = 'global';
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
@@ -12,10 +12,12 @@ import {
   VB_PATH_INDEX_DATA,
   VB_PATH_SO_DATA,
 } from '../../../../../../utils/constants';
+import { CURRENT_TENANT } from '../../../../../../utils/commands';
 
 if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Vis Builder: Table Chart', () => {
     before(() => {
+      CURRENT_TENANT.newTenant = 'global';
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);


### PR DESCRIPTION
### Description
Flaky tests due to loading time due to switch tenant. Currently set default tenant to global.

### Issues Resolved
Partial https://github.com/opensearch-project/opensearch-build/issues/4433

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
