### PR TITLE
Add further creation waits to notebooks tests

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -10,7 +10,6 @@ import {
   BASE_PATH,
   delayTime,
   MARKDOWN_TEXT,
-  OBSERVABILITY_INDEX_NAME,
 } from '../../../utils/constants';
 
 import { skipOn } from '@cypress/skip-test';
@@ -34,25 +33,6 @@ const makeTestNotebook = () => {
   cy.get('button[data-test-subj="custom-input-modal-confirm-button"]').click();
 
   cy.contains(`Notebook "${notebookName}" successfully created`);
-
-  // Force refresh/reload due to concurrency bug:
-  // https://github.com/opensearch-project/dashboards-observability/issues/1822
-  // TODO delete the refresh/reload when the issue is closed
-  cy.request({
-    method: 'POST',
-    failOnStatusCode: false,
-    form: false,
-    url: 'api/console/proxy',
-    headers: {
-      'content-type': 'application/json;charset=UTF-8',
-      'osd-xsrf': true,
-    },
-    qs: {
-      path: `${OBSERVABILITY_INDEX_NAME}/_refresh`,
-      method: 'POST',
-    },
-  });
-  cy.reload();
 
   cy.get('h1[data-test-subj="notebookTitle"]')
     .contains(notebookName)

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -33,22 +33,7 @@ const makeTestNotebook = () => {
   cy.get('input[data-test-subj="custom-input-modal-input"]').type(notebookName);
   cy.get('button[data-test-subj="custom-input-modal-confirm-button"]').click();
 
-  // Force refresh the observablity index and reload page to load notebooks.
-  cy.request({
-    method: 'POST',
-    failOnStatusCode: false,
-    form: false,
-    url: 'api/console/proxy',
-    headers: {
-      'content-type': 'application/json;charset=UTF-8',
-      'osd-xsrf': true,
-    },
-    qs: {
-      path: `${OBSERVABILITY_INDEX_NAME}/_refresh`,
-      method: 'POST',
-    },
-  });
-  cy.reload();
+  cy.contains(`Notebook "${notebookName}" successfully created`);
 
   cy.get('h1[data-test-subj="notebookTitle"]')
     .contains(notebookName)

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -10,6 +10,7 @@ import {
   BASE_PATH,
   delayTime,
   MARKDOWN_TEXT,
+  OBSERVABILITY_INDEX_NAME,
 } from '../../../utils/constants';
 
 import { skipOn } from '@cypress/skip-test';
@@ -33,6 +34,25 @@ const makeTestNotebook = () => {
   cy.get('button[data-test-subj="custom-input-modal-confirm-button"]').click();
 
   cy.contains(`Notebook "${notebookName}" successfully created`);
+
+  // Force refresh/reload due to concurrency bug:
+  // https://github.com/opensearch-project/dashboards-observability/issues/1822
+  // TODO delete the refresh/reload when the issue is closed
+  cy.request({
+    method: 'POST',
+    failOnStatusCode: false,
+    form: false,
+    url: 'api/console/proxy',
+    headers: {
+      'content-type': 'application/json;charset=UTF-8',
+      'osd-xsrf': true,
+    },
+    qs: {
+      path: `${OBSERVABILITY_INDEX_NAME}/_refresh`,
+      method: 'POST',
+    },
+  });
+  cy.reload();
 
   cy.get('h1[data-test-subj="notebookTitle"]')
     .contains(notebookName)

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -10,7 +10,6 @@ import {
   BASE_PATH,
   delayTime,
   MARKDOWN_TEXT,
-  OBSERVABILITY_INDEX_NAME,
 } from '../../../utils/constants';
 
 import { skipOn } from '@cypress/skip-test';


### PR DESCRIPTION
### Description

Since notebooks are still flaky on notebook creation, even with refresh logic added (see #1250), I think the reason the tests are still failing is because notebook creation is flaky in some index refresh race condition scenarios. This PR refactors the notebook creation to drop the refresh attempt and only check for a successful creation message, on the assumption that notebooks should have a functional requirement to always show a valid notebook after stating a successful creation.

I'm not sure this fixes the flaky tests in CI (still struggling to understand the root cause and get exact repro steps), but in local testing this passed 10 consecutive runs (the old version failed after 6 runs and a version with both parts fails almost every run). This should also pass the ball out of the testing repo's court, I've created a corresponding issue: https://github.com/opensearch-project/dashboards-observability/issues/1822. 

Also needs backport to 2.x and main.

### Issues Resolved

N/A

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

[^1]: We're still keeping the refresh, see below comment.
