### PR TITLE
Clean query to make the test more robust

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
@@ -86,6 +86,7 @@ describe('discover app', { scrollBehavior: false }, () => {
       cy.get('[data-test-subj~="filter-key-extension.raw"]').should(
         'be.visible'
       );
+      cy.clearTopNavQuery();
     });
   });
 

--- a/cypress/utils/dashboards/commands.js
+++ b/cypress/utils/dashboards/commands.js
@@ -41,6 +41,22 @@ Cypress.Commands.add('setTopNavQuery', (value, submit = true) => {
   }
 });
 
+Cypress.Commands.add('clearTopNavQuery', (submit = true) => {
+  const opts = { log: false };
+
+  Cypress.log({
+    name: 'clearTopNavQuery',
+    displayName: 'clear query',
+    message: 'clearing query field',
+  });
+
+  cy.getElementByTestId('queryInput', opts).clear(opts).blur(opts);
+
+  if (submit) {
+    cy.updateTopNav(opts);
+  }
+});
+
 Cypress.Commands.add('setTopNavDate', (start, end, submit = true) => {
   const opts = { log: false };
 


### PR DESCRIPTION
### Description

Observe the following issue sometimes in OSD CI.
![image (3)](https://github.com/user-attachments/assets/58f3c1de-24af-48b3-96ca-b903bed72295)

The bug is due to the query from a previous test response:200 is not cleaned out
```
it('should persist across refresh', function () {
      // Set up query and filter
      cy.setTopNavQuery('response:200');
      cy.submitFilterFromDropDown('extension.raw', 'is one of', 'jpg');
      cy.reload();
      cy.getElementByTestId(`queryInput`).should('have.text', 'response:200');
      cy.get('[data-test-subj~="filter-key-extension.raw"]').should(
        'be.visible'
      );
    });
```

Therefore we add a function to manual clean out the query to make the test more robust.

<img width="1766" alt="Screenshot 2024-10-23 at 12 20 06 PM" src="https://github.com/user-attachments/assets/f525742a-b51e-4496-9c91-5657b286ef91">


### Issues Resolved

NA

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
