### PR TITLE
Fix meta data missing in no auth data source saved object

### DIFF
--- a/.github/workflows/ml-commons-release-e2e-workflow.yml
+++ b/.github/workflows/ml-commons-release-e2e-workflow.yml
@@ -14,6 +14,7 @@ jobs:
           filters: |
             tests:
               - 'cypress/**/ml-commons-dashboards/**'
+              - 'cypress/utils/dashboards/datasource-management-dashboards-plugin/commands.js'
 
   tests:
     needs: changes


### PR DESCRIPTION
### Description

[Describe what this change achieves]
This PR is for fixing meta data missing in no auth data source saved object. The ml-commons has implemented the version decoupling for data source. The data source won't be displayed if data source meta data (installed plugins, version, engine type) was missed.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
