### PR TITLE
[Workspace] Clean up workspace after tests and disable multi-tenancy when running workspace test

### DIFF
--- a/.github/workflows/workspace-release-e2e-workflow.yml
+++ b/.github/workflows/workspace-release-e2e-workflow.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       test-name: dashboards workspace
       test-command: env CYPRESS_WORKSPACE_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/*'
-      osd-serve-args: --workspace.enabled=true --savedObjects.permission.enabled=true
+      osd-serve-args: --workspace.enabled=true --savedObjects.permission.enabled=true --opensearch_security.multitenancy.enabled=false
   tests-without-security:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/workspace_create.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/workspace_create.spec.js
@@ -6,6 +6,7 @@
 import { BASE_PATH } from '../../../../utils/constants';
 
 if (Cypress.env('WORKSPACE_ENABLED')) {
+  let workspaceId;
   describe('Workspace CRUD APIs', () => {
     describe('Create a workspace', () => {
       it('should successfully create a worksapce', () => {
@@ -24,8 +25,18 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
           body: body,
         }).as('createWorkspace');
         cy.get('@createWorkspace').should((res) => {
+          workspaceId = res.body.result.id;
           expect(res.body.success).to.eql(true);
         });
+      });
+    });
+    after(() => {
+      cy.request({
+        method: 'DELETE',
+        url: `${BASE_PATH}/api/workspaces/${workspaceId}`,
+        headers: {
+          'osd-xsrf': true,
+        },
       });
     });
   });


### PR DESCRIPTION
### Description

Fix errors in the workspace workflow.
1. When `workspace` and `opensearch_security.multitenancy` are  enabled at the same time, OSD will report an error ([plugins][securityDashboards] StatusCodeError: Authorization Exception).
Related Issue: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6314
2. Create a workspace in the test and do not delete it after completing the test, resulting in the inconsistent return result with the expected result.


### Issues Resolved
Turn off `opensearch_security.multitenancy` when `security` is enabled.
Add an operation to delete the workspace in `after()`.
### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
