### PR TITLE
Security analytics cypress test fixes.

### DIFF
--- a/cypress/fixtures/plugins/security-analytics-dashboards-plugin/integration_tests/rule/create_dns_rule_with_type_selection.json
+++ b/cypress/fixtures/plugins/security-analytics-dashboards-plugin/integration_tests/rule/create_dns_rule_with_type_selection.json
@@ -1,5 +1,5 @@
 {
-  "id": "25b9c01c-350d-4b95-bed1-836d04a4f325",
+  "id": "25b9c01c-350d-4b95-bed1-836d04a4f324",
   "category": "dns",
   "title": "Cypress DNS Type Rule",
   "description": "Detects DNS type as QWE",

--- a/cypress/utils/plugins/security-analytics-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/security-analytics-dashboards-plugin/commands.js
@@ -198,6 +198,9 @@ Cypress.Commands.add(
     Cypress.log({ message: `Select combobox items: ${items.join(' | ')}` });
     items.map((item) => {
       cy.wrap(subject).type(item);
+
+      // Short wait to reduce flakiness
+      cy.wait(3000);
       cy.get(`[title="${item}"]`).click({ force: true });
     });
   }


### PR DESCRIPTION
### Description
1. Added short wait to help reduce flakiness.
2. Gave rule unique ID.

Please backport this PR back to v2.17.

### Testing
The affected test class passes locally on a 2.17.1 security-enabled domain.
![Screenshot 2024-10-17 at 4 22 55 PM](https://github.com/user-attachments/assets/e58e8c7e-e2b2-4397-9464-29ece5b2f5b2)

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
