### PR TITLE
[Backport 2.16] Fix channel tests (#1507)

### DIFF
--- a/cypress/fixtures/plugins/notifications-dashboards/test_chime_channel.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_chime_channel.json
@@ -5,7 +5,7 @@
     "config_type": "chime",
     "is_enabled": true,
     "chime": {
-      "url": "https://sample-chime-webhook"
+      "url": "https://hooks.chime.aws/incomingwebhooks/sample_chime_url?token=123456"
     }
   }
 }

--- a/cypress/fixtures/plugins/notifications-dashboards/test_slack_channel.json
+++ b/cypress/fixtures/plugins/notifications-dashboards/test_slack_channel.json
@@ -5,7 +5,7 @@
     "config_type": "slack",
     "is_enabled": true,
     "slack": {
-      "url": "https://sample-slack-webhook"
+      "url": "https://hooks.slack.com/services/A123456/B1234567/A1B2C3D4E5F6G7H8I9J0K1L2"
     }
   }
 }

--- a/cypress/integration/plugins/notifications-dashboards/2_channels.spec.js
+++ b/cypress/integration/plugins/notifications-dashboards/2_channels.spec.js
@@ -37,7 +37,7 @@ describe('Test create channels', () => {
 
     cy.get('[placeholder="Enter channel name"]').type('Test slack channel');
     cy.get('[data-test-subj="create-channel-slack-webhook-input"]').type(
-      'https://sample-slack-webhook'
+      'https://hooks.slack.com/services/A123456/B1234567/A1B2C3D4E5F6G7H8I9J0K1L2'
     );
     cy.wait(NOTIFICATIONS_DELAY);
     cy.get('[data-test-subj="create-channel-send-test-message-button"]').click({
@@ -46,10 +46,12 @@ describe('Test create channels', () => {
     cy.wait(NOTIFICATIONS_DELAY);
     // This needs some time to appear as it will wait for backend call to timeout
     cy.contains('test message.').should('exist');
+    cy.wait(NOTIFICATIONS_DELAY);
 
     cy.get('[data-test-subj="create-channel-create-button"]').click({
       force: true,
     });
+    cy.wait(NOTIFICATIONS_DELAY);
     cy.contains('successfully created.').should('exist');
   });
 
@@ -64,13 +66,14 @@ describe('Test create channels', () => {
     cy.wait(NOTIFICATIONS_DELAY);
 
     cy.get('[data-test-subj="create-channel-chime-webhook-input"]').type(
-      'https://sample-chime-webhook'
+      'https://hooks.chime.aws/incomingwebhooks/sample_chime_url?token=123456'
     );
     cy.wait(NOTIFICATIONS_DELAY);
 
     cy.get('[data-test-subj="create-channel-create-button"]').click({
       force: true,
     });
+    cy.wait(NOTIFICATIONS_DELAY);
     cy.contains('successfully created.').should('exist');
   });
 


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1507

* add ; to tests

Signed-off-by: Riya Saxena <riysaxen@amazon.com>

* fix channel tests in notifications

Signed-off-by: Riya Saxena <riysaxen@amazon.com>

* fix channel tests in notifications

Signed-off-by: Riya Saxena <riysaxen@amazon.com>

---------

Signed-off-by: Riya Saxena <riysaxen@amazon.com>
(cherry picked from commit 09bf9ce4d661b3f287a3d6454da89be2fafeaf6e)

### Description

[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
