### PR TITLE
Navigate directly to discover to reduce flakiness

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/dashboard_share_copy_link_test.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/dashboard_share_copy_link_test.js
@@ -2,15 +2,14 @@
  * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { STACK_MANAGEMENT_PATH } from '../../../utils/dashboards/constants';
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+
+const miscUtils = new MiscUtils(cy);
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Copy Link functionality working', () => {
     it('Tests the link copys and can be routed to in Safari', () => {
-      cy.visit(STACK_MANAGEMENT_PATH);
-      cy.waitForLoader();
-      cy.getElementByTestId('toggleNavButton').click();
-      cy.get('span[title="Discover"]').click();
+      miscUtils.visitPage('app/data-explorer/discover#/');
       cy.getElementByTestId('shareTopNavButton').click();
       cy.getElementByTestId('copyShareUrlButton').click();
 


### PR DESCRIPTION
### Description

Tries to reduce some flakiness from this test by navigating directly to discover instead of starting at stack management and trying to navigate there via UI

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
