### PR TITLE
Fix workspace failed integration tests

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_create.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_create.spec.js
@@ -77,7 +77,7 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
         cy.getElementByTestId('workspaceForm-bottomBar-createButton').click({
           force: true,
         });
-        cy.contains("Name can't be empty").should('exist');
+        cy.contains('Name is required. Enter a name.').should('exist');
       });
 
       it('workspace name is not valid', () => {
@@ -90,7 +90,7 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
         cy.getElementByTestId('workspaceForm-bottomBar-createButton').click({
           force: true,
         });
-        cy.contains('Invalid workspace name').should('exist');
+        cy.contains('Name is invalid. Enter a valid name.').should('exist');
       });
 
       it('workspace name cannot use an existing name', () => {
@@ -145,8 +145,9 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
           cy.getElementByTestId(
             'workspaceForm-permissionSettingPanel-user-addNew'
           ).click();
-          cy.getElementByTestId('comboBoxSearchInput')
-            .last()
+          cy.contains('.euiComboBoxPlaceholder', 'Select a user')
+            .parent()
+            .find('input')
             .type('test_user_sfslja260');
           cy.getElementByTestId('workspaceForm-bottomBar-createButton').click({
             force: true,

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_import_sample_data_to.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_import_sample_data_to.spec.js
@@ -21,22 +21,39 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
 
     before(() => {
       if (MDSEnabled) {
-        cy.createDataSourceNoAuth().then((result) => {
-          dataSourceId = result[0];
-          dataSourceTitle = result[1];
+        cy.createDataSourceNoAuth()
+          .then((result) => {
+            dataSourceId = result[0];
+            dataSourceTitle = result[1];
+            return result;
+          })
+          .then((result) => {
+            cy.createWorkspace({
+              name: workspaceName,
+              settings: MDSEnabled
+                ? {
+                    dataSources: [result[0]],
+                  }
+                : undefined,
+            }).then((id) => {
+              workspaceId = id;
+            });
+          });
+      } else {
+        cy.createWorkspace({
+          name: workspaceName,
+        }).then((id) => {
+          workspaceId = id;
         });
       }
-      cy.createWorkspace({ name: workspaceName }).then((id) => {
-        workspaceId = id;
-      });
     });
 
     after(() => {
       if (workspaceId) {
         cy.deleteWorkspaceById(workspaceId);
       }
-      if (dataSourceId) {
-        cy.deleteDataSource(dataSourceId);
+      if (MDSEnabled) {
+        cy.deleteAllDataSources();
       }
     });
 

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_overview.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_overview.spec.js
@@ -23,6 +23,12 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
           'workspace_update',
           'use-case-observability',
         ],
+        settings: {
+          permissions: {
+            library_write: { users: ['%me%'] },
+            write: { users: ['%me%'] },
+          },
+        },
       }).then((id) => {
         workspaceId = id;
       });
@@ -97,14 +103,17 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
       );
     });
 
-    it('should show wokrspace update when click on settings tab', () => {
+    it('should show workspace update when click on settings tab', () => {
       // click on settings tab
       cy.getElementByTestId('workspaceTabs').find('#settings').click();
-      cy.contains('Enter Details').should('be.visible');
+      cy.contains('Enter details').should('be.visible');
 
-      cy.getElementByTestId('workspaceForm-workspaceDetails-nameInputText')
-        .clear()
-        .type(`${workspaceDescription}-updated`);
+      cy.getElementByTestId(
+        'workspaceForm-workspaceDetails-nameInputText'
+      ).clear();
+      cy.getElementByTestId(
+        'workspaceForm-workspaceDetails-nameInputText'
+      ).type(`${workspaceDescription}-updated`);
       cy.getElementByTestId('workspaceForm-bottomBar-updateButton').click({
         force: true,
       });

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_update.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_update.spec.js
@@ -19,6 +19,12 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
           'workspace_update',
           'use-case-observability',
         ],
+        settings: {
+          permissions: {
+            library_write: { users: ['%me%'] },
+            write: { users: ['%me%'] },
+          },
+        },
       }).then((value) => (workspaceId = value));
     });
 
@@ -57,7 +63,7 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
         cy.getElementByTestId('workspaceForm-bottomBar-updateButton').click({
           force: true,
         });
-        cy.contains("Name can't be empty").should('exist');
+        cy.contains('Name is required. Enter a name.').should('exist');
       });
 
       it('workspace name is not valid', () => {
@@ -80,7 +86,7 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
         cy.getElementByTestId('workspaceForm-bottomBar-updateButton').click({
           force: true,
         });
-        cy.contains('Invalid workspace name').should('exist');
+        cy.contains('Name is invalid. Enter a valid name.').should('exist');
       });
     });
 
@@ -172,8 +178,9 @@ if (Cypress.env('WORKSPACE_ENABLED')) {
           cy.getElementByTestId(
             'workspaceForm-permissionSettingPanel-user-addNew'
           ).click();
-          cy.getElementByTestId('comboBoxSearchInput')
-            .last()
+          cy.contains('.euiComboBoxPlaceholder', 'Select a user')
+            .parent()
+            .find('input')
             .type('test_user_Fnxs972xC');
           cy.getElementByTestId('workspaceForm-bottomBar-updateButton').click({
             force: true,

--- a/cypress/utils/dashboards/workspace-plugin/commands.js
+++ b/cypress/utils/dashboards/workspace-plugin/commands.js
@@ -41,7 +41,7 @@ Cypress.Commands.add('deleteWorkspaceByName', (workspaceName) => {
   });
 });
 
-Cypress.Commands.add('createWorkspace', (workspace) => {
+Cypress.Commands.add('createWorkspace', ({ settings, ...workspace } = {}) => {
   cy.request({
     method: 'POST',
     url: `${BASE_PATH}${WORKSPACE_API_PREFIX}`,
@@ -53,6 +53,7 @@ Cypress.Commands.add('createWorkspace', (workspace) => {
         ...workspace,
         description: workspace.description || 'test_description',
       },
+      settings,
     },
   }).then((resp) => {
     if (resp && resp.body && resp.body.success) {


### PR DESCRIPTION
### Description

Due to [workspace form refactor PR](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7133) in OSD, some workspace integration test cases were failed across below files:
- cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_create.spec.js
- cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_import_sample_data_to.spec.js
- cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_overview.spec.js
- cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_update.spec.js

This PR aim to fix these failed test cases.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
