### PR TITLE
Fix panel test not respecting base path setting

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
@@ -30,7 +30,7 @@ describe('Testing panels table', () => {
     cy.get('input.euiFieldText').focus().type(TEST_PANEL, {
       delay: 50,
     });
-    cy.intercept('POST', '/api/saved_objects/*').as('createDashboard');
+    cy.intercept('POST', `${BASE_PATH}/api/saved_objects/*`).as('createDashboard');
     cy.get('.euiButton__text')
       .contains(/^Create$/)
       .trigger('mouseover')

--- a/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
@@ -30,7 +30,9 @@ describe('Testing panels table', () => {
     cy.get('input.euiFieldText').focus().type(TEST_PANEL, {
       delay: 50,
     });
-    cy.intercept('POST', `${BASE_PATH}/api/saved_objects/*`).as('createDashboard');
+    cy.intercept('POST', `${BASE_PATH}/api/saved_objects/*`).as(
+      'createDashboard'
+    );
     cy.get('.euiButton__text')
       .contains(/^Create$/)
       .trigger('mouseover')


### PR DESCRIPTION
### Description

The test fails if a base path is set, which doesn't show up as a problem in GH CI but does in other CI pipelines. Will need backport to 2.x for 2.17.

### Issues Resolved

N/A

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
