### PR TITLE
[Backport 2.16] Fixes the permissions spec and related to fixtures to reflect correct action-group names (#1449)

### DIFF
--- a/cypress/fixtures/plugins/security/permissions/actiongroups_post_new_creation_from_selection_response.json
+++ b/cypress/fixtures/plugins/security/permissions/actiongroups_post_new_creation_from_selection_response.json
@@ -1,7 +1,7 @@
 {
   "total": 26,
   "data": {
-    "test": {
+    "test-selection": {
       "reserved": false,
       "hidden": false,
       "allowed_actions": ["data_access"],

--- a/cypress/fixtures/plugins/security/permissions/actiongroups_post_new_creation_response.json
+++ b/cypress/fixtures/plugins/security/permissions/actiongroups_post_new_creation_response.json
@@ -1,7 +1,7 @@
 {
   "total": 26,
   "data": {
-    "test": {
+    "test-creation": {
       "reserved": false,
       "hidden": false,
       "allowed_actions": [],

--- a/cypress/integration/plugins/security/permissions_spec.js
+++ b/cypress/integration/plugins/security/permissions_spec.js
@@ -73,13 +73,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
     });
 
     it('should create new action group successfully by selecting `Create from blank`', () => {
-      cy.mockPermissionsAction(
-        SEC_PERMISSIONS_FIXTURES_PATH +
-          '/actiongroups_post_new_creation_response.json',
-        () => {
-          cy.visit(SEC_UI_PERMISSIONS_PATH);
-        }
-      );
+      cy.visit(SEC_UI_PERMISSIONS_PATH);
 
       cy.contains('button', 'Create action group')
         .first()
@@ -92,16 +86,26 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.contains('.euiModalHeader__title', 'Create new action group');
 
       const actionGroupName = 'test-creation';
-      cy.get('input[data-test-subj="name-text"]').type(actionGroupName, {
-        force: true,
-      });
+      cy.get('input[data-test-subj="name-text"]')
+        .focus()
+        .clear()
+        .type(actionGroupName, {
+          force: true,
+        })
+        .blur();
       cy.get('input[data-test-subj="name-text"]').should(
         'have.value',
         actionGroupName
       );
+      cy.get('button[id="submit"]').should('not.have.attr', 'disabled');
 
-      cy.get('button[id="submit"]').first().click({ force: true });
-
+      cy.mockPermissionsAction(
+        SEC_PERMISSIONS_FIXTURES_PATH +
+          '/actiongroups_post_new_creation_response.json',
+        () => {
+          cy.get('button[id="submit"]').first().click({ force: true });
+        }
+      );
       cy.url().should((url) => {
         expect(url).to.contain('/permissions');
       });
@@ -139,13 +143,19 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.contains('.euiModalHeader__title', 'Create new action group');
 
       const actionGroupName = 'test-selection';
-      cy.get('input[data-test-subj="name-text"]').type(actionGroupName, {
-        force: true,
-      });
+      cy.get('input[data-test-subj="name-text"]')
+        .focus()
+        .clear()
+        .type(actionGroupName, {
+          force: true,
+        })
+        .blur();
+
       cy.get('input[data-test-subj="name-text"]').should(
         'have.value',
         actionGroupName
       );
+      cy.get('button[id="submit"]').should('not.have.attr', 'disabled');
 
       cy.get('div[data-test-subj="comboBoxInput"]')
         .find('span')


### PR DESCRIPTION
Signed-off-by: Darshit Chanpura [dchanp@amazon.com](mailto:dchanp@amazon.com)
(cherry picked from commit https://github.com/opensearch-project/opensearch-dashboards-functional-test/commit/a8ba15a0175cc1684a020cac5712de12c99c68d9)

Description
Backports https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1449 via https://github.com/opensearch-project/opensearch-dashboards-functional-test/commit/a8ba15a0175cc1684a020cac5712de12c99c68d9

Required manual backport because sanitty_test_spec.js file is not present in 2.16 but is changed in main.

- Related to https://github.com/opensearch-project/security-dashboards-plugin/issues/2055

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
