### PR TITLE
Move Intercept in Observability Panels Test

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
@@ -30,11 +30,11 @@ describe('Testing panels table', () => {
     cy.get('input.euiFieldText').focus().type(TEST_PANEL, {
       delay: 50,
     });
+    cy.intercept('POST', '/api/saved_objects/*').as('createDashboard');
     cy.get('.euiButton__text')
       .contains(/^Create$/)
       .trigger('mouseover')
       .click();
-    cy.intercept('POST', '/api/saved_objects/*').as('createDashboard');
     cy.wait('@createDashboard');
 
     cy.contains(TEST_PANEL).should('exist');


### PR DESCRIPTION
### Description

Move `createDashboard` intercept to before `Create` button is clicked, in the event that the `Create` request completes prior to the wait.

Needs `backport 2.x`

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
