### PR TITLE
Add env_var params to allow customizing runs on ftrepo tests

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -90,7 +90,6 @@ fi
 
 if [ -n "$ENV_VAR" ]; then
   echo "User defined ENV_VAR for the run: $ENV_VAR"
-  ENV_VAR="env $ENV_VAR"
 fi
 
 if [ -z "$REMOTE_CYPRESS_ENABLED" ]
@@ -139,11 +138,11 @@ fi
 
 if [ "$SECURITY_ENABLED" = "true" ]
 then
-   cmd="$ENV_VAR yarn cypress:run-with-security --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
+   cmd="yarn cypress:run-with-security \"$ENV_VAR\" --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
    echo "run security enabled tests: $cmd"
    eval $cmd
 else
-   cmd="$ENV_VAR yarn cypress:run-without-security --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
+   cmd="$ENV_VAR yarn cypress:run-without-security \"$ENV_VAR\" --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
    echo "run security disabled tests: $cmd"
    eval $cmd
 fi

--- a/integtest.sh
+++ b/integtest.sh
@@ -17,6 +17,7 @@ function usage() {
     echo -e "-b BIND_ADDRESS\t, defaults to localhost | 127.0.0.1, can be changed to any IP or domain name for the cluster location."
     echo -e "-p BIND_PORT\t, defaults to 9200 or 5601 depends on OpenSearch or Dashboards, can be changed to any port for the cluster location."
     echo -e "-s SECURITY_ENABLED\t(true | false), defaults to true. Specify the OpenSearch/Dashboards have security enabled or not."
+    echo -e "-e ENV_VAR\t, no defaults, specify potential ENV_VAR in integtest.sh, separate by space if adding multiple (-e \"CYPRESS_NO_COMMAND_LOG=1 SOME_PARAMS=2\")"
     echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
     echo -e "-t TEST_COMPONENTS\t(OpenSearch-Dashboards reportsDashboards etc.), optional, specify test components, separate with space, else test everything."
     echo -e "-v VERSION\t, no defaults, indicates the OpenSearch version to test."
@@ -26,7 +27,7 @@ function usage() {
     echo "--------------------------------------------------------------------------"
 }
 
-while getopts ":hb:p:s:c:t:v:o:r:" arg; do
+while getopts ":hb:p:s:e:c:t:v:o:r:" arg; do
     case $arg in
         h)
             usage
@@ -40,6 +41,9 @@ while getopts ":hb:p:s:c:t:v:o:r:" arg; do
             ;;
         s)
             SECURITY_ENABLED=$OPTARG
+            ;;
+        e)
+            ENV_VAR=$OPTARG
             ;;
         c)
             CREDENTIAL=$OPTARG
@@ -82,6 +86,12 @@ fi
 if [ -z "$SECURITY_ENABLED" ]
 then
   SECURITY_ENABLED="true"
+fi
+
+if [ -n "$ENV_VAR" ]; then
+then
+  echo "User defined ENV_VAR for the run: $ENV_VAR"
+  ENV_VAR="env $ENV_VAR"
 fi
 
 if [ -z "$REMOTE_CYPRESS_ENABLED" ]
@@ -131,8 +141,8 @@ fi
 if [ "$SECURITY_ENABLED" = "true" ]
 then
    echo "run security enabled tests"
-   yarn cypress:run-with-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
+   $ENV_VAR yarn cypress:run-with-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
 else
    echo "run security disabled tests"
-   yarn cypress:run-without-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
+   $ENV_VAR yarn cypress:run-without-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
 fi

--- a/integtest.sh
+++ b/integtest.sh
@@ -139,11 +139,11 @@ fi
 
 if [ "$SECURITY_ENABLED" = "true" ]
 then
-   cmd="yarn cypress:run --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,AGGREGATION_VIEW=true,WAIT_FOR_LOADER_BUFFER_MS=3000,$ENV_VAR --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
+   cmd="yarn cypress:run --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,AGGREGATION_VIEW=true,WAIT_FOR_LOADER_BUFFER_MS=3000$ENV_VAR --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
    echo "run security enabled tests: $cmd"
    eval $cmd
 else
-   cmd="$ENV_VAR yarn cypress:run --env SECURITY_ENABLED=false,$ENV_VAR --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
+   cmd="$ENV_VAR yarn cypress:run --env SECURITY_ENABLED=false$ENV_VAR --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
    echo "run security disabled tests: $cmd"
    eval $cmd
 fi

--- a/integtest.sh
+++ b/integtest.sh
@@ -139,9 +139,9 @@ fi
 
 if [ "$SECURITY_ENABLED" = "true" ]
 then
-   echo "run security enabled tests"
-   $ENV_VAR yarn cypress:run-with-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
+   cmd="$ENV_VAR yarn cypress:run-with-security --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
+   echo "run security enabled tests: $cmd"
 else
-   echo "run security disabled tests"
-   $ENV_VAR yarn cypress:run-without-security --browser "$BROWSER_PATH" --spec "$TEST_FILES"
+   cmd="$ENV_VAR yarn cypress:run-without-security --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
+   echo "run security disabled tests: $cmd"
 fi

--- a/integtest.sh
+++ b/integtest.sh
@@ -141,7 +141,9 @@ if [ "$SECURITY_ENABLED" = "true" ]
 then
    cmd="$ENV_VAR yarn cypress:run-with-security --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
    echo "run security enabled tests: $cmd"
+   eval $cmd
 else
    cmd="$ENV_VAR yarn cypress:run-without-security --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
    echo "run security disabled tests: $cmd"
+   eval $cmd
 fi

--- a/integtest.sh
+++ b/integtest.sh
@@ -89,7 +89,6 @@ then
 fi
 
 if [ -n "$ENV_VAR" ]; then
-then
   echo "User defined ENV_VAR for the run: $ENV_VAR"
   ENV_VAR="env $ENV_VAR"
 fi

--- a/integtest.sh
+++ b/integtest.sh
@@ -139,11 +139,11 @@ fi
 
 if [ "$SECURITY_ENABLED" = "true" ]
 then
-   cmd="yarn cypress:run-with-security $ENV_VAR --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
+   cmd="yarn cypress:run --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,AGGREGATION_VIEW=true,WAIT_FOR_LOADER_BUFFER_MS=3000,$ENV_VAR --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
    echo "run security enabled tests: $cmd"
    eval $cmd
 else
-   cmd="$ENV_VAR yarn cypress:run-without-security $ENV_VAR --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
+   cmd="$ENV_VAR yarn cypress:run --env SECURITY_ENABLED=false,$ENV_VAR --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
    echo "run security disabled tests: $cmd"
    eval $cmd
 fi

--- a/integtest.sh
+++ b/integtest.sh
@@ -17,7 +17,7 @@ function usage() {
     echo -e "-b BIND_ADDRESS\t, defaults to localhost | 127.0.0.1, can be changed to any IP or domain name for the cluster location."
     echo -e "-p BIND_PORT\t, defaults to 9200 or 5601 depends on OpenSearch or Dashboards, can be changed to any port for the cluster location."
     echo -e "-s SECURITY_ENABLED\t(true | false), defaults to true. Specify the OpenSearch/Dashboards have security enabled or not."
-    echo -e "-e ENV_VAR\t, no defaults, specify potential ENV_VAR in integtest.sh, separate by space if adding multiple (-e \"CYPRESS_NO_COMMAND_LOG=1 SOME_PARAMS=2\")"
+    echo -e "-e ENV_VAR\t, no defaults, specify potential ENV_VAR in integtest.sh, separate by comma(,) if adding multiple (-e \"CYPRESS_NO_COMMAND_LOG=1,SOME_PARAMS=2\")"
     echo -e "-c CREDENTIAL\t(usename:password), no defaults, effective when SECURITY_ENABLED=true."
     echo -e "-t TEST_COMPONENTS\t(OpenSearch-Dashboards reportsDashboards etc.), optional, specify test components, separate with space, else test everything."
     echo -e "-v VERSION\t, no defaults, indicates the OpenSearch version to test."
@@ -90,6 +90,7 @@ fi
 
 if [ -n "$ENV_VAR" ]; then
   echo "User defined ENV_VAR for the run: $ENV_VAR"
+  ENV_VAR=,$ENV_VAR
 fi
 
 if [ -z "$REMOTE_CYPRESS_ENABLED" ]
@@ -138,11 +139,11 @@ fi
 
 if [ "$SECURITY_ENABLED" = "true" ]
 then
-   cmd="yarn cypress:run-with-security \"$ENV_VAR\" --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
+   cmd="yarn cypress:run-with-security $ENV_VAR --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
    echo "run security enabled tests: $cmd"
    eval $cmd
 else
-   cmd="$ENV_VAR yarn cypress:run-without-security \"$ENV_VAR\" --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
+   cmd="$ENV_VAR yarn cypress:run-without-security $ENV_VAR --browser \"$BROWSER_PATH\" --spec \"$TEST_FILES\""
    echo "run security disabled tests: $cmd"
    eval $cmd
 fi

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "cypress:open": "cypress open",
-    "cypress:run-without-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 \"$1\" cypress run --headless --env SECURITY_ENABLED=false; }; f",
-    "cypress:run-with-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 \"$1\" cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,WAIT_FOR_LOADER_BUFFER_MS=3000; }; f",
+    "cypress:run-without-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=false\"$1\"; }; f",
+    "cypress:run-with-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,WAIT_FOR_LOADER_BUFFER_MS=3000\"$1\"; }; f",
     "cypress:run-with-security-and-aggregation-view": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,AGGREGATION_VIEW=true,WAIT_FOR_LOADER_BUFFER_MS=3000",
     "cypress:run-plugin-tests-without-security": "yarn cypress:run-without-security --spec 'cypress/integration/plugins/*/*.js'",
     "cypress:run-plugin-tests-with-security": "yarn cypress:run-with-security --spec 'cypress/integration/plugins/*/*.js'",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "cypress:open": "cypress open",
-    "cypress:run-without-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=false\"$1\"; }; f",
-    "cypress:run-with-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,WAIT_FOR_LOADER_BUFFER_MS=3000\"$1\"; }; f",
+    "cypress:run": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless",
+    "cypress:run-without-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=false",
+    "cypress:run-with-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,WAIT_FOR_LOADER_BUFFER_MS=3000",
     "cypress:run-with-security-and-aggregation-view": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,AGGREGATION_VIEW=true,WAIT_FOR_LOADER_BUFFER_MS=3000",
     "cypress:run-plugin-tests-without-security": "yarn cypress:run-without-security --spec 'cypress/integration/plugins/*/*.js'",
     "cypress:run-plugin-tests-with-security": "yarn cypress:run-with-security --spec 'cypress/integration/plugins/*/*.js'",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "cypress:open": "cypress open",
-    "cypress:run-without-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=false",
-    "cypress:run-with-security": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,WAIT_FOR_LOADER_BUFFER_MS=3000",
+    "cypress:run-without-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 \"$@\" cypress run --headless --env SECURITY_ENABLED=false; }; f",
+    "cypress:run-with-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 \"$@\" cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,WAIT_FOR_LOADER_BUFFER_MS=3000; }; f",
     "cypress:run-with-security-and-aggregation-view": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,AGGREGATION_VIEW=true,WAIT_FOR_LOADER_BUFFER_MS=3000",
     "cypress:run-plugin-tests-without-security": "yarn cypress:run-without-security --spec 'cypress/integration/plugins/*/*.js'",
     "cypress:run-plugin-tests-with-security": "yarn cypress:run-with-security --spec 'cypress/integration/plugins/*/*.js'",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "cypress:open": "cypress open",
-    "cypress:run-without-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 \"$@\" cypress run --headless --env SECURITY_ENABLED=false; }; f",
-    "cypress:run-with-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 \"$@\" cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,WAIT_FOR_LOADER_BUFFER_MS=3000; }; f",
+    "cypress:run-without-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 \"$1\" cypress run --headless --env SECURITY_ENABLED=false; }; f",
+    "cypress:run-with-security": "f() { env TZ=America/Los_Angeles NO_COLOR=1 \"$1\" cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,WAIT_FOR_LOADER_BUFFER_MS=3000; }; f",
     "cypress:run-with-security-and-aggregation-view": "env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,AGGREGATION_VIEW=true,WAIT_FOR_LOADER_BUFFER_MS=3000",
     "cypress:run-plugin-tests-without-security": "yarn cypress:run-without-security --spec 'cypress/integration/plugins/*/*.js'",
     "cypress:run-plugin-tests-with-security": "yarn cypress:run-with-security --spec 'cypress/integration/plugins/*/*.js'",


### PR DESCRIPTION
### Description

Add env_var params to allow customizing runs on ftrepo tests.
We are trying to add env var `CYPRESS_NO_COMMAND_LOG=1` for OSD core, and potentially other env vars later on for tests run in ftrepo.

Thanks.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/4681
https://github.com/opensearch-project/opensearch-build/issues/4745

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
