### PR TITLE
Update assertion after loading fix

### DIFF
--- a/cypress/integration/plugins/security/roles_spec.js
+++ b/cypress/integration/plugins/security/roles_spec.js
@@ -50,7 +50,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
         .click({ force: true });
 
       cy.contains('span', 'cluster:admin/opendistro/ad/detector/search').should(
-        'not.exist'
+        'exist'
       );
     });
 


### PR DESCRIPTION
### Description

After an upstream change in security dashboards plugin, we are now showing a loading screen until the data is returned. This means that a previously faulty assertion became untrue. This PR fixes that. Now it asserts that when clicking on a cluster filter dropdown, a cluster permission link exists (previously it did not exist since the data was not returned yet). 

### Issues Resolved

Fix: https://github.com/opensearch-project/security-dashboards-plugin/issues/1999
### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
