### PR TITLE
Reintroduce 2-second delay to fix Cypress test failures

### DIFF
--- a/cypress/utils/dashboards/vis-augmenter/commands.js
+++ b/cypress/utils/dashboards/vis-augmenter/commands.js
@@ -35,6 +35,7 @@ Cypress.Commands.add('visitDashboard', (dashboardName) => {
   cy.intercept('/api/saved_objects/_find*').as('loadDashboards');
   cy.visit(`${BASE_PATH}/app/dashboards`);
   cy.wait('@loadDashboards', { timeout: 300000 });
+  cy.wait(2000);
   cy.get('.euiFieldSearch').type(dashboardName);
   cy.wait(2000);
   cy.get('[data-test-subj="itemsInMemTable"]').contains(dashboardName).click({


### PR DESCRIPTION
[PR 1038](https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1038/files) removed a 2-second delay in `cypress/utils/dashboards/vis-augmenter/commands.js`, which was intended to allow UI elements to render fully before interactions in Cypress tests. This removal led to test failures due to timing issues when typing in the dashboard name during the test execution. Specifically, the error encountered was a `TypeError` related to the `KeyboardEvent`, indicating that the expected input element was not ready at the time of interaction. Example error trace:

```
1) Anomaly detection integration with vis augmenter
       Associate existing detector - creation flow:
     TypeError: Cannot read properties of undefined (reading 'KeyboardEvent')
      at Keyboard.fireSimulatedEvent (http://localhost:5601/__cypress/runner/cypress_runner.js:165273:28)
      at Keyboard.simulatedKeydown (http://localhost:5601/__cypress/runner/cypress_runner.js:165418:58)
      at Keyboard.typeSimulatedKey (http://localhost:5601/__cypress/runner/cypress_runner.js:165458:10)
      at http://localhost:5601/__cypress/runner/cypress_runner.js:165128:14
      at tryCatcher (http://localhost:5601/__cypress/runner/cypress_runner.js:13022:23)
      at Function.Promise.attempt.Promise.try (http://localhost:5601/__cypress/runner/cypress_runner.js:10296:29)
      at http://localhost:5601/__cypress/runner/cypress_runner.js:165138:67
      at tryCatcher (http://localhost:5601/__cypress/runner/cypress_runner.js:13022:23)
      at Object.gotValue (http://localhost:5601/__cypress/runner/cypress_runner.js:12164:18)
      at Object.gotAccum (http://localhost:5601/__cypress/runner/cypress_runner.js:12153:25)
      at Object.tryCatcher (http://localhost:5601/__cypress/runner/cypress_runner.js:13022:23)
      at Promise._settlePromiseFromHandler (http://localhost:5601/__cypress/runner/cypress_runner.js:10957:31)
      at Promise._settlePromise (http://localhost:5601/__cypress/runner/cypress_runner.js:11014:18)
      at Promise._settlePromise0 (http://localhost:5601/__cypress/runner/cypress_runner.js:11059:10)
      at Promise._settlePromises (http://localhost:5601/__cypress/runner/cypress_runner.js:11139:18)
      at Promise._fulfill (http://localhost:5601/__cypress/runner/cypress_runner.js:11083:18)
```

The test failures were observed in the ad anywhere related tests.

CI Failure Details: https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/actions/runs/8916683824/job/24488529476

This PR reinstates the 2-second wait, resolving the timing issue and ensuring that the necessary DOM elements are fully loaded before proceeding with the tests.

**Testing Done:**
1. Confirmed that all related tests, including those in `ad anywhere`, now pass with the reintroduction of the delay.

```
(Run Finished)

       Spec                                              Tests  Passing  Failing  Pending  Skipped
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/anomaly-detection-dashboard      05:23        5        5        -        -        - │
  │    s-plugin/vis_augmenter/associate_de                                                         │
  │    tector_spec.js                                                                              │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/anomaly-detection-dashboard      02:00        3        3        -        -        - │
  │    s-plugin/vis_augmenter/augment_vis_                                                         │
  │    saved_object_spec.js                                                                        │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/anomaly-detection-dashboard      02:12        4        4        -        -        - │
  │    s-plugin/vis_augmenter/view_anomaly                                                         │
  │    _events_spec.js                                                                             │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        09:35       12       12        -        -        -
```

### Description

[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
