### PR TITLE
Cypress Fix for few flaky tests in index-management dashboard plugin during Jenkins executions

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -167,7 +167,7 @@ describe('Aliases', () => {
         );
         let num =
           response_obj['_all']['total']['translog']['uncommitted_operations'];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       cy.get('[data-test-subj="moreAction"]').click();

--- a/cypress/integration/plugins/index-management-dashboards-plugin/data_streams.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/data_streams.js
@@ -110,7 +110,7 @@ describe('Data stream', () => {
         );
         let num =
           response_obj['_all']['total']['translog']['uncommitted_operations'];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       cy.get('[data-test-subj="moreAction"]').click();

--- a/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
@@ -628,7 +628,7 @@ describe('Indices', () => {
         );
         let num =
           response_obj['_all']['total']['translog']['uncommitted_operations'];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       // Select an index
@@ -688,7 +688,7 @@ describe('Indices', () => {
         );
         let num =
           response_obj['_all']['total']['translog']['uncommitted_operations'];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       cy.get('[data-test-subj="moreAction"]').click();

--- a/cypress/integration/plugins/index-management-dashboards-plugin/rollups_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/rollups_spec.js
@@ -17,7 +17,7 @@ describe('Rollups', () => {
     cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`);
 
     // Click on "Sample data" tab
-    cy.contains('Sample data').click({ force: true });
+    cy.contains('Sample data', { timeout: 60000 }).click({ force: true });
     // Load sample eCommerce data
     cy.get(`button[data-test-subj="addSampleDataSetecommerce"]`).click({
       force: true,

--- a/cypress/integration/plugins/index-management-dashboards-plugin/transforms_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/transforms_spec.js
@@ -266,6 +266,9 @@ describe('Transforms', () => {
         .should('not.be.disabled')
         .click();
 
+      // Extra wait to reduce the possibility of version conflict exception
+      cy.wait(2000);
+
       cy.wait('@stopTransform');
       cy.wait('@getTransform');
 


### PR DESCRIPTION
### Description

This change reduces the possibility of failures of few flaky tests in IM dashboard

Flaky tests:
1. rollup_spec cypress test
![](https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.15.0/7742/linux/x64/deb/test-results/5966/integ-test/indexManagementDashboards/with-security/cypress-screenshots/plugins/index-management-dashboards-plugin/rollups_spec.js/Rollups+--+successfully+--+before+each+hook+%28failed%29.png)

2. transform_spec cypress test
![](https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.15.0/7742/linux/x64/deb/test-results/5966/integ-test/indexManagementDashboards/with-security/cypress-screenshots/plugins/index-management-dashboards-plugin/transforms_spec.js/Transforms+--+can+be+enabled+and+disabled+--+successfully+%28failed%29.png)
### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
