### PR TITLE
Fix reports dashboards test

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -50,7 +50,9 @@ describe('Cypress', () => {
     cy.wait('@notebook');
 
     // update the report name
-    cy.get('#reportSettingsName').type('{selectall}{backspace} update name');
+    cy.get('#reportSettingsName')
+      .click({ force: true })
+      .type('{selectall}{backspace} update name');
 
     // update report description
     cy.get('#reportSettingsDescription').type(


### PR DESCRIPTION
### Description

Fixes reporting dashboards test where an input element is covered by another element, the test was modified to force click on that element.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
