### PR TITLE
make modifyColumnsOnSwitc test more robust

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_advanced_settings.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_advanced_settings.spec.js
@@ -430,7 +430,9 @@ describe('discover_advanced_setting', () => {
     });
 
     it('check refresh data button is displayed when searchOnPageLoad is set as false', function () {
-      cy.get('.euiButton__text').contains('Refresh data').should('exist');
+      cy.get('button.euiButton')
+        .contains('.euiButton__text', 'Refresh data')
+        .should('exist');
     });
 
     after(() => {


### PR DESCRIPTION
### Description
seeing this error in CI
```
core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_advanced_settings.spec.js

  modifyColumnsOnSwitch advanced setting
    - check columns still available after switching data sources in legacy table
    âœ“ check columns still available after switching data sources in new table (39154ms)


  16 passing (8m)
  1 pending
  1 failing

  1) discover_advanced_setting
       searchOnPageLoad advanced setting
         check refresh data button is displayed when searchOnPageLoad is set as false:
     AssertionError: Timed out retrying after 60000ms: Expected to find content: 'Refresh data' within the element: <span.euiButton__text.euiSuperUpdateButton__text> but never did.
      at Context.eval (http://localhost:5601/__cypress/tests?p=cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_advanced_settings.spec.js:515:59)
```
I am able to reproduce locally. The issue is that Cypress is trying to find the text "Refresh data" directly within an element with class .euiButton__text, but it needs to:
1. find the button element
2. look for the text within that button's descendant elements

After the fix, local test can pass
<img width="1779" alt="Screenshot 2024-10-31 at 1 48 53 PM" src="https://github.com/user-attachments/assets/7631fb08-49a0-451e-99b2-e9e96282ff91">

Note: currently only add this for 2.18. I will verify 2.x and main. If the issue persists (I don't see that in recent main CI), I will create PRs for main and 2.x.

### Issues Resolved
NA

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
