### PR TITLE
Fix Cypress Test Flakiness by Executing cy.visit Before cy.request

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_detector_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_detector_spec.js
@@ -15,6 +15,7 @@ context('Create detector workflow', () => {
 
   // Index some sample data first
   beforeEach(() => {
+    cy.visit(AD_URL.OVERVIEW, { timeout: 10000 });
     cy.deleteAllIndices();
     cy.deleteADSystemIndices();
     cy.fixture(AD_FIXTURE_BASE_PATH + 'sample_test_data.txt').then((data) => {

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/detector_configuration_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/detector_configuration_spec.js
@@ -9,6 +9,7 @@ context('Detector configuration page', () => {
   // Creating a sample detector and visiting the config page. Stopping the detector
   // for easier checks when editing detector
   before(() => {
+    cy.visit(AD_URL.OVERVIEW, { timeout: 10000 });
     cy.deleteAllIndices();
     cy.deleteADSystemIndices();
     cy.visit(AD_URL.OVERVIEW);

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/historical_analysis_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/historical_analysis_spec.js
@@ -52,10 +52,12 @@ describe('Historical results page', () => {
 
   // Creating a sample detector and visiting the config page
   before(() => {
+    cy.visit(AD_URL.OVERVIEW, { timeout: 10000 });
     cy.deleteAllIndices();
     cy.deleteADSystemIndices();
     cy.wait(5000);
-    cy.visit(AD_URL.OVERVIEW);
+    cy.visit(AD_URL.OVERVIEW, { timeout: 10000 });
+    cy.wait(2000);
     cy.get('[data-test-subj=createHttpSampleDetectorButton]').then(() => {
       cy.getElementByTestId('createHttpSampleDetectorButton').click();
       cy.wait(10000);

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/overview_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/overview_spec.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AD_URL } from '../../../utils/constants';
+import { AD_URL } from '../../../utils/plugins/anomaly-detection-dashboards-plugin/constants';
 
 context('Overview page', () => {
   function validatePageElements() {

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/sample_detector_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/sample_detector_spec.js
@@ -4,8 +4,12 @@
  */
 
 import { createSampleDetector } from '../../../utils/helpers';
+import { AD_URL } from '../../../utils/plugins/anomaly-detection-dashboards-plugin/constants';
 
 context('Sample detectors', () => {
+  before(() => {
+    cy.visit(AD_URL.OVERVIEW, { timeout: 10000 });
+  });
   beforeEach(() => {
     cy.deleteAllIndices();
     cy.deleteADSystemIndices();

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/vis_augmenter/associate_detector_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/vis_augmenter/associate_detector_spec.js
@@ -20,6 +20,7 @@ import {
   INDEX_SETTINGS_FILEPATH_SIMPLE,
   SAMPLE_DATA_FILEPATH_SIMPLE,
 } from '../../../../utils/constants';
+import { AD_URL } from '../../../../utils/plugins/anomaly-detection-dashboards-plugin/constants';
 
 describe('Anomaly detection integration with vis augmenter', () => {
   const indexName = 'ad-vis-augmenter-sample-index';
@@ -51,6 +52,7 @@ describe('Anomaly detection integration with vis augmenter', () => {
       dashboardName,
       [visualizationSpec]
     );
+    cy.visit(AD_URL.OVERVIEW, { timeout: 10000 });
   });
 
   after(() => {

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/vis_augmenter/augment_vis_saved_object_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/vis_augmenter/augment_vis_saved_object_spec.js
@@ -18,6 +18,7 @@ import {
   INDEX_SETTINGS_FILEPATH_SIMPLE,
   SAMPLE_DATA_FILEPATH_SIMPLE,
 } from '../../../../utils/constants';
+import { AD_URL } from '../../../../utils/plugins/anomaly-detection-dashboards-plugin/constants';
 
 describe('AD augment-vis saved objects', () => {
   const commonUI = new CommonUI(cy);
@@ -50,6 +51,7 @@ describe('AD augment-vis saved objects', () => {
       dashboardName,
       [visualizationSpec]
     );
+    cy.visit(AD_URL.OVERVIEW, { timeout: 10000 });
   });
 
   after(() => {

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/vis_augmenter/view_anomaly_events_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/vis_augmenter/view_anomaly_events_spec.js
@@ -17,6 +17,7 @@ import {
   INDEX_SETTINGS_FILEPATH_SIMPLE,
   SAMPLE_DATA_FILEPATH_SIMPLE,
 } from '../../../../utils/constants';
+import { AD_URL } from '../../../../utils/plugins/anomaly-detection-dashboards-plugin/constants';
 
 describe('View anomaly events in flyout', () => {
   const indexName = 'ad-vis-augmenter-sample-index';
@@ -48,6 +49,7 @@ describe('View anomaly events in flyout', () => {
       dashboardName,
       [visualizationSpec]
     );
+    cy.visit(AD_URL.OVERVIEW, { timeout: 10000 });
   });
 
   after(() => {


### PR DESCRIPTION
### Description
This PR addresses intermittent failures in the AD Cypress tests related to a known issue in Cypress (https://github.com/cypress-io/cypress/issues/25397). The specific failure observed was:

```
Sample detector
"before all" hook for "Empty message with modal":
AssertionError: Timed out retrying after 60000ms: Expected to find element: `[data-test-subj="viewSampleDetectorLink"]`, but never found it.
```

To mitigate this issue, we applied a workaround suggested in the GitHub issue, ensuring that cy.visit is executed before cy.request. This change helps stabilize the tests by properly loading AD overview page  before making any API requests.

Testing:
* Ran all Cypress tests with the modified code to verify the fix.

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
