### PR TITLE
Add tests for query and filter syncing in discover

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
@@ -63,6 +63,32 @@ describe('discover app', { scrollBehavior: false }, () => {
 
   after(() => {});
 
+  describe('filters and queries', () => {
+    after(() => {
+      cy.get('[data-test-subj~="filter-key-extension.raw"]').click();
+      cy.getElementByTestId(`deleteFilter`).click();
+      cy.switchDiscoverTable('legacy');
+    });
+    it('should persist across refresh', function () {
+      // Set up query and filter
+      cy.setTopNavQuery('response:200');
+      cy.submitFilterFromDropDown('extension.raw', 'is one of', 'jpg');
+      cy.reload();
+      cy.getElementByTestId(`queryInput`).should('have.text', 'response:200');
+      cy.get('[data-test-subj~="filter-key-extension.raw"]').should(
+        'be.visible'
+      );
+    });
+
+    it('should persist across switching table', function () {
+      cy.switchDiscoverTable('new');
+      cy.getElementByTestId(`queryInput`).should('have.text', 'response:200');
+      cy.get('[data-test-subj~="filter-key-extension.raw"]').should(
+        'be.visible'
+      );
+    });
+  });
+
   describe('save search', () => {
     const saveSearch1 = 'Save Search # 1';
     const saveSearch2 = 'Modified Save Search # 1';


### PR DESCRIPTION
### Description

Follow up PR of https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8168 to add test to make sure queries and filters are persisted across refresh, and switching between new and legacy tables.


### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
