### PR TITLE
Cleanup Index patterns after the test

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/index_pattern_without_field.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/index_pattern_without_field.spec.js
@@ -45,6 +45,7 @@ describe('index pattern without field spec', () => {
     testFixtureHandler.clearJSONMapping(
       'cypress/fixtures/dashboard/opensearch_dashboards/data_explorer/index_pattern_without_timefield/mappings.json.txt'
     );
+    cy.deleteSavedObjectByType('index-pattern');
   });
 
   it('should not display a timepicker', () => {

--- a/cypress/utils/dashboards/vis_type_table/table.js
+++ b/cypress/utils/dashboards/vis_type_table/table.js
@@ -119,5 +119,5 @@ Cypress.Commands.add('tbClickFilterFromExpand', (action) => {
   cy.get('[class="euiPopoverFooter"]')
     .find('[class="euiFlexItem"]')
     .find(`[data-test-subj=${actionButton}]`)
-    .click();
+    .click({ force: true });
 });


### PR DESCRIPTION
### Description

The test cleans up the index pattern after it has been used for the test. 
![image](https://github.com/user-attachments/assets/aced31ac-86d5-4ce8-87b3-e730472ccf80)
![image](https://github.com/user-attachments/assets/bbcaf68a-b152-4afe-97b2-c2cd96c733b7)

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
