### PR TITLE
Fix: flaky test on 2.14

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/aaa_before.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/aaa_before.spec.js
@@ -10,6 +10,7 @@ import { CURRENT_TENANT } from '../../../../../utils/commands';
 describe('Before', () => {
   before(() => {
     CURRENT_TENANT.newTenant = 'global';
+    cy.fleshTenantSettings();
     cy.deleteAllIndices();
     cy.deleteSavedObjectByType('index-pattern');
   });

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
@@ -27,6 +27,7 @@ const indexSet = [
 describe('discover app', { scrollBehavior: false }, () => {
   before(() => {
     CURRENT_TENANT.newTenant = 'global';
+    cy.fleshTenantSettings();
     // import logstash functional
     testFixtureHandler.importJSONDocIfNeeded(
       indexSet,

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
@@ -27,7 +27,17 @@ const indexSet = [
 describe('discover app', { scrollBehavior: false }, () => {
   before(() => {
     CURRENT_TENANT.newTenant = 'global';
-    cy.fleshTenantSettings();
+    if (Cypress.env('SECURITY_ENABLED')) {
+      /**
+       * Security plugin is using private tenant as default.
+       * So here we'd need to set global tenant as default manually.
+       */
+      cy.changeDefaultTenant({
+        multitenancy_enabled: true,
+        private_tenant_enabled: true,
+        default_tenant: 'global',
+      });
+    }
     // import logstash functional
     testFixtureHandler.importJSONDocIfNeeded(
       indexSet,

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_advanced_settings.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_advanced_settings.spec.js
@@ -24,6 +24,7 @@ const indexSet = [
 describe('discover_advanced_setting', () => {
   before(() => {
     CURRENT_TENANT.newTenant = 'global';
+    cy.fleshTenantSettings();
     // import logstash functional
     testFixtureHandler.importJSONDocIfNeeded(
       indexSet,

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/index_pattern_without_field.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/index_pattern_without_field.spec.js
@@ -18,6 +18,7 @@ const testFixtureHandler = new TestFixtureHandler(
 describe('index pattern without field spec', () => {
   before(() => {
     CURRENT_TENANT.newTenant = 'global';
+    cy.fleshTenantSettings();
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_pattern_without_timefield/mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
@@ -27,6 +27,7 @@ const indexSet = [
 describe('shared links', () => {
   before(() => {
     CURRENT_TENANT.newTenant = 'global';
+    cy.fleshTenantSettings();
     testFixtureHandler.importJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/discover/discover.mappings.json.txt'
     );

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis-augmenter/dashboard_spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis-augmenter/dashboard_spec.js
@@ -81,6 +81,7 @@ describe('Vis augmenter - existing dashboards work as expected', () => {
 
     before(() => {
       CURRENT_TENANT.newTenant = 'global';
+      cy.fleshTenantSettings();
       // Create a dashboard and add some visualizations
       bootstrapDashboard(
         INDEX_SETTINGS_FILEPATH_SIMPLE,

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/basic.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/basic.spec.js
@@ -23,7 +23,7 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Visualization Builder Base Tests', () => {
     before(() => {
       CURRENT_TENANT.newTenant = 'global';
-      cy.visit(`${BASE_PATH}/app/visualize`);
+      cy.fleshTenantSettings();
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/basic.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/basic.spec.js
@@ -23,6 +23,7 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Visualization Builder Base Tests', () => {
     before(() => {
       CURRENT_TENANT.newTenant = 'global';
+      cy.visit(`${BASE_PATH}/app/visualize`);
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/dashboard.spec.js
@@ -24,6 +24,7 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Visualization Builder Dashboard Tests', () => {
     before(() => {
       CURRENT_TENANT.newTenant = 'global';
+      cy.fleshTenantSettings();
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
 

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/area.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/area.spec.js
@@ -18,6 +18,7 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Vis Builder: Area Chart', () => {
     before(() => {
       CURRENT_TENANT.newTenant = 'global';
+      cy.fleshTenantSettings();
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/bar.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/bar.spec.js
@@ -18,6 +18,7 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Vis Builder: Bar Chart', () => {
     before(() => {
       CURRENT_TENANT.newTenant = 'global';
+      cy.fleshTenantSettings();
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/line.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/line.spec.js
@@ -18,6 +18,7 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Vis Builder: Line Chart', () => {
     before(() => {
       CURRENT_TENANT.newTenant = 'global';
+      cy.fleshTenantSettings();
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/metric.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/metric.spec.js
@@ -18,6 +18,7 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Vis Builder: Metric Chart', () => {
     before(() => {
       CURRENT_TENANT.newTenant = 'global';
+      cy.fleshTenantSettings();
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_builder/vis_types/table.spec.js
@@ -18,6 +18,7 @@ if (Cypress.env('VISBUILDER_ENABLED')) {
   describe('Vis Builder: Table Chart', () => {
     before(() => {
       CURRENT_TENANT.newTenant = 'global';
+      cy.fleshTenantSettings();
       cy.deleteIndex(VB_INDEX_ID);
       cy.bulkUploadDocs(VB_PATH_INDEX_DATA);
       cy.importSavedObjects(VB_PATH_SO_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/basic.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/basic.spec.js
@@ -27,6 +27,7 @@ import { CURRENT_TENANT } from '../../../../../utils/commands';
 describe('table visualization basic functions', () => {
   before(() => {
     CURRENT_TENANT.newTenant = 'global';
+    cy.fleshTenantSettings();
     cy.deleteIndex(TABLE_INDEX_ID);
     cy.deleteIndexPattern(TABLE_INDEX_PATTERN);
     cy.bulkUploadDocs(TABLE_PATH_INDEX_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/data.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/data.spec.js
@@ -26,6 +26,7 @@ const commonUI = new CommonUI(cy);
 describe('table visualization data', () => {
   before(() => {
     CURRENT_TENANT.newTenant = 'global';
+    cy.fleshTenantSettings();
     cy.deleteIndex(TABLE_INDEX_ID);
     cy.deleteIndexPattern(TABLE_INDEX_PATTERN);
     cy.bulkUploadDocs(TABLE_PATH_INDEX_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/embed.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/embed.spec.js
@@ -58,6 +58,7 @@ describe('table visualization in embedded mode', () => {
 
   before(() => {
     CURRENT_TENANT.newTenant = 'global';
+    cy.fleshTenantSettings();
     cy.deleteIndex(TABLE_INDEX_ID);
     cy.deleteIndexPattern(TABLE_INDEX_PATTERN);
     cy.bulkUploadDocs(TABLE_PATH_INDEX_DATA);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/options.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/options.spec.js
@@ -20,6 +20,7 @@ import { CURRENT_TENANT } from '../../../../../utils/commands';
 describe('Table visualization options', () => {
   before(() => {
     CURRENT_TENANT.newTenant = 'global';
+    cy.fleshTenantSettings();
     cy.deleteIndex(TABLE_INDEX_ID);
     cy.deleteIndexPattern(TABLE_INDEX_PATTERN);
     cy.bulkUploadDocs(TABLE_PATH_INDEX_DATA);

--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -587,3 +587,9 @@ Cypress.Commands.add('loadSampleData', (type) => {
     url: `${BASE_PATH}/api/sample_data/${type}`,
   });
 });
+
+Cypress.Commands.add('fleshTenantSettings', () => {
+  // Go to the home page to flesh the tenant settings
+  cy.visit(`/app/home`);
+  cy.waitForLoader();
+});


### PR DESCRIPTION
### Description

The security plugin underwent a logic change, rendering the current tenant setting code invalid. To rectify this, cy.fleshTenantSettings is being added to ensure that the tenant is properly configured, allowing all test cases to pass as they did previously.

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6472

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
