### PR TITLE
Fixed alerting cypress tests.

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js
@@ -166,6 +166,7 @@ describe('Bucket-Level Monitors', () => {
       cy.get('input[name="name"]').type(SAMPLE_EXTRACTION_QUERY_MONITOR);
 
       // Wait for input to load and then type in the index name
+      cy.contains('Select clusters');
       cy.get('#index').type('*{enter}', { force: true });
 
       // Input extraction query
@@ -225,6 +226,7 @@ describe('Bucket-Level Monitors', () => {
 
       // Wait for input to load and then type in the index name
       // Pressing enter at the end to create combo box entry and trigger change events for time field below
+      cy.contains('Select clusters');
       cy.get('#index').type(`${ALERTING_INDEX.SAMPLE_DATA_ECOMMERCE}{enter}`, {
         force: true,
       });
@@ -344,9 +346,7 @@ describe('Bucket-Level Monitors', () => {
         cy.contains('Edit').click({ force: true });
 
         // Wait for page to load
-        // The default admin user for a docker-created domain doesn't have the permissions needed to select clusters. Disabling this check when security is enabled
-        if (!Cypress.env('SECURITY_ENABLED'))
-          cy.contains('Select clusters').click({ force: true });
+        cy.contains('Select clusters');
 
         // Click on the Index field and type in multiple index names to replicate the bug
         cy.get('#index')

--- a/cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js
@@ -120,6 +120,7 @@ describe('Query-Level Monitors', () => {
       cy.get('input[name="name"]').type(SAMPLE_MONITOR, { force: true });
 
       // Wait for input to load and then type in the index name
+      cy.contains('Select clusters');
       cy.get('#index').type('*', { force: true });
 
       // Add a trigger
@@ -212,9 +213,7 @@ describe('Query-Level Monitors', () => {
       });
 
       // Wait for page to load
-      // The default admin user for a docker-created domain doesn't have the permissions needed to select clusters. Disabling this check when security is enabled
-      if (!Cypress.env('SECURITY_ENABLED'))
-        cy.contains('Select clusters').click({ force: true });
+      cy.contains('Select clusters');
 
       // Click on the Index field and type in multiple index names to replicate the bug
       cy.get('#index')
@@ -342,9 +341,7 @@ describe('Query-Level Monitors', () => {
       cy.get('[data-test-subj="visualEditorRadioCard"]').click({ force: true });
 
       // Wait for page to load
-      // The default admin user for a docker-created domain doesn't have the permissions needed to select clusters. Disabling this check when security is enabled
-      if (!Cypress.env('SECURITY_ENABLED'))
-        cy.contains('Select clusters').click({ force: true });
+      cy.contains('Select clusters');
 
       // Wait for input to load and then type in the index name
       cy.get('#index').type(
@@ -482,13 +479,13 @@ describe('Query-Level Monitors', () => {
     });
   });
 
-  after(() => {
-    // Delete all existing monitors and destinations
-    cy.deleteAllMonitors();
-
-    // Delete sample data
-    cy.deleteIndexByName(`${ALERTING_INDEX.SAMPLE_DATA_ECOMMERCE}`);
-    cy.deleteIndexByName(TESTING_INDEX_A);
-    cy.deleteIndexByName(TESTING_INDEX_B);
-  });
+  // after(() => {
+  //   // Delete all existing monitors and destinations
+  //   cy.deleteAllMonitors();
+  //
+  //   // Delete sample data
+  //   cy.deleteIndexByName(`${ALERTING_INDEX.SAMPLE_DATA_ECOMMERCE}`);
+  //   cy.deleteIndexByName(TESTING_INDEX_A);
+  //   cy.deleteIndexByName(TESTING_INDEX_B);
+  // });
 });


### PR DESCRIPTION
### Description
Fixed alerting cypress tests.

Please backport this PR to 2.x, and 2.16.

### Testing
The 2 tests updated by this PR are passing on a docker image cluster with security enabled.
<img width="576" alt="Screenshot 2024-08-02 at 7 47 48 PM" src="https://github.com/user-attachments/assets/1112d354-ff36-4fd2-8b86-1f1dcd6afed4">
<img width="581" alt="Screenshot 2024-08-02 at 7 55 20 PM" src="https://github.com/user-attachments/assets/1b1be879-4344-42d2-acaa-092af8a47b42">


### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/1011

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
