### PR TITLE
fix issue code reviewer list doesn't reflect the right code owner list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*   @tianleh @kavilla @ohltyler @CCongWang @ashwin-pc @peterzhuamazon @ananzh @prudhvigodithi
-*   @xluo-aws @Hailong-am @SuZhou-Joe @ruanyl @wanglam @raintygao
+*   @tianleh @kavilla @ohltyler @CCongWang @ashwin-pc @peterzhuamazon @ananzh @prudhvigodithi @xluo-aws @Hailong-am @SuZhou-Joe @ruanyl @wanglam @raintygao


### PR DESCRIPTION
### Description

current code owner list doesn't match with reviewer list

current list 
https://raw.githubusercontent.com/opensearch-project/opensearch-dashboards-functional-test/main/.github/CODEOWNERS

```
*   @tianleh @kavilla @ohltyler @CCongWang @ashwin-pc @peterzhuamazon @ananzh @prudhvigodithi
*   @xluo-aws @Hailong-am @SuZhou-Joe @ruanyl @wanglam @raintygao
```

Current review list
![image](https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/550437/348bdebd-55c4-448d-89ae-705ac476326c)

looks like default reviewer list load last line of the file.

merge two lines to fix the issue


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
