### PR TITLE
[MD] Replace fake data source endpoint with configurable real endpoint

### DIFF
--- a/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based.yml
@@ -17,12 +17,12 @@ jobs:
     with:
       test-name: Core Dashboards using Bundle Snapshot
       test-command: env CYPRESS_NO_COMMAND_LOG=1 CYPRESS_ML_COMMONS_DASHBOARDS_ENABLED=true CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
-      osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true --ml_commons_dashboards.enabled=true
+      osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --vis_builder.enabled=true --ml_commons_dashboards.enabled=true 
 
   tests-without-security:
     uses: ./.github/workflows/release-e2e-workflow-template.yml
     with:
       test-name: Core Dashboards using Bundle Snapshot
       test-command: env CYPRESS_NO_COMMAND_LOG=1 CYPRESS_ML_COMMONS_DASHBOARDS_ENABLED=true CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-without-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
-      osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true --ml_commons_dashboards.enabled=true
+      osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --vis_builder.enabled=true --ml_commons_dashboards.enabled=true
       security-enabled: false

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/datasource-management-plugin/1_create_datasource.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/datasource-management-plugin/1_create_datasource.spec.js
@@ -5,7 +5,6 @@
 
 import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
 import {
-  OSD_TEST_DOMAIN_ENDPOINT_URL,
   OSD_INVALID_ENDPOINT_URL,
   DATASOURCE_DELAY,
   REGION,
@@ -16,14 +15,13 @@ import {
   AUTH_TYPE_SIGV4,
   SERVICE_TYPE_OPENSEARCH,
   SERVICE_TYPE_OPENSEARCH_SERVERLESS,
+  OSD_TEST_DATA_SOURCE_ENDPOINT_NO_AUTH,
+  USERNAME,
+  PASSWORD,
+  OSD_TEST_DATA_SOURCE_ENDPOINT_BASIC_AUTH,
 } from '../../../../utils/dashboards/datasource-management-dashboards-plugin/constants';
 
 const miscUtils = new MiscUtils(cy);
-// Get environment variables
-const username = Cypress.env('username');
-const password = Cypress.env('password');
-
-// TODO: create datasource with basic auth and sigv4
 
 if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
   describe('Create datasources', () => {
@@ -58,7 +56,7 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       it('with no auth and all required inputs', () => {
         cy.getElementByTestId('createDataSourceButton').should('be.disabled');
         cy.get('[name="dataSourceTitle"]').type('test_noauth');
-        cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL);
+        cy.get('[name="endpoint"]').type(OSD_TEST_DATA_SOURCE_ENDPOINT_NO_AUTH);
         cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
         cy.get(`button[id=${AUTH_TYPE_NO_AUTH}]`).click();
 
@@ -80,16 +78,18 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       it('with basic auth and all required inputs', () => {
         cy.getElementByTestId('createDataSourceButton').should('be.disabled');
         cy.get('[name="dataSourceTitle"]').type('test_auth');
-        cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL);
+        cy.get('[name="endpoint"]').type(
+          OSD_TEST_DATA_SOURCE_ENDPOINT_BASIC_AUTH
+        );
         cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
         cy.get(`button[id=${AUTH_TYPE_BASIC_AUTH}]`)
           .click()
           .wait(DATASOURCE_DELAY);
         cy.getElementByTestId('createDataSourceFormUsernameField').type(
-          username
+          USERNAME
         );
         cy.getElementByTestId('createDataSourceFormPasswordField').type(
-          password
+          PASSWORD
         );
         cy.getElementByTestId('createDataSourceButton').should('be.enabled');
         cy.get('[name="dataSourceDescription"]').type(
@@ -104,11 +104,11 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
           'app/management/opensearch-dashboards/dataSources'
         );
       });
-
-      it('with sigV4 and all required inputs to connect to OpenSearch Service', () => {
+      // TODO: once create datasource with sigv4 is in plance, remove the skip
+      it.skip('with sigV4 and all required inputs to connect to OpenSearch Service', () => {
         cy.getElementByTestId('createDataSourceButton').should('be.disabled');
         cy.get('[name="dataSourceTitle"]').type('test_sigv4_es');
-        cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL);
+        cy.get('[name="endpoint"]').type('placehoderForSigV4Endpoint');
         cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
         cy.get(`button[id=${AUTH_TYPE_SIGV4}]`).click().wait(DATASOURCE_DELAY);
         cy.getElementByTestId('createDataSourceFormRegionField').type(REGION);
@@ -140,10 +140,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
         );
       });
 
-      it('with sigV4 and all required inputs to connect to OpenSearch Serverless Service', () => {
+      it.skip('with sigV4 and all required inputs to connect to OpenSearch Serverless Service', () => {
         cy.getElementByTestId('createDataSourceButton').should('be.disabled');
         cy.get('[name="dataSourceTitle"]').type('test_sigv4_aoss');
-        cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL);
+        cy.get('[name="endpoint"]').type('placehoderForSigV4Endpoint');
         cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
         cy.get(`button[id=${AUTH_TYPE_SIGV4}]`).click().wait(DATASOURCE_DELAY);
         cy.getElementByTestId('createDataSourceFormRegionField').type(REGION);
@@ -231,7 +231,9 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
       });
 
       it('validate that endpoint field does not show any error if URL is valid', () => {
-        cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL).blur();
+        cy.get('[name="endpoint"]')
+          .type(OSD_TEST_DATA_SOURCE_ENDPOINT_NO_AUTH)
+          .blur();
         cy.get('input[name="endpoint"]:valid').should('have.length', 1);
       });
     });
@@ -266,7 +268,7 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
           .click()
           .wait(DATASOURCE_DELAY);
         cy.getElementByTestId('createDataSourceFormUsernameField')
-          .type(username)
+          .type(USERNAME)
           .blur();
         cy.get(
           'input[data-test-subj="createDataSourceFormUsernameField"]:valid'
@@ -302,7 +304,7 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
           .click()
           .wait(DATASOURCE_DELAY);
         cy.getElementByTestId('createDataSourceFormPasswordField')
-          .type(password)
+          .type(PASSWORD)
           .blur();
         cy.get(
           'input[data-test-subj="createDataSourceFormPasswordField"]:valid'
@@ -370,7 +372,7 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
 
       it('validate if create data source button is not disabled only if there is no any field error', () => {
         cy.get('[name="dataSourceTitle"]').type('test_create_button');
-        cy.get('[name="endpoint"]').type(OSD_TEST_DOMAIN_ENDPOINT_URL);
+        cy.get('[name="endpoint"]').type(OSD_TEST_DATA_SOURCE_ENDPOINT_NO_AUTH);
         cy.getElementByTestId('createDataSourceFormAuthTypeSelect').click();
         cy.get(`button[id=${AUTH_TYPE_NO_AUTH}]`)
           .click()
@@ -386,10 +388,6 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
           'include',
           'app/management/opensearch-dashboards/dataSources'
         );
-      });
-
-      it('creates a datasources to a real opensearch instance', () => {
-        cy.createDataSourceNoAuth();
       });
     });
   });

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/datasource-management-plugin/2_datasource_table.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/datasource-management-plugin/2_datasource_table.spec.js
@@ -5,7 +5,10 @@
 
 import {
   TIMEOUT_OPTS,
-  OSD_TEST_DOMAIN_ENDPOINT_URL,
+  USERNAME,
+  PASSWORD,
+  OSD_TEST_DATA_SOURCE_ENDPOINT_NO_AUTH,
+  OSD_TEST_DATA_SOURCE_ENDPOINT_BASIC_AUTH,
 } from '../../../../utils/dashboards/datasource-management-dashboards-plugin/constants';
 
 const searchFieldIdentifier = 'input[type="search"]';
@@ -52,7 +55,10 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
             attributes: {
               title: `ds_${char}`,
               description: `test ds_description_${char}`,
-              endpoint: `${OSD_TEST_DOMAIN_ENDPOINT_URL}/${char}`,
+              endpoint:
+                i % 2
+                  ? OSD_TEST_DATA_SOURCE_ENDPOINT_BASIC_AUTH
+                  : OSD_TEST_DATA_SOURCE_ENDPOINT_NO_AUTH,
               auth: {
                 type: i % 2 ? 'username_password' : 'no_auth',
               },
@@ -60,8 +66,8 @@ if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
           };
           if (dataSourceJSON.attributes.auth.type === 'username_password') {
             dataSourceJSON.attributes.auth.credentials = {
-              username: char,
-              password: char,
+              username: USERNAME,
+              password: PASSWORD,
             };
           }
           cy.createDataSource(dataSourceJSON);

--- a/cypress/utils/dashboards/datasource-management-dashboards-plugin/commands.js
+++ b/cypress/utils/dashboards/datasource-management-dashboards-plugin/commands.js
@@ -32,7 +32,7 @@ Cypress.Commands.add('deleteAllDataSources', () => {
 Cypress.Commands.add('createDataSourceNoAuth', () => {
   cy.request({
     method: 'POST',
-    url: `${Cypress.config('baseUrl')}/api/saved_objects/data-source`,
+    url: `${BASE_PATH}/api/saved_objects/data-source`,
     headers: {
       'osd-xsrf': true,
     },
@@ -55,7 +55,7 @@ Cypress.Commands.add('createDataSourceNoAuth', () => {
 Cypress.Commands.add('createDataSourceBasicAuth', () => {
   cy.request({
     method: 'POST',
-    url: `${Cypress.config('baseUrl')}/api/saved_objects/data-source`,
+    url: `${BASE_PATH}/api/saved_objects/data-source`,
     headers: {
       'osd-xsrf': true,
     },

--- a/cypress/utils/dashboards/datasource-management-dashboards-plugin/constants.js
+++ b/cypress/utils/dashboards/datasource-management-dashboards-plugin/constants.js
@@ -5,6 +5,15 @@
 
 export const DS_API_PREFIX = '/api/saved_objects';
 export const OSD_TEST_DOMAIN_ENDPOINT_URL = 'https://opensearch.org';
+export const OSD_TEST_DATA_SOURCE_ENDPOINT_NO_AUTH = Cypress.env(
+  'remoteDataSourceNoAuthUrl'
+);
+export const OSD_TEST_DATA_SOURCE_ENDPOINT_BASIC_AUTH = Cypress.env(
+  'remoteDataSourceBasicAuthUrl'
+);
+export const USERNAME = Cypress.env('remoteDataSourceBasicAuthUsername');
+export const PASSWORD = Cypress.env('remoteDataSourceBasicAuthPassword');
+
 export const OSD_INVALID_ENDPOINT_URL = 'test';
 export const DS_API = {
   DATA_SOURCES_LISTING: `${DS_API_PREFIX}/_find?fields=id&fields=description&fields=title&per_page=10000&type=data-source`,
@@ -32,7 +41,7 @@ export const DS_JSON = {
   attributes: {
     title: 'ds_for_update_test',
     description: 'test ds_description_update',
-    endpoint: OSD_TEST_DOMAIN_ENDPOINT_URL,
+    endpoint: OSD_TEST_DATA_SOURCE_ENDPOINT_NO_AUTH,
     auth: {
       type: AUTH_TYPE_NO_AUTH,
     },
@@ -43,7 +52,7 @@ export const DS_JSON_2 = {
   attributes: {
     title: 'ds_dup_test',
     description: 'test ds_description_update',
-    endpoint: OSD_TEST_DOMAIN_ENDPOINT_URL,
+    endpoint: OSD_TEST_DATA_SOURCE_ENDPOINT_NO_AUTH,
     auth: {
       type: AUTH_TYPE_NO_AUTH,
     },
@@ -54,7 +63,7 @@ export const DS_JSON_UNIQUE_VALUES = {
   attributes: {
     title: 'ds_unique_title',
     description: '',
-    endpoint: OSD_TEST_DOMAIN_ENDPOINT_URL,
+    endpoint: OSD_TEST_DATA_SOURCE_ENDPOINT_NO_AUTH,
     auth: {
       type: AUTH_TYPE_NO_AUTH,
       credentials: {


### PR DESCRIPTION
### Description

- Replace fake data source endpoint with real endpoint (auth, and no auth)
- skip sigv4 related tests since infra workflow doesn't support create , and those tests will fail

![image](https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/32652829/89138720-4391-4585-821e-dadd0c591fe2)

### Test
There are 4 CI related to the function tests is OSD core, and they all failed, not caused by MDS tests and test infra.
1. [e2e windows, with security:](https://github.com/opensearch-project/opensearch-dashboards-functional-test/actions/runs/8934752160/job/24542128919?pr=1260) failed to spin up opensearch, not even reach cypress test step
2. [e2e windows, without security](https://github.com/opensearch-project/opensearch-dashboards-functional-test/actions/runs/8934752160/job/24542128808?pr=1260): failed because workflow template doesn't allow passing osd arguments `data_source.enabled=true`
https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/79d98cabc16f43a781b8638dcad1e34d5951390d/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml#L20-L21
4. [e2e linux, with security](https://github.com/opensearch-project/opensearch-dashboards-functional-test/actions/runs/8934752166/job/24542128885?pr=1260): cypress crashed, not even reach to MDS test
5. [e2e linux, without security](https://github.com/opensearch-project/opensearch-dashboards-functional-test/actions/runs/8934752166/job/24542128758?pr=1260): MDS test can pass, viz builder tests are failing


### Issues Resolved

#1202 

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
