### PR TITLE
[2.x] Fixes flaky-ness in permissions spec test

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -16,6 +16,7 @@
     "remoteDataSourceBasicAuthUsername": "admin",
     "remoteDataSourceBasicAuthPassword": "admin",
     "SECURITY_ENABLED": false,
+    "MULTITENANCY_ENABLED": true,
     "AGGREGATION_VIEW": false,
     "username": "admin",
     "password": "myStrongPassword123!",

--- a/cypress/integration/plugins/security-dashboards-plugin/inaccessible_tenancy_features.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/inaccessible_tenancy_features.js
@@ -5,7 +5,7 @@
 
 import { TENANTS_MANAGE_PATH } from '../../../utils/dashboards/constants';
 
-if (Cypress.env('SECURITY_ENABLED')) {
+if (Cypress.env('SECURITY_ENABLED') && !Cypress.env('MULTITENANCY_ENABLED')) {
   describe('Multi Tenancy Tests: ', () => {
     before(() => {
       cy.server();

--- a/cypress/integration/plugins/security-dashboards-plugin/readonly.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/readonly.js
@@ -62,6 +62,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
             `"${TEST_CONFIG.tenant.name}"`
           );
           window.localStorage.setItem('home:newThemeModal:show', false);
+          window.localStorage.setItem('home:welcome:show', false);
         },
       });
       cy.waitForLoader();

--- a/cypress/integration/plugins/security-dashboards-plugin/switch_tenant.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/switch_tenant.js
@@ -7,12 +7,12 @@ export function switchTenantTo(newTenant) {
   cy.getElementByTestId('account-popover').click();
   cy.intercept({
     method: 'GET',
-    url: '/api/v1/auth/dashboardsinfo',
+    url: '/api/v1/auth/dashboardsinfo*',
   }).as('waitForDashboardsInfo');
 
   cy.intercept({
     method: 'GET',
-    url: '/api/v1/configuration/account',
+    url: '/api/v1/configuration/account*',
   }).as('waitForAccountInfo');
 
   cy.getElementByTestId('switch-tenants').click();
@@ -37,7 +37,7 @@ export function switchTenantTo(newTenant) {
 
   cy.intercept({
     method: 'POST',
-    url: '/api/v1/multitenancy/tenant',
+    url: '/api/v1/multitenancy/tenant*',
   }).as('waitForUpdatingTenants');
   cy.getElementByTestId('tenant-switch-modal')
     .find('[data-test-subj="confirm"]')

--- a/cypress/integration/plugins/security/permissions_spec.js
+++ b/cypress/integration/plugins/security/permissions_spec.js
@@ -91,7 +91,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.contains('button', 'Cancel');
       cy.contains('.euiModalHeader__title', 'Create new action group');
 
-      const actionGroupName = 'test';
+      const actionGroupName = 'test-creation';
       cy.get('input[data-test-subj="name-text"]').type(actionGroupName, {
         force: true,
       });
@@ -138,7 +138,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.contains('button', 'Cancel');
       cy.contains('.euiModalHeader__title', 'Create new action group');
 
-      const actionGroupName = 'test';
+      const actionGroupName = 'test-selection';
       cy.get('input[data-test-subj="name-text"]').type(actionGroupName, {
         force: true,
       });


### PR DESCRIPTION
_**note**: this change already exists on main and was added via: https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1444_

### Description

2.16 integ test build failed for securityDashboards:
https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7841/linux/arm64/tar/test-results/6098/integ-test/securityDashboards/with-security/cypress-screenshots/plugins/security/permissions_spec.js/Permissions+page+--+should+create+new+action+group+successfully+by+selecting+%60Create+from+selection%60+%28failed%29.png

cypress test-run video: https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7841/linux/arm64/tar/test-results/6098/integ-test/securityDashboards/with-security/cypress-videos/plugins/security/permissions_spec.js.mp4

The root-cause is potentially due to same names used for testing creation of action groups in 2 tests.

### Issues Resolved

- Related to https://github.com/opensearch-project/security-dashboards-plugin/issues/2055

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
