### PR TITLE
Fix tests

### DIFF
--- a/cypress/integration/plugins/notifications-dashboards/1_email_senders_and_groups.spec.js
+++ b/cypress/integration/plugins/notifications-dashboards/1_email_senders_and_groups.spec.js
@@ -271,6 +271,10 @@ describe('Test create, edit and delete recipient group', () => {
   });
 
   it('deletes recipient groups', () => {
+    cy.wait(NOTIFICATIONS_DELAY);
+    cy.get('tbody > tr').should(($tr) => {
+      expect($tr, '1 row').to.have.length(1);
+    });
     cy.get('[data-test-subj="checkboxSelectAll"]').click({ force: true });
     cy.wait(NOTIFICATIONS_DELAY);
     cy.get('[data-test-subj="recipient-groups-table-delete-button"]').click({


### PR DESCRIPTION
### Description

* Fix Notification tests when Security enabled to fix CI failure -> https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.16.0/7852/linux/x64/rpm/test-results/6147/integ-test/notificationsDashboards/with-security/cypress-videos/plugins/notifications-dashboards/1_email_senders_and_groups.spec.js.mp4

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
