### PR TITLE
[Observability:Notebooks] Update notebook test

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -34,7 +34,7 @@ const makeTestNotebook = () => {
 
   cy.contains(`Notebook "${notebookName}" successfully created`);
 
-  cy.get('h1[data-test-subj="notebookTitle"]')
+  cy.get('[data-test-subj="notebookTitle"]')
     .contains(notebookName)
     .should('exist');
 
@@ -61,8 +61,7 @@ const deleteNotebook = (notebookName) => {
     .find('input[type="checkbox"]')
     .check();
 
-  cy.get('button[data-test-subj="notebookTableActionBtn"]').click();
-  cy.get('button[data-test-subj="deleteNotebookBtn"]').click();
+  cy.get('button[data-test-subj="deleteSelectedNotebooks"]').click();
 
   cy.get('input[data-test-subj="delete-notebook-modal-input"]').focus();
   cy.get('input[data-test-subj="delete-notebook-modal-input"]').type('delete');


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1606 

Updated notebooks cypress tests due to fit and finish changes.
<img width="1284" alt="Screenshot 2024-10-28 at 12 09 40 PM" src="https://github.com/user-attachments/assets/bd294903-0642-4be5-8f54-f7705ca7cfbe">

[Describe what this change achieves]

### Issues Resolved

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
