### PR TITLE
[OSD] Sanitize copied share-link before validating

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
@@ -58,7 +58,13 @@ describe('shared links', () => {
       cy.getElementByTestId('shareTopNavButton').should('be.visible').click();
       cy.getElementByTestId('copyShareUrlButton')
         .invoke('attr', 'data-share-url')
-        .should('eq', url)
+        // Even though `CURRENT_TENANT.newTenant` is set to global, that could change and hence this test will remove
+        // either of the tenants it sees.
+        .should(
+          'satisfy',
+          (copied) =>
+            copied.replace(/\?security_tenant=(global|private)/, '') === url
+        )
         .then((url) => {
           cy.log(url);
           cy.request(url).its('status').should('eq', 200);


### PR DESCRIPTION
### Description

A copied snapshot URL included `security_tenant` when security plugin was enabled and multitenancy was configured. This change sanitizes the copied URL before asserting to make the tests work correctly with and without security and multitenancy.

### Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6373

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
