### PR TITLE
Update getDetectors URL to match recent API changes

### DIFF
--- a/cypress/utils/plugins/anomaly-detection-dashboards-plugin/constants.js
+++ b/cypress/utils/plugins/anomaly-detection-dashboards-plugin/constants.js
@@ -45,7 +45,7 @@ export function getADStopDetectorApiPath(detectorId) {
 const BASE_AD_NODE_API_PATH = BASE_PATH + '/api/anomaly_detectors';
 
 export const AD_NODE_API_PATH = {
-  GET_DETECTORS: BASE_AD_NODE_API_PATH + '/detectors*',
+  GET_DETECTORS: BASE_AD_NODE_API_PATH + '/detectors/_list*',
   GET_INDICES: BASE_AD_NODE_API_PATH + '/_indices*',
   GET_MAPPINGS: BASE_AD_NODE_API_PATH + '/_mappings*',
   VALIDATE: BASE_AD_NODE_API_PATH + '/detectors/_validate',


### PR DESCRIPTION
### Description

This PR addresses a test failure caused by the recent update of the listing detectors URL from '/detectors' to '/detectors/_list' as implemented in server/routes/ad.ts. The change was introduced in https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/739. Previously, the tests in `dashboard_spec.js` and `detector_list_spec.js` were failing because they were waiting for requests to `BASE_AD_NODE_API_PATH + '/detectors*'`, which no longer exists due to the URL update.

Testing:
- Successfully ran all tests in `dashboard_spec.js` and `detector_list_spec.js` to ensure that they now correctly interact with the updated URL.


### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
