### PR TITLE
fix: use lightweight way to flesh tenant settings

### DIFF
--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -590,10 +590,11 @@ Cypress.Commands.add('loadSampleData', (type) => {
 
 Cypress.Commands.add('fleshTenantSettings', () => {
   if (Cypress.env('SECURITY_ENABLED')) {
-    localStorage.setItem('home:newThemeModal:show', 'false');
-    localStorage.setItem('home:welcome:show', 'false');
-    // Go to the home page to flesh the tenant settings
-    cy.visit(`/app/home`);
-    cy.waitForLoader();
+    // Use xhr request is good enough to flesh tenant
+    cy.request({
+      url: `${BASE_PATH}/app/home?security_tenant=${CURRENT_TENANT.defaultTenant}`,
+      method: 'GET',
+      failOnStatusCode: false,
+    });
   }
 });

--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -587,14 +587,3 @@ Cypress.Commands.add('loadSampleData', (type) => {
     url: `${BASE_PATH}/api/sample_data/${type}`,
   });
 });
-
-Cypress.Commands.add('fleshTenantSettings', () => {
-  if (Cypress.env('SECURITY_ENABLED')) {
-    // Use xhr request is good enough to flesh tenant
-    cy.request({
-      url: `${BASE_PATH}/app/home?security_tenant=${CURRENT_TENANT.defaultTenant}`,
-      method: 'GET',
-      failOnStatusCode: false,
-    });
-  }
-});

--- a/cypress/utils/dashboards/commands.js
+++ b/cypress/utils/dashboards/commands.js
@@ -7,6 +7,8 @@ import './vis_builder/commands';
 import './vis_type_table/commands';
 import './vis-augmenter/commands';
 import './data_explorer/commands';
+import { BASE_PATH } from '../base_constants';
+import { CURRENT_TENANT } from '../commands';
 
 Cypress.Commands.add('waitForLoader', () => {
   const opts = { log: false };
@@ -116,4 +118,15 @@ Cypress.Commands.add('setTopNavDate', (start, end, submit = true) => {
 
 Cypress.Commands.add('updateTopNav', (options) => {
   cy.getElementByTestId('querySubmitButton', options).click({ force: true });
+});
+
+Cypress.Commands.add('fleshTenantSettings', () => {
+  if (Cypress.env('SECURITY_ENABLED')) {
+    // Use xhr request is good enough to flesh tenant
+    cy.request({
+      url: `${BASE_PATH}/app/home?security_tenant=${CURRENT_TENANT.defaultTenant}`,
+      method: 'GET',
+      failOnStatusCode: false,
+    });
+  }
 });


### PR DESCRIPTION
## Description

Tests ran failed on jenkins, where a smaller EC2 is used to run the integration test. This PR is changing to use a lightweight solution to flesh tenant settings to fix the bug and accelerate the test.

### security enabled
failed https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.14.0/7633/linux/arm64/tar/test-results/5916/integ-test/OpenSearch-Dashboards/with-security/stdout.txt

**snapshot:**
<img width="821" alt="image" src="https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/13493605/a04d68e6-ecfb-417a-b015-c4cfda69c767">

### security disabled
pass https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.14.0/7633/linux/arm64/tar/test-results/5916/integ-test/OpenSearch-Dashboards/without-security/stdout.txt

**snapshot:**

<img width="922" alt="image" src="https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/13493605/0f9c23f3-2248-4e66-bb5d-fe31264af77a">

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
