### PR TITLE
[2.17][Security analytics] Bypass element overlap when typing

### DIFF
--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/2_rules.spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/2_rules.spec.js
@@ -494,24 +494,30 @@ describe('Rules', () => {
 
       // selection name field
       getSelectionPanelByIndex(0).within(() =>
-        getSelectionNameField().type('{selectall}').type('{backspace}')
+        getSelectionNameField()
+          .type('{selectall}', { force: true })
+          .type('{backspace}', { force: true })
       );
       toastShouldExist();
       getSelectionPanelByIndex(0).within(() =>
-        getSelectionNameField().type('Selection_1')
+        getSelectionNameField().type('Selection_1', { force: true })
       );
 
       // selection map key field
       getSelectionPanelByIndex(0).within(() =>
-        getMapKeyField().type('{selectall}').type('{backspace}')
+        getMapKeyField()
+          .type('{selectall}', { force: true })
+          .type('{backspace}', { force: true })
       );
       getSelectionPanelByIndex(0).within(() =>
-        getMapKeyField().type('FieldKey')
+        getMapKeyField().type('FieldKey', { force: true })
       );
 
       // selection map value field
       getSelectionPanelByIndex(0).within(() =>
-        getMapValueField().type('{selectall}').type('{backspace}')
+        getMapValueField()
+          .type('{selectall}', { force: true })
+          .type('{backspace}', { force: true })
       );
       toastShouldExist();
 


### PR DESCRIPTION
### Description
Fixes issue with Rules spec in Security Analytics

### Issues Resolved
https://github.com/opensearch-project/security-analytics-dashboards-plugin/issues/1122

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
