### PR TITLE
Update integration tests with privacy setting features

### DIFF
--- a/cypress/utils/dashboards/workspace-plugin/test-cases/mds_workspace_collaborators.cases.js
+++ b/cypress/utils/dashboards/workspace-plugin/test-cases/mds_workspace_collaborators.cases.js
@@ -5,6 +5,21 @@
 
 import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
 
+const updatePrivacySetting = (settingId) => {
+  cy.getElementByTestId('workspaceCollaborators-privacySetting-edit').click();
+  cy.getElementByTestId('workspacePrivacySettingSelector').click({
+    force: true,
+  });
+  cy.get(`#${settingId}`).click({ force: true });
+  cy.getElementByTestId('workspaceCollaborators-privacySetting-save').click({
+    force: true,
+  });
+
+  cy.getElementByTestId('workspaceCollaborators-privacySetting-save').should(
+    'not.exist'
+  );
+};
+
 export const WorkspaceCollaboratorsTestCases = () => {
   const miscUtils = new MiscUtils(cy);
   const workspaceName = 'test_workspace_collaborators';
@@ -208,6 +223,108 @@ export const WorkspaceCollaboratorsTestCases = () => {
           },
         };
         cy.checkWorkspace(workspaceId, expectedWorkspace);
+      });
+
+      it('should change to "anyone can read" successfully', () => {
+        updatePrivacySetting('anyone-can-view');
+
+        const expectedWorkspace = {
+          name: workspaceName,
+          features: ['use-case-observability'],
+          description: 'test_description',
+          permissions: {
+            library_write: {
+              users: [`${Cypress.env('username')}`],
+              groups: ['admin_group'],
+            },
+            write: {
+              users: [`${Cypress.env('username')}`],
+              groups: ['admin_group'],
+            },
+            library_read: {
+              users: ['read_user', '*'],
+            },
+            read: {
+              users: ['read_user', '*'],
+            },
+          },
+        };
+        cy.checkWorkspace(workspaceId, expectedWorkspace);
+      });
+
+      it('should change to "anyone can edit" successfully', () => {
+        updatePrivacySetting('anyone-can-edit');
+
+        const expectedWorkspace = {
+          name: workspaceName,
+          features: ['use-case-observability'],
+          description: 'test_description',
+          permissions: {
+            library_write: {
+              users: [`${Cypress.env('username')}`, '*'],
+              groups: ['admin_group'],
+            },
+            write: {
+              users: [`${Cypress.env('username')}`],
+              groups: ['admin_group'],
+            },
+            library_read: {
+              users: ['read_user'],
+            },
+            read: {
+              users: ['read_user', '*'],
+            },
+          },
+        };
+        cy.checkWorkspace(workspaceId, expectedWorkspace);
+      });
+
+      it('should change back to "private to collaborators" successfully', () => {
+        updatePrivacySetting('anyone-can-view');
+        cy.checkWorkspace(workspaceId, {
+          name: workspaceName,
+          features: ['use-case-observability'],
+          description: 'test_description',
+          permissions: {
+            library_write: {
+              users: [`${Cypress.env('username')}`],
+              groups: ['admin_group'],
+            },
+            write: {
+              users: [`${Cypress.env('username')}`],
+              groups: ['admin_group'],
+            },
+            library_read: {
+              users: ['read_user', '*'],
+            },
+            read: {
+              users: ['read_user', '*'],
+            },
+          },
+        });
+
+        updatePrivacySetting('private-to-collaborators');
+        cy.checkWorkspace(workspaceId, {
+          name: workspaceName,
+          features: ['use-case-observability'],
+          description: 'test_description',
+          permissions: {
+            library_write: {
+              users: [`${Cypress.env('username')}`],
+              groups: ['admin_group'],
+            },
+            write: {
+              users: [`${Cypress.env('username')}`],
+              groups: ['admin_group'],
+            },
+            library_read: {
+              users: ['read_user'],
+            },
+            read: {
+              users: ['read_user'],
+            },
+          },
+        });
       });
     });
   }

--- a/cypress/utils/dashboards/workspace-plugin/test-cases/mds_workspace_create.cases.js
+++ b/cypress/utils/dashboards/workspace-plugin/test-cases/mds_workspace_create.cases.js
@@ -156,6 +156,9 @@ export const WorkspaceCreateTestCases = () => {
             cy.deleteWorkspaceByName(workspaceName);
             inputWorkspaceName(workspaceName);
             inputDataSourceWhenMDSEnabled(dataSourceTitle);
+            cy.getElementByTestId('jumpToCollaboratorsCheckbox').click({
+              force: true,
+            });
             cy.getElementByTestId('workspaceForm-bottomBar-createButton').click(
               {
                 force: true,
@@ -171,6 +174,36 @@ export const WorkspaceCreateTestCases = () => {
                 'include',
                 `w/${workspaceId}/app/workspace_collaborators`
               );
+            });
+          });
+
+          it('should creating a workspace with privacy setting', () => {
+            cy.deleteWorkspaceByName(workspaceName);
+            inputWorkspaceName(workspaceName);
+            inputDataSourceWhenMDSEnabled(dataSourceTitle);
+            cy.get('#anyone-can-edit').click();
+            cy.getElementByTestId('jumpToCollaboratorsCheckbox')
+              .should('be.enabled')
+              .click({
+                force: true,
+              });
+            cy.getElementByTestId('workspaceForm-bottomBar-createButton').click(
+              {
+                force: true,
+              }
+            );
+
+            let workspaceId;
+            cy.wait('@createWorkspaceRequest').then((interception) => {
+              expect(interception.response.statusCode).to.equal(200);
+              workspaceId = interception.response.body.result.id;
+
+              cy.location('pathname', { timeout: 6000 }).should(
+                'include',
+                `w/${workspaceId}/app/workspace_collaborators`
+              );
+
+              cy.contains('Anyone can edit').should('be.exist');
             });
           });
         }


### PR DESCRIPTION
### Description

This PR updates integration tests for workspace privacy setting feature. Can be reviewed after the [OSD workspace privacy setting feature PR](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8907) merged.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
