### PR TITLE
[Security Analytics][2.15] Fix alerts tests security analytics

### DIFF
--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/3_alerts.spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/3_alerts.spec.js
@@ -75,10 +75,13 @@ describe('Alerts', () => {
   });
 
   it('are generated', () => {
+    setupIntercept(cy, '/_security_analytics/alerts', 'getAlerts', 'GET');
+
     // Refresh the table
     cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click({
       force: true,
     });
+    cy.wait('@getAlerts').should('have.property', 'state', 'Complete');
 
     // Confirm there are alerts created
     cy.get('tbody > tr')
@@ -385,6 +388,8 @@ describe('Alerts', () => {
         cy.get('[aria-label="Acknowledge"]').click({ force: true });
       });
 
+    // Wait for acknowledge to go through
+    cy.wait(2000);
     cy.get('tbody > tr')
       .filter(`:contains(${alertName})`)
       .should('have.length', 1);
@@ -395,6 +400,8 @@ describe('Alerts', () => {
       cy.contains('Acknowledged').click({ force: true });
     });
 
+    // Wait for filter to apply
+    cy.wait(2000);
     // Confirm there are now 3 "Acknowledged" alerts
     cy.get('tbody > tr')
       .filter(`:contains(${alertName})`)


### PR DESCRIPTION
### Description
Updates alerts spec test for PRs 
- https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1031
- https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1033

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
