### PR TITLE
feat: reuse specs finder

### DIFF
--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
@@ -35,17 +35,14 @@ jobs:
         name: Get specs array
         run: |
           cd spec-detect
+          source ./test_finder.sh
           result="["
           ## split CI_Groups into array
           IFS="," read -a groups <<< "${{ env.CI_GROUPS }}"
           for group in "${groups[@]}"; do
             item="{\"ciGroup\": \"${group}\", \"specs\": "
-            IFS="," read -a SPEC_ARRAY <<< "$(npm run -s osd:ciGroup${group})"
-            FORMATTED_SPEC="\""
-            for i in "${SPEC_ARRAY[@]}"; do
-              FORMATTED_SPEC+="cypress/integration/core-opensearch-dashboards/opensearch-dashboards/${i},"
-            done
-            FORMATTED_SPEC+="\" }"
+            specs_of_ci_group=`ci_grouped_specs_finder ${group}`
+            FORMATTED_SPEC="\"${specs_of_ci_group}\" }"
             if [[ "${result}" != "[" ]];
             then
                 result+=","

--- a/test_finder.sh
+++ b/test_finder.sh
@@ -6,6 +6,7 @@ OSD_BUILD_MANIFEST='../local-test-cluster/opensearch-dashboards-*/manifest.yml'
 OSD_TEST_PATH='cypress/integration/core-opensearch-dashboards'
 OSD_PLUGIN_TEST_PATH='cypress/integration/plugins'
 TEST_TYPE=$OPTION
+CI_GROUP_PATTERN_PREFIX="OpenSearch-Dashboards-ci-group-"
 
 # Map component name in opensearch-build repo INPUT_MANIFEST with folder name for tests in functional repo
 OSD_COMPONENT_TEST_MAP=( "OpenSearch-Dashboards:opensearch-dashboards"
@@ -23,6 +24,15 @@ OSD_COMPONENT_TEST_MAP=( "OpenSearch-Dashboards:opensearch-dashboards"
                          "mlCommonsDashboards:ml-commons-dashboards"
                          "securityAnalyticsDashboards:security-analytics-dashboards-plugin"
                          "assistantDashboards:dashboards-assistant"
+                         "OpenSearch-Dashboards-ci-group-1:OpenSearch-Dashboards-ci-group-1"
+                         "OpenSearch-Dashboards-ci-group-2:OpenSearch-Dashboards-ci-group-2"
+                         "OpenSearch-Dashboards-ci-group-3:OpenSearch-Dashboards-ci-group-3"
+                         "OpenSearch-Dashboards-ci-group-4:OpenSearch-Dashboards-ci-group-4"
+                         "OpenSearch-Dashboards-ci-group-5:OpenSearch-Dashboards-ci-group-5"
+                         "OpenSearch-Dashboards-ci-group-6:OpenSearch-Dashboards-ci-group-6"
+                         "OpenSearch-Dashboards-ci-group-7:OpenSearch-Dashboards-ci-group-7"
+                         "OpenSearch-Dashboards-ci-group-8:OpenSearch-Dashboards-ci-group-8"
+                         "OpenSearch-Dashboards-ci-group-9:OpenSearch-Dashboards-ci-group-9"
                        )
 
 if [ -z $TEST_TYPE ]; then
@@ -71,7 +81,13 @@ function get_test_list() {
             else
                 for test_component in $TEST_COMPONENTS_LOCAL; do
                     if [ "$test_component" = "$component_name" ]; then
-                        TEST_FILES_LOCAL+="$TEST_PATH_LOCAL/$test_folder/$TEST_FILES_EXT_LOCAL,"
+                        ci_group_pattern="${CI_GROUP_PATTERN_PREFIX}*"
+                        if [[ $test_component == $ci_group_pattern ]]; then
+                            group=${test_component#${CI_GROUP_PATTERN_PREFIX}}
+                            TEST_FILES_LOCAL=`ci_grouped_specs_finder ${group}`
+                        else
+                            TEST_FILES_LOCAL+="$TEST_PATH_LOCAL/$test_folder/$TEST_FILES_EXT_LOCAL,"
+                        fi
                         break
                     fi
                 done
@@ -86,4 +102,16 @@ function get_test_list() {
     done
 
     echo "${TEST_FILES_LOCAL%,}"
+}
+
+function ci_grouped_specs_finder {
+    group=$1
+
+    IFS="," read -a SPEC_ARRAY <<< "$(npm run -s osd:ciGroup${group})"
+    FORMATTED_SPEC=""
+    for i in "${SPEC_ARRAY[@]}"; do
+        FORMATTED_SPEC+="${OSD_TEST_PATH}/opensearch-dashboards/${i},"
+    done
+
+    echo "${FORMATTED_SPEC}"
 }


### PR DESCRIPTION
### Description

Extract the ci_groups_finder logic to test_finder.sh so that Jenkins workflow can reuse the CI groups to organize OSD test cases.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
