### PR TITLE
Bump JDK to 21

### DIFF
--- a/.github/actions/start-opensearch/action.yml
+++ b/.github/actions/start-opensearch/action.yml
@@ -40,7 +40,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 21
 
     - name: Create temporary directory
       run: | 

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - '.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml'
       - 'cypress/**/core-opensearch-dashboards/**'
-      - 'cypress/utils/dashboards/**',
+      - 'cypress/utils/dashboards/**'
       - '.github/actions/start-opensearch/action.yml'
 
   push:

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
@@ -5,13 +5,16 @@ on:
     paths:
       - '.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml'
       - 'cypress/**/core-opensearch-dashboards/**'
-      - 'cypress/utils/dashboards/**'
+      - 'cypress/utils/dashboards/**',
+      - '.github/actions/start-opensearch/action.yml'
+
   push:
     branches: ['**']
     paths:
       - '.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml'
       - 'cypress/**/core-opensearch-dashboards/**'
       - 'cypress/utils/dashboards/**'
+      - '.github/actions/start-opensearch/action.yml'
 
 env:
   CI_GROUPS: "1,2,3,4,5,6,7,8,9"

--- a/.github/workflows/release-e2e-workflow-template-windows.yml
+++ b/.github/workflows/release-e2e-workflow-template-windows.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 21
       - name: Checkout cypress-test
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 21
       - name: Checkout cypress-test
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
### Description

![image](https://github.com/opensearch-project/opensearch-dashboards-functional-test/assets/13493605/82eeaa6b-01f4-4315-af8b-d27811caceb8)

There is a jar hell issue in opensearch 3.0.0. Bump JDK to 21 to mitigate.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
