### PR TITLE
[Enhancement] Skip datasources tests for managed service run

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/7_datasources_dashboard.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/7_datasources_dashboard.spec.js
@@ -25,52 +25,54 @@ const visitDatasourcesCreationPage = () => {
   cy.visit(BASE_PATH + DATASOURCES_PATH.DATASOURCES_CREATION_BASE);
 };
 
-describe('Integration tests for datasources plugin', () => {
-  it('Navigates to datasources plugin and expects the correct header', () => {
-    visitDatasourcesHomePage();
-    cy.get('[data-test-subj="dataconnections-header"]', {
-      timeout: 120000,
-    }).should('exist');
+if (!Cypress.env('MANAGED_SERVICE_ENDPOINT')) {
+  describe('Integration tests for datasources plugin', () => {
+    it('Navigates to datasources plugin and expects the correct header', () => {
+      visitDatasourcesHomePage();
+      cy.get('[data-test-subj="dataconnections-header"]', {
+        timeout: 120000,
+      }).should('exist');
+    });
+
+    it('Tests navigation between tabs', () => {
+      visitDatasourcesHomePage();
+
+      cy.get(manageDataSourcesTag)
+        .should('have.class', 'euiTab-isSelected')
+        .and('have.attr', 'aria-selected', 'true');
+      cy.get(manageDataSourcesTag).click();
+      cy.url().should('include', '/manage');
+
+      cy.get(newDataSourcesTag).click();
+      cy.get(newDataSourcesTag)
+        .should('have.class', 'euiTab-isSelected')
+        .and('have.attr', 'aria-selected', 'true');
+      cy.url().should('include', '/new');
+
+      cy.get(createS3Button).should('be.visible');
+      cy.get(createPrometheusButton).should('be.visible');
+    });
+
+    it('Tests navigation of S3 datasources creation page with hash', () => {
+      visitDatasourcesCreationPage();
+
+      cy.get(createS3Button).should('be.visible').click();
+      cy.url().should('include', 'configure/AmazonS3AWSGlue');
+
+      cy.get('h1.euiTitle.euiTitle--medium')
+        .should('be.visible')
+        .and('contain', 'Configure Amazon S3 data source');
+    });
+
+    it('Tests navigation of Prometheus datasources creation page with hash', () => {
+      visitDatasourcesCreationPage();
+
+      cy.get(createPrometheusButton).should('be.visible').click();
+      cy.url().should('include', 'configure/Prometheus');
+
+      cy.get('h4.euiTitle.euiTitle--medium')
+        .should('be.visible')
+        .and('contain', 'Configure Prometheus data source');
+    });
   });
-
-  it('Tests navigation between tabs', () => {
-    visitDatasourcesHomePage();
-
-    cy.get(manageDataSourcesTag)
-      .should('have.class', 'euiTab-isSelected')
-      .and('have.attr', 'aria-selected', 'true');
-    cy.get(manageDataSourcesTag).click();
-    cy.url().should('include', '/manage');
-
-    cy.get(newDataSourcesTag).click();
-    cy.get(newDataSourcesTag)
-      .should('have.class', 'euiTab-isSelected')
-      .and('have.attr', 'aria-selected', 'true');
-    cy.url().should('include', '/new');
-
-    cy.get(createS3Button).should('be.visible');
-    cy.get(createPrometheusButton).should('be.visible');
-  });
-
-  it('Tests navigation of S3 datasources creation page with hash', () => {
-    visitDatasourcesCreationPage();
-
-    cy.get(createS3Button).should('be.visible').click();
-    cy.url().should('include', 'configure/AmazonS3AWSGlue');
-
-    cy.get('h1.euiTitle.euiTitle--medium')
-      .should('be.visible')
-      .and('contain', 'Configure Amazon S3 data source');
-  });
-
-  it('Tests navigation of Prometheus datasources creation page with hash', () => {
-    visitDatasourcesCreationPage();
-
-    cy.get(createPrometheusButton).should('be.visible').click();
-    cy.url().should('include', 'configure/Prometheus');
-
-    cy.get('h4.euiTitle.euiTitle--medium')
-      .should('be.visible')
-      .and('contain', 'Configure Prometheus data source');
-  });
-});
+}


### PR DESCRIPTION
### Description
- Skip datasources tests for managed service run
- backport `2.x`, `2.13`

### Issues Resolved

Due to the design difference between opensource and managed service, the tests for observability datasources should only be run for opensource version.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
