### PR TITLE
[MDS]Add FT test for default data source

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/datasource-management-plugin/4_set_default_datasource.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/datasource-management-plugin/4_set_default_datasource.spec.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+
+const miscUtils = new MiscUtils(cy);
+
+if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
+  describe('Default data sources', () => {
+    before(() => {
+      // Clean up before creating new data sources for testing
+      cy.deleteAllDataSourcesOnUI();
+    });
+
+    describe('The default data source can behave normal when edit data source table', () => {
+      before(() => {
+        for (let i = 1; i < 4; i++) {
+          const title = `ds_${i}`;
+          cy.createDataSourceNoAuthWithTitle(title);
+          cy.wait(6000);
+        }
+        cy.visitDataSourcesListingPage();
+        cy.wait(6000);
+      });
+      after(() => {
+        // Clean up after all test are run
+        cy.deleteAllDataSourcesOnUI();
+      });
+      it('The first data source is the default data source', () => {
+        cy.visitDataSourcesListingPage();
+
+        // Use Cypress commands to find the table cell with content "ds_1"
+        cy.contains('td.euiTableRowCell', 'ds_1').as('ds_1');
+
+        // Check if the cell with current ds_1 content exists
+        cy.get('@ds_1').should('exist');
+
+        // Get the parent row of the cell
+        cy.get('@ds_1').parents('tr').as('row_ds_1');
+        // Check if the "Default" badge exists in the same row
+        cy.get('@row_ds_1').contains('span', 'Default').should('exist');
+      });
+      it('Delete the default data source, the next one will become default data source', () => {
+        cy.singleDeleteDataSourceByTitle('ds_1');
+
+        // Check that ds_2 now has the Default badge
+        cy.contains('td.euiTableRowCell', 'ds_2').as('ds_2');
+        cy.get('@ds_2').parents('tr').as('row_ds_2');
+        cy.get('@row_ds_2').contains('span', 'Default').should('exist');
+      });
+      it('Go the edit data source page of default data source, the set_default button should be disabled', () => {
+        cy.contains('a', 'ds_2')
+          .should('exist') // Ensure the anchor tag exists
+          .invoke('attr', 'href') // Get the href attribute
+          .then((href) => {
+            // Extract the unique identifier part from the href
+            const uniqueId = href.split('/').pop(); // Assumes the unique ID is the last part of the URL
+            miscUtils.visitPage(
+              `app/management/opensearch-dashboards/dataSources/${uniqueId}`
+            );
+            cy.getElementByTestId('editSetDefaultDataSource')
+              .should('be.exist')
+              .should('not.enabled');
+            cy.wait(1000);
+          });
+      });
+      it('Go the edit data source page of non-default data source, the set_default button should be enabled and can set to default ds', () => {
+        cy.visitDataSourcesListingPage();
+
+        cy.contains('a', 'ds_3')
+          .should('exist') // Ensure the anchor tag exists
+          .invoke('attr', 'href') // Get the href attribute
+          .then((href) => {
+            // Extract the unique identifier part from the href
+            const uniqueId = href.split('/').pop(); // Assumes the unique ID is the last part of the URL
+            miscUtils.visitPage(
+              `app/management/opensearch-dashboards/dataSources/${uniqueId}`
+            );
+            cy.getElementByTestId('editSetDefaultDataSource')
+              .should('be.exist')
+              .should('be.enabled')
+              .click({ force: true });
+            cy.wait(1000);
+          });
+        cy.visitDataSourcesListingPage();
+        cy.contains('td.euiTableRowCell', 'ds_3').as('ds_3');
+        cy.get('@ds_3').parents('tr').as('row_ds_3');
+        cy.get('@row_ds_3').contains('span', 'Default').should('exist');
+        cy.contains('td.euiTableRowCell', 'ds_2').as('ds_2');
+        cy.get('@ds_2').parents('tr').as('row_ds_2');
+        cy.get('@row_ds_2').contains('span', 'Default').should('not.exist');
+      });
+    });
+  });
+}

--- a/cypress/utils/dashboards/datasource-management-dashboards-plugin/commands.js
+++ b/cypress/utils/dashboards/datasource-management-dashboards-plugin/commands.js
@@ -240,3 +240,111 @@ Cypress.Commands.add('createDataSourceNoAuthWithTitle', (title) => {
     expect(interception.response.statusCode).to.equal(200);
   });
 });
+
+Cypress.Commands.add('multiDeleteDataSourceByTitle', (dataSourceTitles) => {
+  cy.visitDataSourcesListingPage();
+  cy.wait(1000);
+
+  dataSourceTitles.forEach((dataSourceTitle) => {
+    cy.contains('a', dataSourceTitle)
+      .should('exist') // Ensure the anchor tag exists
+      .invoke('attr', 'href') // Get the href attribute
+      .then((href) => {
+        // Extract the unique identifier part from the href
+        const uniqueId = href.split('/').pop(); // Assumes the unique ID is the last part of the URL
+        if (isValidUUID(uniqueId)) {
+          const testId = `checkboxSelectRow-${uniqueId}`;
+          cy.getElementByTestId(testId)
+            .check({ force: true })
+            .should('be.checked');
+        }
+      });
+  });
+
+  // Wait for the selections to be checked
+  cy.wait(1000);
+
+  cy.getElementByTestId('deleteDataSourceConnections')
+    .should('exist')
+    .should('be.enabled')
+    .click({ force: true });
+
+  // Wait for the delete confirmation modal
+  cy.wait(1000);
+
+  cy.get('button[data-test-subj="confirmModalConfirmButton"]')
+    .should('exist') // Ensure the button exists
+    .should('be.visible') // Ensure the button is visible
+    .click({ force: true });
+
+  // Wait for the delete action to complete
+  cy.wait(1000);
+  cy.visitDataSourcesListingPage();
+});
+
+Cypress.Commands.add('singleDeleteDataSourceByTitle', (dataSourceTitle) => {
+  cy.visitDataSourcesListingPage();
+  cy.wait(1000);
+  cy.contains('a', dataSourceTitle)
+    .should('exist') // Ensure the anchor tag exists
+    .invoke('attr', 'href') // Get the href attribute
+    .then((href) => {
+      // Extract the unique identifier part from the href
+      const uniqueId = href.split('/').pop(); // Assumes the unique ID is the last part of the URL
+      miscUtils.visitPage(
+        `app/management/opensearch-dashboards/dataSources/${uniqueId}`
+      );
+      cy.wait(1000);
+      cy.getElementByTestId('editDatasourceDeleteIcon').click({ force: true });
+    });
+  cy.wait(1000);
+  cy.get('button[data-test-subj="confirmModalConfirmButton"]')
+    .should('exist') // Ensure the button exists
+    .should('be.visible') // Ensure the button is visible
+    .click({ force: true }); // Click the button
+  cy.wait(1000);
+  cy.visitDataSourcesListingPage();
+});
+
+Cypress.Commands.add('deleteAllDataSourcesOnUI', () => {
+  cy.visitDataSourcesListingPage();
+  cy.wait(1000);
+
+  // Clean all data sources
+  // check if checkboxSelectAll input exist
+  // if exist, check it and delete all
+  // for test purpose, no need to consider pagination
+  // we can use both deleteAll on UI and request part
+  cy.ifElementExists('[data-test-subj="checkboxSelectAll"]', () => {
+    // Your logic when the element exists
+    cy.getElementByTestId('checkboxSelectAll')
+      .should('exist')
+      .check({ force: true });
+    // Add any additional actions you want to perform
+    cy.getElementByTestId('deleteDataSourceConnections')
+      .should('exist')
+      .should('be.enabled')
+      .click({ force: true });
+    cy.getElementByTestId('confirmModalConfirmButton')
+      .should('exist') // Ensure the button exists
+      .should('be.visible') // Ensure the button is visible
+      .click({ force: true });
+  });
+  // after delete all data sources, the selectAll input should not exist
+  cy.getElementByTestId('checkboxSelectAll').should('not.exist');
+});
+
+const isValidUUID = (str) => {
+  const uuidRegex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(str);
+};
+
+Cypress.Commands.add('ifElementExists', (selector, callback) => {
+  cy.get('body').then(($body) => {
+    if ($body.find(selector).length) {
+      // Element exists, call the callback
+      callback();
+    }
+  });
+});


### PR DESCRIPTION
Add FT for default data source 
1. Create data source
    1. when create the first data source, it will be the default data source
2. Edit data source
    1. Go to edit data source page, when the current data source is default data source, the set_default button is disabled
    2. when the current data source is not default, the set_default button is enabled
    3. After back to data source table, the default bage will be attached to the new data source
3. Data source table
    1. Delete the default data source, the next one will be the default data source

### Description

  ✓ The first data source is the default data source (71217ms)
      ✓ Delete the default data source, the next one will become default data source (8905ms)
      ✓ Go the edit data source page of default data source, the set_default button should be disabled
      ✓ Go the edit data source page of non-default data source, the set_default button should be enabled and can set to default ds (6477ms)


https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/112784385/1db998b0-5928-4457-9c83-ab16014e47fa



### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
