### PR TITLE
Check trace group table loading state 

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/1_trace_analytics_dashboard.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/1_trace_analytics_dashboard.spec.js
@@ -36,6 +36,10 @@ describe('Testing dashboard table', () => {
       '[data-test-subj="trace-groups-service-operation-accordian"]'
     ).click();
 
+    cy.get('[data-test-subj="dashboard-table-trace-group-name-button"]').should(
+      'be.visible'
+    );
+
     cy.contains(' >= 95 percentile').click({ force: true });
     cy.wait(delayTime);
     cy.contains(' >= 95 percentile').click({ force: true });
@@ -64,6 +68,11 @@ describe('Testing dashboard table', () => {
     cy.get(
       '[data-test-subj="trace-groups-service-operation-accordian"]'
     ).click();
+
+    cy.get('[data-test-subj="dashboard-table-trace-group-name-button"]').should(
+      'be.visible'
+    );
+
     cy.get('.euiButtonIcon[aria-label="Open popover"]').first().click();
     cy.get('text.ytitle[data-unformatted="Hourly latency (ms)"]').should(
       'exist'
@@ -74,6 +83,11 @@ describe('Testing dashboard table', () => {
     cy.get(
       '[data-test-subj="trace-groups-service-operation-accordian"]'
     ).click();
+
+    cy.get('[data-test-subj="dashboard-table-trace-group-name-button"]').should(
+      'be.visible'
+    );
+
     cy.get('[data-test-subj="dashboard-table-traces-button"]')
       .contains('13')
       .click();
@@ -100,6 +114,10 @@ describe('Testing plots', () => {
     cy.get(
       '[data-test-subj="trace-groups-service-operation-accordian"]'
     ).click();
+
+    cy.get('[data-test-subj="dashboard-table-trace-group-name-button"]').should(
+      'be.visible'
+    );
   });
 
   it('Renders plots', () => {


### PR DESCRIPTION
### Description

Waits for trace group table to load, before proceeding to next cypress checks

### Issues Resolved

https://github.com/opensearch-project/opensearch-dashboards-functional-test/issues/1269

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
