### PR TITLE
Set dashboards admin for security enabled tests

### DIFF
--- a/.github/workflows/workspace-release-e2e-workflow.yml
+++ b/.github/workflows/workspace-release-e2e-workflow.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       test-name: dashboards workspace
       test-command: env CYPRESS_WORKSPACE_ENABLED=true CYPRESS_SAVED_OBJECTS_PERMISSION_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/*'
-      osd-serve-args: --workspace.enabled=true --savedObjects.permission.enabled=true --opensearch_security.multitenancy.enabled=false
+      osd-serve-args: --workspace.enabled=true --savedObjects.permission.enabled=true --opensearch_security.multitenancy.enabled=false --opensearchDashboards.dashboardAdmin.users='["admin"]'
   tests-without-security:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}

--- a/.github/workflows/workspace-release-e2e-workflow.yml
+++ b/.github/workflows/workspace-release-e2e-workflow.yml
@@ -15,6 +15,7 @@ jobs:
           filters: |
             tests:
               - 'cypress/**/workspace-plugin/**'
+              - '.github/workflows/workspace-release-e2e-workflow.yml'
   tests-with-security:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}


### PR DESCRIPTION
### Description

Fix dashboards admin missing for workspace security enabled tests

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
