### PR TITLE
Increase jvm_heap_memory_threshold to 100 for ml-commons dashboards

### DIFF
--- a/cypress/utils/plugins/ml-commons-dashboards/commands.js
+++ b/cypress/utils/plugins/ml-commons-dashboards/commands.js
@@ -104,6 +104,7 @@ Cypress.Commands.add('disableNativeMemoryCircuitBreaker', () => {
     body: {
       transient: {
         'plugins.ml_commons.native_memory_threshold': 100,
+        'plugins.ml_commons.jvm_heap_memory_threshold': 100,
       },
     },
     failOnStatusCode: false,


### PR DESCRIPTION
### Description

This PR is for fixing integration test failed in https://github.com/opensearch-project/ml-commons-dashboards/issues/322 .
The root cause of tests failed was `Memory Circuit Breaker is open`, increase to 100 to avoid this error.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
