### PR TITLE
Don't need to force DatePickerMenu open

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
@@ -279,15 +279,12 @@ describe('discover app', { scrollBehavior: false }, () => {
             .should('be.visible')
             .clear()
             .type('2');
-
-          cy.makeDatePickerMenuOpen();
           cy.getElementByTestId('superDatePickerToggleRefreshButton').click();
 
           // Let auto refresh run
           cy.wait(100);
 
           // Close the auto refresh
-          cy.makeDatePickerMenuOpen();
           cy.getElementByTestId('superDatePickerToggleRefreshButton').click();
 
           // Check the timestamp of the last request, it should be different than the first timestamp

--- a/cypress/utils/dashboards/data_explorer/commands.js
+++ b/cypress/utils/dashboards/data_explorer/commands.js
@@ -156,18 +156,6 @@ Cypress.Commands.add('switchDiscoverTable', (name) => {
     });
 });
 
-Cypress.Commands.add('makeDatePickerMenuOpen', () => {
-  cy.get(
-    '[class="euiFormControlLayout euiFormControlLayout--group euiSuperDatePicker"]'
-  ).then(($popover) => {
-    // Check if the popover does not have the 'euiPopover-isOpen' class
-    if (!$popover.hasClass('euiPopover-isOpen')) {
-      // If not open, click the button to open the quick menu
-      cy.getElementByTestId('superDatePickerToggleQuickMenuButton').click();
-    }
-  });
-});
-
 function checkForElementVisibility() {
   cy.getElementsByTestIds('queryInput')
     .should('be.visible')

--- a/cypress/utils/dashboards/data_explorer/index.d.ts
+++ b/cypress/utils/dashboards/data_explorer/index.d.ts
@@ -17,6 +17,5 @@ declare namespace Cypress {
       clearSaveQuery(): Chainable<any>;
       deleteSaveQuery(name: string): Chainable<any>;
       switchDiscoverTable(name: string): Chainable<any>;
-      makeDatePickerMenuOpen(): Chainable<any>;
     }
   }


### PR DESCRIPTION
### Description
Due to https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6167, we don't have the double render issue when global state is updated.

Therefore we don't need to call makeDatePickerMenuOpen function, which is just to reclick the DatePickerToggle to make the menu re-open. This function is a tmp solution to allow test passing.

In this PR, we will remove the function and all the usages.


https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/79961084/940a369b-bfb6-41f4-b7bf-0fefa9ce9c91



### Issues Resolved
NA

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
