### PR TITLE
Use moveToTestNotebook during notebooks-reporting integration suite

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -138,6 +138,7 @@ describe('Testing notebook actions', () => {
 describe('Test reporting integration if plugin installed', () => {
   beforeEach(() => {
     let notebookName = makeTestNotebook();
+    moveToTestNotebook(notebookName);
     cy.get('body').then(($body) => {
       skipOn($body.find('#reportingActionsButton').length <= 0);
     });

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -24,10 +24,14 @@ const moveToNotebookHome = () => {
   cy.visit(`${BASE_PATH}/app/observability-notebooks#/`);
 };
 
-const moveToTestNotebook = (notebookName) => {
-  cy.visit(`${BASE_PATH}/app/observability-notebooks#/`, {
-    timeout: delayTime * 3,
-  });
+const makeTestNotebook = () => {
+  let notebookName = testNotebookName();
+
+  moveToNotebookHome();
+  cy.get('a[data-test-subj="createNotebookPrimaryBtn"]').click();
+  cy.get('input[data-test-subj="custom-input-modal-input"]').focus();
+  cy.get('input[data-test-subj="custom-input-modal-input"]').type(notebookName);
+  cy.get('button[data-test-subj="custom-input-modal-confirm-button"]').click();
 
   // Force refresh the observablity index and reload page to load notebooks.
   cy.request({
@@ -46,21 +50,6 @@ const moveToTestNotebook = (notebookName) => {
   });
   cy.reload();
 
-  cy.get('.euiTableCellContent')
-    .contains(notebookName, {
-      timeout: delayTime * 3,
-    })
-    .click();
-};
-
-const makeTestNotebook = () => {
-  let notebookName = testNotebookName();
-
-  moveToNotebookHome();
-  cy.get('a[data-test-subj="createNotebookPrimaryBtn"]').click();
-  cy.get('input[data-test-subj="custom-input-modal-input"]').focus();
-  cy.get('input[data-test-subj="custom-input-modal-input"]').type(notebookName);
-  cy.get('button[data-test-subj="custom-input-modal-confirm-button"]').click();
   cy.get('h1[data-test-subj="notebookTitle"]')
     .contains(notebookName)
     .should('exist');
@@ -107,7 +96,6 @@ const deleteNotebook = (notebookName) => {
 describe('Testing notebook actions', () => {
   beforeEach(() => {
     let notebookName = makeTestNotebook();
-    moveToTestNotebook(notebookName);
     cy.wrap({ name: notebookName }).as('notebook');
   });
 
@@ -138,7 +126,6 @@ describe('Testing notebook actions', () => {
 describe('Test reporting integration if plugin installed', () => {
   beforeEach(() => {
     let notebookName = makeTestNotebook();
-    moveToTestNotebook(notebookName);
     cy.get('body').then(($body) => {
       skipOn($body.find('#reportingActionsButton').length <= 0);
     });


### PR DESCRIPTION
### Description

While debugging the failing tests https://github.com/opensearch-project/dashboards-observability/issues/1702, it looks like the reason is that the notebook loading is flaky immediately after creation. This is due to not using the refresh logic in the `moveToTestNotebook` method in the second test suite, it was only present in the first. After looking over the usage of this method, I decided to move the refresh logic straight to `makeTestNotebook` and deleted `moveToTestNotebook` since its only use seemed to be to force this refresh.

Needs backport to 2.x / 2.14.

### Issues Resolved

N/A

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
