### PR TITLE
[Maps plugin] Skip new home UI test if disabled in OSD

### DIFF
--- a/cypress/integration/plugins/custom-import-map-dashboards/7_enable_new_home_ui.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/7_enable_new_home_ui.spec.js
@@ -9,19 +9,22 @@ import { CURRENT_TENANT } from '../../../utils/commands';
 
 const miscUtils = new MiscUtils(cy);
 
-describe('Add flights dataset saved object', () => {
-  before(() => {
+describe('Add flights dataset saved object', function () {
+  before(function () {
     CURRENT_TENANT.newTenant = 'global';
     cy.deleteAllIndices();
     miscUtils.addSampleData();
     cy.wait(10000);
 
-    // Enable the new home UI
+    // Enable the new home UI if possible
     cy.visit(`${BASE_PATH}/app/settings`);
     cy.get(
       '[data-test-subj="advancedSetting-editField-home:useNewHomePage"]'
     ).then(($switch) => {
-      if ($switch.attr('aria-checked') === 'false') {
+      if ($switch.attr('disabled') === 'disabled') {
+        cy.log('Switch is disabled and cannot be changed.');
+        this.skip(); // Skip all tests in this suite
+      } else if ($switch.attr('aria-checked') === 'false') {
         cy.wrap($switch).click();
         cy.get('[data-test-subj="advancedSetting-saveButton"]').click();
         cy.get('button.euiButton--primary.euiButton--small', {
@@ -35,12 +38,14 @@ describe('Add flights dataset saved object', () => {
 
   after(() => {
     miscUtils.removeSampleData();
-    // Disable the new home UI
+    // Disable the new home UI if possible
     cy.visit(`${BASE_PATH}/app/settings`);
     cy.get(
       '[data-test-subj="advancedSetting-editField-home:useNewHomePage"]'
     ).then(($switch) => {
-      if ($switch.attr('aria-checked') === 'true') {
+      if ($switch.attr('disabled') === 'disabled') {
+        cy.log('Switch is disabled and cannot be changed.');
+      } else if ($switch.attr('aria-checked') === 'true') {
         cy.wrap($switch).click();
         cy.get('[data-test-subj="advancedSetting-saveButton"]').click();
         cy.get('button.euiButton--primary.euiButton--small', {


### PR DESCRIPTION
### Description
Skip new home UI test if disabled in OSD


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
