### PR TITLE
select checkbox via id instead of class name

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -170,28 +170,20 @@ describe('Aliases', () => {
         expect(num).to.equal(1);
       });
 
-      cy.get('[data-test-subj="moreAction"]').click();
-      // Flush btn should be disabled if no items selected
-      cy.get('[data-test-subj="Flush Action"]').should(
-        'have.class',
-        'euiContextMenuItem-isDisabled'
-      );
+      cy.get('[data-test-subj="moreAction"] button')
+        .click()
+        .get('[data-test-subj="Flush Action"]')
+        .should('be.disabled')
+        .end();
 
-      // Select an alias
-      cy.get(`[data-test-subj="checkboxSelectRow-${sample_alias}"]`).check({
-        force: true,
-      });
-
-      cy.get('[data-test-subj="moreAction"]').click();
-
-      // Extra wait required for page data to load, otherwise "Enable" button will be disabled
-      cy.wait(2000);
-
-      // Flush btn should be enabled
-      cy.get('[data-test-subj="Flush Action"]')
-        .should('exist')
-        .should('not.have.class', 'euiContextMenuItem-isDisabled')
-        .click();
+      cy.get(`#_selection_column_${sample_alias}-checkbox`)
+        .click()
+        .get('[data-test-subj="moreAction"] button')
+        .click()
+        .get('[data-test-subj="Flush Action"]')
+        .should('not.be.disabled')
+        .click()
+        .end();
 
       // Check for flush index modal
       cy.contains('Flush alias');

--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -142,9 +142,9 @@ describe('Aliases', () => {
 
   describe('can flush an alias', () => {
     it('successfully flush an index', () => {
-      let sample_alias = `${SAMPLE_ALIAS_PREFIX}-${1}`;
+      let sample_alias = `${SAMPLE_ALIAS_PREFIX}-1`;
       // Sort all aliases in asc order to make it at first page
-      cy.contains('Alias name').click();
+      cy.get('[placeholder="Search..."]').type(`${sample_alias}{enter}`);
       // Confirm we have our initial alias
       cy.contains(sample_alias);
       // index a test doc


### PR DESCRIPTION
### Description

There is flaky test where checkbox is not getting selected in windows run.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
