### PR TITLE
fix tests to work with security enabled

### DIFF
--- a/cypress/integration/plugins/notifications-dashboards/1_email_senders_and_groups.spec.js
+++ b/cypress/integration/plugins/notifications-dashboards/1_email_senders_and_groups.spec.js
@@ -276,7 +276,8 @@ describe('Test create, edit and delete recipient group', () => {
     cy.get('[data-test-subj="recipient-groups-table-delete-button"]').click({
       force: true,
     });
-    cy.get('input[placeholder="delete"]').type('delete');
+    cy.wait(NOTIFICATIONS_DELAY);
+    cy.get('input[placeholder="delete"]').should('be.visible').type('delete');
     cy.wait(NOTIFICATIONS_DELAY);
     cy.get(
       '[data-test-subj="delete-recipient-group-modal-delete-button"]'


### PR DESCRIPTION
### Description

* This PR fixes the delete recepient group tests when security is enabled.
Tests passing locally
```
Couldn't determine Mocha version


  Test create email senders
    ✓ creates ssl sender (23454ms)
    ✓ creates tls sender (9529ms)
    ✓ creates SES sender (7720ms)

  Test edit senders
    ✓ edits sender email address (7649ms)
    ✓ edits ses sender region (6772ms)

  Test delete senders
    ✓ deletes smtp senders (8828ms)
    ✓ deletes ses senders (9164ms)

  Test create, edit and delete recipient group
    ✓ creates recipient group (13723ms)
    ✓ edits recipient group description (7658ms)
    ✓ opens email addresses popup (5351ms)
    ✓ deletes recipient groups (10181ms)


```

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
