### PR TITLE
Check for inequality in ISM tests

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -157,7 +157,7 @@ describe('Aliases', () => {
         body: { test: 'test' },
       });
 
-      // confirm uncommitted_operations is 1 after indexing doc
+      // confirm uncommitted_operations is not 0 after indexing doc
       cy.request({
         method: 'GET',
         url: `${Cypress.env('openSearchUrl')}/${sample_alias}/_stats/translog`,
@@ -167,7 +167,7 @@ describe('Aliases', () => {
         );
         let num =
           response_obj['_all']['total']['translog']['uncommitted_operations'];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       cy.get('[data-test-subj="moreAction"] button')

--- a/cypress/integration/plugins/index-management-dashboards-plugin/data_streams.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/data_streams.js
@@ -100,7 +100,7 @@ describe('Data stream', () => {
         body: { '@timestamp': 123123123 },
       });
 
-      // confirm uncommitted_operations is 1 after indexing doc
+      // confirm uncommitted_operations is not 0 after indexing doc
       cy.request({
         method: 'GET',
         url: `${Cypress.env('openSearchUrl')}/ds-/_stats/translog`,
@@ -110,7 +110,7 @@ describe('Data stream', () => {
         );
         let num =
           response_obj['_all']['total']['translog']['uncommitted_operations'];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       cy.get('[data-test-subj="moreAction"]').click();

--- a/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
@@ -618,7 +618,7 @@ describe('Indices', () => {
         body: { test: 'test' },
       });
 
-      // confirm uncommitted_operations is 1 after indexing doc
+      // confirm uncommitted_operations is not 0 after indexing doc
       cy.request({
         method: 'GET',
         url: `${Cypress.env('openSearchUrl')}/${SAMPLE_INDEX}/_stats/translog`,
@@ -628,7 +628,7 @@ describe('Indices', () => {
         );
         let num =
           response_obj['_all']['total']['translog']['uncommitted_operations'];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       // Select an index
@@ -678,7 +678,7 @@ describe('Indices', () => {
         body: { test: 'test' },
       });
 
-      // confirm uncommitted_operations is 1 after indexing doc
+      // confirm uncommitted_operations is not 0 after indexing doc
       cy.request({
         method: 'GET',
         url: `${Cypress.env('openSearchUrl')}/${SAMPLE_INDEX}/_stats/translog`,
@@ -688,7 +688,7 @@ describe('Indices', () => {
         );
         let num =
           response_obj['_all']['total']['translog']['uncommitted_operations'];
-        expect(num).to.equal(1);
+        expect(num).not.equal(0);
       });
 
       cy.get('[data-test-subj="moreAction"]').click();


### PR DESCRIPTION
### Description

When testing against cluster with more than one node, we encounter that this check fails as total number of uncommitted operations will be as per replica configuration. Eg. for a 1:1 pri:rep case, total number of uncommitted operations will be two (one for primary, one for replica), so modifying the check to check for inequality instead

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
