### PR TITLE
Rollup and Transform flaky test fix

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/rollups_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/rollups_spec.js
@@ -210,42 +210,6 @@ describe('Rollups', () => {
     });
   });
 
-  describe('can be deleted', () => {
-    before(() => {
-      cy.deleteAllIndices();
-      cy.deleteIMJobs();
-      cy.createRollup(ROLLUP_ID, sampleRollup);
-    });
-
-    it('successfully', () => {
-      // Confirm we have our initial rollup
-      cy.contains(ROLLUP_ID);
-
-      // Select checkbox for our rollup job
-      cy.get(`#_selection_column_${ROLLUP_ID}-checkbox`).check({ force: true });
-
-      // Click on Actions popover menu
-      cy.get(`[data-test-subj="actionButton"]`).click({ force: true });
-
-      // Click Delete button
-      cy.get(`[data-test-subj="deleteButton"]`).click({ force: true });
-
-      // Type "delete" to confirm deletion
-      cy.get(`input[placeholder="delete"]`).type('delete', { force: true });
-
-      // Click the delete confirmation button in modal
-      cy.get(`[data-test-subj="confirmModalConfirmButton"]`).click();
-
-      // Confirm we got deleted toaster
-      cy.contains(`"${ROLLUP_ID}" successfully deleted!`);
-
-      // Confirm showing empty loading state
-      cy.contains(
-        'Rollup jobs help you conserve storage space for historical time series data while preserving the specific information you need'
-      );
-    });
-  });
-
   describe('can be enabled and disabled', () => {
     before(() => {
       cy.deleteAllIndices();
@@ -291,6 +255,42 @@ describe('Rollups', () => {
 
       // Confirm we get toaster saying rollup job is enabled
       cy.contains(`${ROLLUP_ID} is enabled`);
+    });
+  });
+
+  describe('can be deleted', () => {
+    before(() => {
+      cy.deleteAllIndices();
+      cy.deleteIMJobs();
+      cy.createRollup(ROLLUP_ID, sampleRollup);
+    });
+
+    it('successfully', () => {
+      // Confirm we have our initial rollup
+      cy.contains(ROLLUP_ID);
+
+      // Select checkbox for our rollup job
+      cy.get(`#_selection_column_${ROLLUP_ID}-checkbox`).check({ force: true });
+
+      // Click on Actions popover menu
+      cy.get(`[data-test-subj="actionButton"]`).click({ force: true });
+
+      // Click Delete button
+      cy.get(`[data-test-subj="deleteButton"]`).click({ force: true });
+
+      // Type "delete" to confirm deletion
+      cy.get(`input[placeholder="delete"]`).type('delete', { force: true });
+
+      // Click the delete confirmation button in modal
+      cy.get(`[data-test-subj="confirmModalConfirmButton"]`).click();
+
+      // Confirm we got deleted toaster
+      cy.contains(`"${ROLLUP_ID}" successfully deleted!`);
+
+      // Confirm showing empty loading state
+      cy.contains(
+        'Rollup jobs help you conserve storage space for historical time series data while preserving the specific information you need'
+      );
     });
   });
 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/transforms_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/transforms_spec.js
@@ -188,50 +188,6 @@ describe('Transforms', () => {
     });
   });
 
-  describe('can be deleted', () => {
-    beforeEach(() => {
-      cy.createTransform(TRANSFORM_ID, sampleTransform);
-      cy.reload();
-    });
-
-    it('successfully', () => {
-      // Confirm we have our initial transform
-      cy.contains(TRANSFORM_ID);
-
-      // Disable transform
-      cy.get(`#_selection_column_${TRANSFORM_ID}-checkbox`).check({
-        force: true,
-      });
-      cy.get(`[data-test-subj="disableButton"]`).click({ force: true });
-      cy.contains(`"${TRANSFORM_ID}" is disabled`);
-
-      // Select checkbox for our transform job
-      cy.get(`#_selection_column_${TRANSFORM_ID}-checkbox`).check({
-        force: true,
-      });
-
-      // Click on Actions popover menu
-      cy.get(`[data-test-subj="actionButton"]`).click({ force: true });
-
-      // Click Delete button
-      cy.get(`[data-test-subj="deleteButton"]`).click({ force: true });
-
-      // Type "delete" to confirm deletion
-      cy.get(`input[placeholder="delete"]`).type('delete', { force: true });
-
-      // Click the delete confirmation button in modal
-      cy.get(`[data-test-subj="confirmModalConfirmButton"]`).click();
-
-      // Confirm we got deleted toaster
-      cy.contains(`"${TRANSFORM_ID}" successfully deleted`);
-
-      // Confirm showing empty loading state
-      cy.contains(
-        'Transform jobs help you create a materialized view on top of existing data.'
-      );
-    });
-  });
-
   describe('can be enabled and disabled', () => {
     beforeEach(() => {
       cy.createTransform(TRANSFORM_ID, sampleTransform);
@@ -288,6 +244,50 @@ describe('Transforms', () => {
 
       // Confirm we get toaster saying transform job is enabled
       cy.contains(`"${TRANSFORM_ID}" is enabled`);
+    });
+  });
+
+  describe('can be deleted', () => {
+    beforeEach(() => {
+      cy.createTransform(TRANSFORM_ID, sampleTransform);
+      cy.reload();
+    });
+
+    it('successfully', () => {
+      // Confirm we have our initial transform
+      cy.contains(TRANSFORM_ID);
+
+      // Disable transform
+      cy.get(`#_selection_column_${TRANSFORM_ID}-checkbox`).check({
+        force: true,
+      });
+      cy.get(`[data-test-subj="disableButton"]`).click({ force: true });
+      cy.contains(`"${TRANSFORM_ID}" is disabled`);
+
+      // Select checkbox for our transform job
+      cy.get(`#_selection_column_${TRANSFORM_ID}-checkbox`).check({
+        force: true,
+      });
+
+      // Click on Actions popover menu
+      cy.get(`[data-test-subj="actionButton"]`).click({ force: true });
+
+      // Click Delete button
+      cy.get(`[data-test-subj="deleteButton"]`).click({ force: true });
+
+      // Type "delete" to confirm deletion
+      cy.get(`input[placeholder="delete"]`).type('delete', { force: true });
+
+      // Click the delete confirmation button in modal
+      cy.get(`[data-test-subj="confirmModalConfirmButton"]`).click();
+
+      // Confirm we got deleted toaster
+      cy.contains(`"${TRANSFORM_ID}" successfully deleted`);
+
+      // Confirm showing empty loading state
+      cy.contains(
+        'Transform jobs help you create a materialized view on top of existing data.'
+      );
     });
   });
 });


### PR DESCRIPTION
### Description

Reordering tests in rollups and transform as checking enable/disbale feature after deleting transform/rollup creates flakiness.

### Issues Resolved

https://github.com/opensearch-project/index-management-dashboards-plugin/issues/1095

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
