### PR TITLE
Fix duplicate test cypress result name

### DIFF
--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
@@ -8,6 +8,7 @@ on:
       - 'cypress/utils/dashboards/**'
       - 'package.json'
       - '.github/actions/start-opensearch/action.yml'
+      - '.github/workflows/release-e2e-workflow-template.yml'
 
   push:
     branches: ['**']
@@ -17,6 +18,7 @@ on:
       - 'cypress/utils/dashboards/**'
       - 'package.json'
       - '.github/actions/start-opensearch/action.yml'
+      - '.github/workflows/release-e2e-workflow-template.yml'
 
 env:
   CI_GROUPS: "1,2,3,4,5,6,7,8,9"

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
@@ -73,7 +73,7 @@ jobs:
       test-name: "osd:ciGroup${{ matrix.ciGroup }}"
       test-command: env CYPRESS_NO_COMMAND_LOG=1 CYPRESS_ML_COMMONS_DASHBOARDS_ENABLED=true CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-with-security --browser chromium --spec '${{ matrix.specs }}'
       osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --vis_builder.enabled=true --ml_commons_dashboards.enabled=true
-      artifact-name-suffix: "-ciGroup${{ matrix.ciGroup }}"
+      artifact-name-suffix: "-with-security-ciGroup${{ matrix.ciGroup }}"
 
   tests-without-security:
     needs: ["get_spec"]
@@ -88,7 +88,7 @@ jobs:
       test-command: env CYPRESS_NO_COMMAND_LOG=1 CYPRESS_ML_COMMONS_DASHBOARDS_ENABLED=true CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-without-security --browser chromium --spec '${{ matrix.specs }}'
       osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --vis_builder.enabled=true --ml_commons_dashboards.enabled=true
       security-enabled: false
-      artifact-name-suffix: "-ciGroup${{ matrix.ciGroup }}"
+      artifact-name-suffix: "-without-security-ciGroup${{ matrix.ciGroup }}"
 
 
   # Hold on windows test cases

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
@@ -73,6 +73,7 @@ jobs:
       test-name: "osd:ciGroup${{ matrix.ciGroup }}"
       test-command: env CYPRESS_NO_COMMAND_LOG=1 CYPRESS_ML_COMMONS_DASHBOARDS_ENABLED=true CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-with-security --browser chromium --spec '${{ matrix.specs }}'
       osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --vis_builder.enabled=true --ml_commons_dashboards.enabled=true
+      artifact-name-suffix: "-ciGroup${{ matrix.ciGroup }}"
 
   tests-without-security:
     needs: ["get_spec"]
@@ -87,6 +88,8 @@ jobs:
       test-command: env CYPRESS_NO_COMMAND_LOG=1 CYPRESS_ML_COMMONS_DASHBOARDS_ENABLED=true CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true yarn cypress:run-without-security --browser chromium --spec '${{ matrix.specs }}'
       osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --vis_builder.enabled=true --ml_commons_dashboards.enabled=true
       security-enabled: false
+      artifact-name-suffix: "-ciGroup${{ matrix.ciGroup }}"
+
 
   # Hold on windows test cases
   # https://github.com/opensearch-project/opensearch-dashboards-functional-test/actions/runs/9377445544/job/25819022121?pr=1352

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -14,6 +14,9 @@ on:
       security-enabled:
         required: false
         type: string
+      artifact-name-suffix:
+        required: false
+        type: string
 jobs:
   tests:
     name: Run Cypress E2E tests for ${{ inputs.test-name }}
@@ -135,17 +138,17 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots${{ inputs.test-name }}
+          name: cypress-screenshots${{ inputs.artifact-name-suffix }}
           path: cypress-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-videos${{ inputs.test-name }}
+          name: cypress-videos${{ inputs.artifact-name-suffix }}
           path: cypress-test/cypress/videos
       # Test reports was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-results${{ inputs.test-name }}
+          name: cypress-results${{ inputs.artifact-name-suffix }}
           path: cypress-test/cypress/results

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -135,17 +135,17 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: cypress-screenshots
+          name: cypress-screenshots${{ inputs.test-name }}
           path: cypress-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-videos
+          name: cypress-videos${{ inputs.test-name }}
           path: cypress-test/cypress/videos
       # Test reports was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: cypress-results
+          name: cypress-results${{ inputs.test-name }}
           path: cypress-test/cypress/results


### PR DESCRIPTION
### Description

This PR is for fixing upload artifact error due to duplicate artifact names. Here is a failed example:
https://github.com/opensearch-project/opensearch-dashboards-functional-test/actions/runs/11659889509/job/32461200995?pr=999
The root cause was a breaking change in [upload-artifact v4](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) from [this PR](https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1545). This action no longer support same upload artifact name.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
