### PR TITLE
Add permission to allow copying to clipboard

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -27,6 +27,9 @@
     "WAIT_FOR_LOADER_BUFFER_MS": 0,
     "DASHBOARDS_ASSISTANT_ENABLED": false,
     "WORKSPACE_ENABLED": false,
-    "SAVED_OBJECTS_PERMISSION_ENABLED": false
+    "SAVED_OBJECTS_PERMISSION_ENABLED": false,
+    "browserPermissions": {
+      "clipboard": "allow"
+    }
   }
 }

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/dashboard_share_copy_link_test.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/dashboard_share_copy_link_test.js
@@ -3,10 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { STACK_MANAGEMENT_PATH } from '../../../utils/dashboards/constants';
+import { CURRENT_TENANT } from '../../../utils/commands';
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Copy Link functionality working', () => {
     it('Tests the link copys and can be routed to in Safari', () => {
+      CURRENT_TENANT.newTenant = 'global';
+
       cy.visit(STACK_MANAGEMENT_PATH);
       cy.waitForLoader();
       cy.getElementByTestId('toggleNavButton').click();


### PR DESCRIPTION
### Description
Add permission for copying link to clipboard in cypress/integration/core-opensearch-dashboards/opensearch-dashboards/dashboard_share_copy_link_test.js

### Issues Resolved

resolves #1081 

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
