### PR TITLE
fix: defaultTenant does not take effect

### DIFF
--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -587,3 +587,14 @@ Cypress.Commands.add('loadSampleData', (type) => {
     url: `${BASE_PATH}/api/sample_data/${type}`,
   });
 });
+
+Cypress.Commands.add('fleshTenantSettings', () => {
+  if (Cypress.env('SECURITY_ENABLED')) {
+    // Use xhr request is good enough to flesh tenant
+    cy.request({
+      url: `${BASE_PATH}/app/home?security_tenant=${CURRENT_TENANT.defaultTenant}`,
+      method: 'GET',
+      failOnStatusCode: false,
+    });
+  }
+});

--- a/cypress/utils/dashboards/commands.js
+++ b/cypress/utils/dashboards/commands.js
@@ -7,8 +7,6 @@ import './vis_builder/commands';
 import './vis_type_table/commands';
 import './vis-augmenter/commands';
 import './data_explorer/commands';
-import { BASE_PATH } from '../base_constants';
-import { CURRENT_TENANT } from '../commands';
 
 Cypress.Commands.add('waitForLoader', () => {
   const opts = { log: false };
@@ -118,15 +116,4 @@ Cypress.Commands.add('setTopNavDate', (start, end, submit = true) => {
 
 Cypress.Commands.add('updateTopNav', (options) => {
   cy.getElementByTestId('querySubmitButton', options).click({ force: true });
-});
-
-Cypress.Commands.add('fleshTenantSettings', () => {
-  if (Cypress.env('SECURITY_ENABLED')) {
-    // Use xhr request is good enough to flesh tenant
-    cy.request({
-      url: `${BASE_PATH}/app/home?security_tenant=${CURRENT_TENANT.defaultTenant}`,
-      method: 'GET',
-      failOnStatusCode: false,
-    });
-  }
 });


### PR DESCRIPTION
### Description

<img width="919" alt="image" src="https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/13493605/9e7cde15-d4a4-4405-ae85-1badf51d65d9">

The default tenant does not take effect if adding commands inside `/dashboards/utils`, seems to have something to do with loop dependency. 

This PR fix that by moving the `fleshTenantSettings` to `/commands` directory.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
