### PR TITLE
fixes observability dashboards tests

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/0_before.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/0_before.spec.js
@@ -15,8 +15,6 @@ describe('Before', () => {
 
     cy.visit(`${BASE_PATH}/app/home#/tutorial_directory/sampleData`);
 
-    // Click on "Sample data" tab
-    cy.contains('Sample data').click({ force: true });
     // Load sample flights data
     cy.get(`button[data-test-subj="addSampleDataSetflights"]`).click({
       force: true,

--- a/cypress/integration/plugins/observability-dashboards/1_trace_analytics_dashboard.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/1_trace_analytics_dashboard.spec.js
@@ -59,7 +59,7 @@ describe('Testing dashboard table', () => {
     cy.contains('Latency percentile within trace group: < 95th').should(
       'exist'
     );
-    cy.contains(' (8)').should('exist');
+    cy.contains(' (7)').should('exist');
     cy.contains('383.05').should('exist');
   });
 
@@ -89,11 +89,11 @@ describe('Testing dashboard table', () => {
     );
 
     cy.get('[data-test-subj="dashboard-table-traces-button"]')
-      .contains('13')
+      .contains('6')
       .click();
     cy.wait(delayTime);
 
-    cy.contains(' (13)').should('exist');
+    cy.contains(' (9)').should('exist');
     cy.contains('client_create_order').should('exist');
 
     cy.get('.euiSideNavItemButton__label').contains('Trace analytics').click();
@@ -122,10 +122,10 @@ describe('Testing plots', () => {
 
   it('Renders plots', () => {
     cy.get('text.ytitle[data-unformatted="Error rate (%)"]').should('exist');
-    cy.get('text.annotation-text[data-unformatted="Now: 14.81%"]').should(
+    cy.get('text.annotation-text[data-unformatted="Now: 26.83%"]').should(
       'exist'
     );
     cy.get('text.ytitle[data-unformatted="Throughput (n)"]').should('exist');
-    cy.get('text.annotation-text[data-unformatted="Now: 108"]').should('exist');
+    cy.get('text.annotation-text[data-unformatted="Now: 41"]').should('exist');
   });
 });

--- a/cypress/integration/plugins/observability-dashboards/1_trace_analytics_dashboard.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/1_trace_analytics_dashboard.spec.js
@@ -59,7 +59,7 @@ describe('Testing dashboard table', () => {
     cy.contains('Latency percentile within trace group: < 95th').should(
       'exist'
     );
-    cy.contains(' (7)').should('exist');
+    cy.contains(' (8)').should('exist');
     cy.contains('383.05').should('exist');
   });
 
@@ -89,11 +89,11 @@ describe('Testing dashboard table', () => {
     );
 
     cy.get('[data-test-subj="dashboard-table-traces-button"]')
-      .contains('6')
+      .contains('13')
       .click();
     cy.wait(delayTime);
 
-    cy.contains(' (9)').should('exist');
+    cy.contains(' (13)').should('exist');
     cy.contains('client_create_order').should('exist');
 
     cy.get('.euiSideNavItemButton__label').contains('Trace analytics').click();
@@ -122,10 +122,10 @@ describe('Testing plots', () => {
 
   it('Renders plots', () => {
     cy.get('text.ytitle[data-unformatted="Error rate (%)"]').should('exist');
-    cy.get('text.annotation-text[data-unformatted="Now: 26.83%"]').should(
+    cy.get('text.annotation-text[data-unformatted="Now: 14.81%"]').should(
       'exist'
     );
     cy.get('text.ytitle[data-unformatted="Throughput (n)"]').should('exist');
-    cy.get('text.annotation-text[data-unformatted="Now: 41"]').should('exist');
+    cy.get('text.annotation-text[data-unformatted="Now: 108"]').should('exist');
   });
 });

--- a/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
@@ -26,7 +26,7 @@ describe('Testing services table', () => {
       .first()
       .focus()
       .type(`${SERVICE_NAME}{enter}`);
-    cy.get('.euiButton__text').contains('Refresh').click();
+    cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click();
     cy.contains(' (1)').should('exist');
   });
 

--- a/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
@@ -18,14 +18,25 @@ describe('Testing traces table', () => {
   });
 
   it('Sorts the traces table', () => {
-    cy.get('.euiTableRow').first().contains('-').should('exist');
+    cy.get(
+      '[data-test-subj="trace-groups-service-operation-accordian"]'
+    ).click();
+
+    cy.get('[data-test-subj="dashboard-table-trace-group-name-button"]').should(
+      'be.visible'
+    );
+
+    cy.get('.euiTableRow')
+      .first()
+      .contains('client_create_order')
+      .should('exist');
     cy.get('.euiTableCellContent').contains('Trace group').click();
     cy.get('.euiTableRow').first().contains('/**').should('exist');
   });
 
   it('Searches correctly', () => {
     cy.get('input[type="search"]').focus().type(`${TRACE_ID}{enter}`);
-    cy.get('.euiButton__text').contains('Refresh').click();
+    cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click();
     cy.contains(' (1)').should('exist');
     cy.contains('03/25/2021 10:21:22').should('exist');
   });

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -34,7 +34,7 @@ const makeTestNotebook = () => {
 
   cy.contains(`Notebook "${notebookName}" successfully created`);
 
-  cy.get('h1[data-test-subj="notebookTitle"]')
+  cy.get('h3[data-test-subj="notebookTitle"]')
     .contains(notebookName)
     .should('exist');
 

--- a/cypress/utils/plugins/observability-dashboards/constants.js
+++ b/cypress/utils/plugins/observability-dashboards/constants.js
@@ -80,7 +80,9 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
       timeout: TIMEOUT_DELAY,
     }).type('{selectall}' + endTime, { force: true });
   }
-  if (refresh) cy.get('.euiButton__text').contains('Refresh').click();
+  if (refresh) {
+    cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click();
+  }
   cy.wait(delayTime);
 };
 


### PR DESCRIPTION
### Description

Fixes tests using the timepicker previously using the string 'Refresh' to now use the updated data-test-subj attribute since that string is not guaranteed to be there.
Fixes notebooks tests using the old header value to grab the specified notebook
Fixes traces tests 1,2,3 - adjusting for changed sample trace data.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
