### PR TITLE
fixes observability dashboards tests

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
@@ -26,7 +26,7 @@ describe('Testing services table', () => {
       .first()
       .focus()
       .type(`${SERVICE_NAME}{enter}`);
-    cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click();
+    cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
     cy.contains(' (1)').should('exist');
   });
 

--- a/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
@@ -26,7 +26,7 @@ describe('Testing services table', () => {
       .first()
       .focus()
       .type(`${SERVICE_NAME}{enter}`);
-    cy.get('.euiButton__text').contains('Refresh').click();
+    cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click();
     cy.contains(' (1)').should('exist');
   });
 

--- a/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
@@ -35,7 +35,8 @@ describe('Testing traces table', () => {
       .eq(11)
       .invoke('text')
       .then((text) => {
-        expect(dayjs(text, 'MM/DD/YYYY HH:mm:ss', true).isValid()).to.be.true;
+        expect(dayjs(text, 'MM/DD/YYYY HH:mm:ss.SSS', true).isValid()).to.be
+          .true;
       });
   });
 });

--- a/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
@@ -29,7 +29,7 @@ describe('Testing traces table', () => {
 
   it('Searches correctly', () => {
     cy.get('input[type="search"]').focus().type(`${TRACE_ID}{enter}`);
-    cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click();
+    cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
     cy.contains(' (1)').should('exist');
     cy.get('.euiTableCellContent')
       .eq(11)

--- a/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
@@ -29,7 +29,7 @@ describe('Testing traces table', () => {
 
   it('Searches correctly', () => {
     cy.get('input[type="search"]').focus().type(`${TRACE_ID}{enter}`);
-    cy.get('.euiButton__text').contains('Refresh').click();
+    cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click();
     cy.contains(' (1)').should('exist');
     cy.get('.euiTableCellContent')
       .eq(11)

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -34,7 +34,7 @@ const makeTestNotebook = () => {
 
   cy.contains(`Notebook "${notebookName}" successfully created`);
 
-  cy.get('h1[data-test-subj="notebookTitle"]')
+  cy.get('h3[data-test-subj="notebookTitle"]')
     .contains(notebookName)
     .should('exist');
 

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -34,7 +34,7 @@ const makeTestNotebook = () => {
 
   cy.contains(`Notebook "${notebookName}" successfully created`);
 
-  cy.get('h3[data-test-subj="notebookTitle"]')
+  cy.get('[data-test-subj="notebookTitle"]')
     .contains(notebookName)
     .should('exist');
 

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -61,8 +61,7 @@ const deleteNotebook = (notebookName) => {
     .find('input[type="checkbox"]')
     .check();
 
-  cy.get('button[data-test-subj="notebookTableActionBtn"]').click();
-  cy.get('button[data-test-subj="deleteNotebookBtn"]').click();
+  cy.get('[data-test-subj="deleteSelectedNotebooks"]').click();
 
   cy.get('input[data-test-subj="delete-notebook-modal-input"]').focus();
   cy.get('input[data-test-subj="delete-notebook-modal-input"]').type('delete');

--- a/cypress/utils/plugins/observability-dashboards/constants.js
+++ b/cypress/utils/plugins/observability-dashboards/constants.js
@@ -81,7 +81,7 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
     }).type('{selectall}' + endTime, { force: true });
   }
   if (refresh) {
-    cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click();
+    cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
   }
   cy.wait(delayTime);
 };

--- a/cypress/utils/plugins/observability-dashboards/constants.js
+++ b/cypress/utils/plugins/observability-dashboards/constants.js
@@ -80,7 +80,9 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
       timeout: TIMEOUT_DELAY,
     }).type('{selectall}' + endTime, { force: true });
   }
-  if (refresh) cy.get('.euiButton__text').contains('Refresh').click();
+  if (refresh) {
+    cy.get('button[data-test-subj="superDatePickerApplyTimeButton"]').click();
+  }
   cy.wait(delayTime);
 };
 


### PR DESCRIPTION
### Description

Fixes tests using the timepicker previously using the string 'Refresh' to now use the updated data-test-subj attribute since that string is not guaranteed to be there.
Fixes notebooks tests using the old header value to grab the specified notebook

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
