### PR TITLE
add tests for deletion

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_delete.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_delete.spec.js
@@ -1,0 +1,176 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+const miscUtils = new MiscUtils(cy);
+const workspace1Name = 'test_workspace_320sdfouAz';
+let workspace1Description = 'This is a workspace1 description.';
+const workspace2Name = 'test_workspace_321sdfouAz';
+let workspace2Description = 'This is a workspace2 description.';
+
+let workspace1Id;
+let workspace2Id;
+
+if (Cypress.env('WORKSPACE_ENABLED')) {
+  describe('Delete Workspace(s) in 2 ways in workspace list page', () => {
+    before(() => {
+      Cypress.config('defaultCommandTimeout', 60000);
+      cy.deleteAllWorkspaces();
+    });
+    beforeEach(() => {
+      // Visit workspace list page
+      miscUtils.visitPage(`/app/workspace_list`);
+      cy.createWorkspace({
+        name: workspace1Name,
+        description: workspace1Description,
+        features: ['workspace_detail', 'use-case-observability'],
+        settings: {
+          permissions: {
+            library_write: { users: ['%me%'] },
+            write: { users: ['%me%'] },
+          },
+        },
+      }).then((value) => {
+        workspace1Id = value;
+        cy.intercept('DELETE', `/api/workspaces/${workspace1Id}`).as(
+          'deleteWorkspace1Request'
+        );
+      });
+
+      cy.createWorkspace({
+        name: workspace2Name,
+        description: workspace2Description,
+        features: ['workspace_detail', 'use-case-search'],
+        settings: {
+          permissions: {
+            library_write: { users: ['%me%'] },
+            write: { users: ['%me%'] },
+          },
+        },
+      }).then((value) => {
+        workspace2Id = value;
+        cy.intercept('DELETE', `/api/workspaces/${workspace2Id}`).as(
+          'deleteWorkspace2Request'
+        );
+      });
+    });
+
+    afterEach(() => {
+      cy.deleteAllWorkspaces();
+    });
+
+    describe('delete a workspace successfully using action buttons', () => {
+      it('should successfully load delete button and show delete modal when clicking action button', () => {
+        cy.contains(workspace1Name).should('be.visible');
+        cy.getElementByTestId('euiCollapsedItemActionsButton').first().click();
+        cy.getElementByTestId('workspace-list-delete-icon').should(
+          'be.visible'
+        );
+        cy.getElementByTestId('workspace-list-delete-icon').click();
+        cy.contains('Delete workspace').should('be.visible');
+        cy.contains(
+          'The following workspace will be permanently deleted. This action cannot be undone'
+        ).should('be.visible');
+        cy.contains(workspace1Name).should('be.visible');
+        cy.getElementByTestId('delete-workspace-modal-input').type('delete');
+        cy.getElementByTestId('delete-workspace-modal-confirm').click();
+        cy.wait('@deleteWorkspace1Request').then((interception) => {
+          expect(interception.response.statusCode).to.equal(200);
+        });
+        cy.location('pathname').should('include', 'app/workspace_list');
+        cy.contains('Delete workspace successfully').should('be.visible');
+        cy.contains(workspace1Name).should('not.exist');
+      });
+    });
+
+    describe('delete workspace(s) successfully using multi-deletion button', () => {
+      it('should successfully show multi-deletion button and perform deletion when choosing one workspace', () => {
+        cy.contains(workspace1Name).should('be.visible');
+        cy.get('[data-test-subj^="checkboxSelectRow"]').first().click();
+        cy.getElementByTestId('multi-deletion-button').should('be.visible');
+        cy.getElementByTestId('multi-deletion-button').click();
+        cy.contains('Delete workspace').should('be.visible');
+        cy.contains(
+          'The following workspace will be permanently deleted. This action cannot be undone'
+        ).should('be.visible');
+        cy.contains(workspace1Name).should('be.visible');
+        cy.getElementByTestId('delete-workspace-modal-input').type('delete');
+        cy.getElementByTestId('delete-workspace-modal-confirm').click();
+        cy.wait('@deleteWorkspace1Request').then((interception) => {
+          expect(interception.response.statusCode).to.equal(200);
+        });
+        cy.location('pathname').should('include', 'app/workspace_list');
+        cy.contains('Delete workspace successfully').should('be.visible');
+        cy.contains(workspace1Name).should('not.exist');
+      });
+
+      it('should successfully delete all', () => {
+        cy.contains(workspace1Name).should('be.visible');
+        cy.contains(workspace2Name).should('be.visible');
+        cy.getElementByTestId('checkboxSelectAll').click();
+        cy.getElementByTestId('multi-deletion-button').should('be.visible');
+        cy.getElementByTestId('multi-deletion-button').click();
+        cy.contains('Delete workspace').should('be.visible');
+        cy.contains(
+          'The following workspace will be permanently deleted. This action cannot be undone'
+        ).should('be.visible');
+        cy.contains(workspace1Name).should('be.visible');
+        cy.contains(workspace2Name).should('be.visible');
+        cy.getElementByTestId('delete-workspace-modal-input').type('delete');
+        cy.getElementByTestId('delete-workspace-modal-confirm').click();
+        cy.wait('@deleteWorkspace1Request').then((interception) => {
+          expect(interception.response.statusCode).to.equal(200);
+        });
+        cy.location('pathname').should('include', 'app/workspace_list');
+        cy.contains('Delete workspace successfully').should('be.visible');
+        cy.contains(workspace1Name).should('not.exist');
+        cy.contains(workspace2Name).should('not.exist');
+      });
+    });
+  });
+
+  describe('Workspace deletion in workspace detail page', () => {
+    before(() => {
+      cy.deleteWorkspaceByName(workspace1Name);
+      cy.createWorkspace({
+        name: workspace1Name,
+        description: workspace1Description,
+        features: ['workspace_detail', 'use-case-observability'],
+        settings: {
+          permissions: {
+            library_write: { users: ['%me%'] },
+            write: { users: ['%me%'] },
+          },
+        },
+      }).then((value) => {
+        workspace1Id = value;
+      });
+    });
+
+    beforeEach(() => {
+      cy.intercept(
+        'DELETE',
+        `/w/${workspace1Id}/api/workspaces/${workspace1Id}`
+      ).as('deleteWorkspace1Request');
+      miscUtils.visitPage(`w/${workspace1Id}/app/workspace_detail`);
+    });
+
+    it('should delete workspace in workspace detail page', () => {
+      cy.getElementByTestId('workspace-detail-delete-button').click();
+      cy.contains('Delete workspace').should('be.visible');
+      cy.contains(workspace1Name).should('be.visible');
+      cy.getElementByTestId('delete-workspace-modal-input').type(
+        workspace1Name
+      );
+      cy.getElementByTestId('delete-workspace-modal-confirm').click();
+      cy.wait('@deleteWorkspace1Request').then((interception) => {
+        expect(interception.response.statusCode).to.equal(200);
+      });
+      cy.contains('Delete workspace successfully').should('be.visible');
+      cy.location('pathname').should('include', 'app/workspace_list');
+      cy.contains(workspace1Name).should('not.exist');
+    });
+  });
+}


### PR DESCRIPTION
### Description

This PR adds tests for workspace deletion, covering three methods:
 1. Deleting a workspace using the action button.
 2. Deleting one or more workspaces using the multi-delete button.
 3. Deleting a workspace from the workspace detail page.
 
![截屏2024-11-08 15 13 42](https://github.com/user-attachments/assets/bca2f817-eea6-4491-84c9-954967380e36)

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
