### PR TITLE
open dropdown if not open already

### DIFF
--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/3_alerts.spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/3_alerts.spec.js
@@ -396,14 +396,19 @@ describe('Alerts', () => {
       .should('have.length', 1);
 
     // Filter the table to show only "Acknowledged" alerts
-    cy.get('[data-text="Status"]').click({ force: true });
-    cy.get('[class="euiFilterSelect__items"]').within(() => {
-      cy.contains('Active').click({ force: true });
-      cy.contains('Acknowledged').click({ force: true });
+    cy.get('body').then(($body) => {
+      if ($body.find('[class="euiFilterSelect__items"]').length === 0) {
+        cy.get('[data-text="Status"]').click({ force: true });
+      }
+
+      cy.get('[class="euiFilterSelect__items"]').within(() => {
+        cy.contains('Active').click({ force: true });
+        cy.contains('Acknowledged').click({ force: true });
+      });
     });
 
     // Wait for filter to apply
-    cy.wait(2000);
+    cy.wait(3000);
     // Confirm there are now 3 "Acknowledged" alerts
     cy.get('tbody > tr')
       .filter(`:contains(${alertName})`)


### PR DESCRIPTION
### Description
Fixes alert related test by ensuring the filter dropdown is opened if not open already.

Passing tests:
<img width="526" alt="image" src="https://github.com/user-attachments/assets/1233e80b-49ee-4663-be72-45be98a8bcf3">


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
