### PR TITLE
Fixes the permissions spec and related to fixtures to reflect correct action-group names

### DIFF
--- a/.github/workflows/security-release-e2e-workflow.yml
+++ b/.github/workflows/security-release-e2e-workflow.yml
@@ -19,6 +19,9 @@ jobs:
   tests:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
+    strategy:
+      matrix:
+        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     uses: ./.github/workflows/release-e2e-workflow-template.yml
     with:
       test-name: Security

--- a/.github/workflows/security-release-e2e-workflow.yml
+++ b/.github/workflows/security-release-e2e-workflow.yml
@@ -19,9 +19,6 @@ jobs:
   tests:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
-    strategy:
-      matrix:
-        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     uses: ./.github/workflows/release-e2e-workflow-template.yml
     with:
       test-name: Security

--- a/cypress/fixtures/plugins/security/permissions/actiongroups_post_new_creation_from_selection_response.json
+++ b/cypress/fixtures/plugins/security/permissions/actiongroups_post_new_creation_from_selection_response.json
@@ -1,7 +1,7 @@
 {
   "total": 26,
   "data": {
-    "test": {
+    "test-selection": {
       "reserved": false,
       "hidden": false,
       "allowed_actions": ["data_access"],

--- a/cypress/fixtures/plugins/security/permissions/actiongroups_post_new_creation_response.json
+++ b/cypress/fixtures/plugins/security/permissions/actiongroups_post_new_creation_response.json
@@ -1,7 +1,7 @@
 {
   "total": 26,
   "data": {
-    "test": {
+    "test-creation": {
       "reserved": false,
       "hidden": false,
       "allowed_actions": [],

--- a/cypress/integration/plugins/security-dashboards-plugin/sanity_tests.spec.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/sanity_tests.spec.js
@@ -156,7 +156,16 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.loadSampleData('flights');
       // Step 3: Navigate to Manage data to add an index pattern
       cy.visit(`${BASE_PATH}/app/home`);
-      cy.get('button[aria-label="Closes this modal window"]').click();
+
+      cy.get('.euiOverlayMask').then(($body) => {
+        if (
+          $body.find('button[aria-label="Closes this modal window"]').length
+        ) {
+          cy.get('button[aria-label="Closes this modal window"]').click();
+        } else {
+          // do nothing
+        }
+      });
       cy.contains('Manage').click(); // Adjust the selector as needed
 
       // Step 4: Add the index pattern

--- a/cypress/integration/plugins/security/permissions_spec.js
+++ b/cypress/integration/plugins/security/permissions_spec.js
@@ -86,13 +86,16 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.contains('.euiModalHeader__title', 'Create new action group');
 
       const actionGroupName = 'test-creation';
-      cy.get('input[data-test-subj="name-text"]').type(actionGroupName, {
-        force: true,
-      });
+      cy.get('input[data-test-subj="name-text"]')
+        .type(actionGroupName, {
+          force: true,
+        })
+        .blur();
       cy.get('input[data-test-subj="name-text"]').should(
         'have.value',
         actionGroupName
       );
+      cy.get('button[id="submit"]').should('not.have.attr', 'disabled');
 
       cy.mockPermissionsAction(
         SEC_PERMISSIONS_FIXTURES_PATH +
@@ -138,13 +141,16 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.contains('.euiModalHeader__title', 'Create new action group');
 
       const actionGroupName = 'test-selection';
-      cy.get('input[data-test-subj="name-text"]').type(actionGroupName, {
-        force: true,
-      });
+      cy.get('input[data-test-subj="name-text"]')
+        .type(actionGroupName, {
+          force: true,
+        })
+        .blur();
       cy.get('input[data-test-subj="name-text"]').should(
         'have.value',
         actionGroupName
       );
+      cy.get('button[id="submit"]').should('not.have.attr', 'disabled');
 
       cy.get('div[data-test-subj="comboBoxInput"]')
         .find('span')

--- a/cypress/integration/plugins/security/permissions_spec.js
+++ b/cypress/integration/plugins/security/permissions_spec.js
@@ -73,13 +73,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
     });
 
     it('should create new action group successfully by selecting `Create from blank`', () => {
-      cy.mockPermissionsAction(
-        SEC_PERMISSIONS_FIXTURES_PATH +
-          '/actiongroups_post_new_creation_response.json',
-        () => {
-          cy.visit(SEC_UI_PERMISSIONS_PATH);
-        }
-      );
+      cy.visit(SEC_UI_PERMISSIONS_PATH);
 
       cy.contains('button', 'Create action group')
         .first()
@@ -100,8 +94,13 @@ if (Cypress.env('SECURITY_ENABLED')) {
         actionGroupName
       );
 
-      cy.get('button[id="submit"]').first().click({ force: true });
-
+      cy.mockPermissionsAction(
+        SEC_PERMISSIONS_FIXTURES_PATH +
+          '/actiongroups_post_new_creation_response.json',
+        () => {
+          cy.get('button[id="submit"]').first().click({ force: true });
+        }
+      );
       cy.url().should((url) => {
         expect(url).to.contain('/permissions');
       });

--- a/cypress/integration/plugins/security/permissions_spec.js
+++ b/cypress/integration/plugins/security/permissions_spec.js
@@ -87,6 +87,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
 
       const actionGroupName = 'test-creation';
       cy.get('input[data-test-subj="name-text"]')
+        .focus()
+        .clear()
         .type(actionGroupName, {
           force: true,
         })
@@ -142,10 +144,13 @@ if (Cypress.env('SECURITY_ENABLED')) {
 
       const actionGroupName = 'test-selection';
       cy.get('input[data-test-subj="name-text"]')
+        .focus()
+        .clear()
         .type(actionGroupName, {
           force: true,
         })
         .blur();
+
       cy.get('input[data-test-subj="name-text"]').should(
         'have.value',
         actionGroupName


### PR DESCRIPTION
### Description

- Re-arranges the fixture load in a test to reflect the correct updates.
- Updates action-group names in fixture files.

### Issues Resolved

- Related to https://github.com/opensearch-project/security-dashboards-plugin/issues/2055

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
