### PR TITLE
Fix paths for MDS api changes

### DIFF
--- a/cypress/utils/plugins/security/commands.js
+++ b/cypress/utils/plugins/security/commands.js
@@ -22,7 +22,7 @@ import {
 Cypress.Commands.add(
   'mockAuthAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(SEC_API_CONFIG_PATH, {
+    cy.intercept(`${SEC_API_CONFIG_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getAuthDetails');
 
@@ -35,7 +35,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'mockRolesAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(SEC_API_ROLES_PATH, {
+    cy.intercept(`${SEC_API_ROLES_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getRoleDetails');
 
@@ -48,7 +48,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'mockInternalUsersAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(SEC_API_INTERNAL_USERS_PATH, {
+    cy.intercept(`${SEC_API_INTERNAL_USERS_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getInternalUsersDetails');
 
@@ -61,7 +61,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'mockPermissionsAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(SEC_API_ACTIONGROUPS_PATH, {
+    cy.intercept(`${SEC_API_ACTIONGROUPS_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getPermissions');
 
@@ -74,7 +74,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'mockTenantsAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(SEC_API_TENANTS_PATH, {
+    cy.intercept(`${SEC_API_TENANTS_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getTenants');
 
@@ -87,7 +87,7 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'mockAuditLogsAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(SEC_API_AUDIT_PATH, {
+    cy.intercept(`${SEC_API_AUDIT_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getAuditInfo');
 
@@ -101,7 +101,7 @@ Cypress.Commands.add(
   'mockAuditConfigUpdateAction',
   function (fixtureFileName, funcMockedOn) {
     cy.intercept(
-      { method: 'POST', url: SEC_API_AUDIT_CONFIG_PATH },
+      { method: 'POST', url: `${SEC_API_AUDIT_CONFIG_PATH}*` },
       {
         fixture: fixtureFileName,
       }
@@ -117,7 +117,7 @@ Cypress.Commands.add(
   'mockCachePurgeAction',
   function (fixtureFileName, funcMockedOn) {
     cy.intercept(
-      { method: 'DELETE', url: SEC_API_CACHE_PURGE_PATH },
+      { method: 'DELETE', url: `${SEC_API_CACHE_PURGE_PATH}*` },
       {
         fixture: fixtureFileName,
       }


### PR DESCRIPTION
### Description

After introducing MDS feature in 2.14, security dashboards API changed to include a query param - dataSourceId= to indicate which datasource the call is being made for. This was not being appropriately handled in the intercept, leading to timeout. This PR adds that param to the intercept calls so that tests work appropriately. 

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
