### PR TITLE
skip searchOnPageLoad test in 2.18

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_advanced_settings.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover_advanced_settings.spec.js
@@ -419,7 +419,7 @@ describe('discover_advanced_setting', () => {
     });
   });
 
-  describe('searchOnPageLoad advanced setting', () => {
+  describe.skip('searchOnPageLoad advanced setting', () => {
     before(() => {
       CURRENT_TENANT.newTenant = 'global';
       cy.fleshTenantSettings();


### PR DESCRIPTION
### Description
ciGroup6 is still flaky on the same test after previous commit. We will have to add a data-test-subj for refresh data button in OSD. Here is the PR https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8782 and here is the ftr update https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1618. 

For now, to unblock progress, we will skip this test for 2.18

### Issues Resolved

na

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
