### PR TITLE
Update observability dashboards tests

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
@@ -26,7 +26,7 @@ describe('Testing services table', () => {
       .first()
       .focus()
       .type(`${SERVICE_NAME}{enter}`);
-    cy.get('.euiButton__text').contains('Refresh').click();
+    cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
     cy.contains(' (1)').should('exist');
   });
 

--- a/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
@@ -25,7 +25,7 @@ describe('Testing traces table', () => {
 
   it('Searches correctly', () => {
     cy.get('input[type="search"]').focus().type(`${TRACE_ID}{enter}`);
-    cy.get('.euiButton__text').contains('Refresh').click();
+    cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
     cy.contains(' (1)').should('exist');
     cy.contains('03/25/2021 10:21:22').should('exist');
   });

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -127,38 +127,38 @@ describe('Test reporting integration if plugin installed', () => {
     cy.get('button.euiContextMenuItem:nth-child(1)')
       .contains('Download PDF')
       .click();
-    cy.get('body').contains('Please continue report generation in the new tab');
+    // cy.get('body').contains('Please continue report generation in the new tab');
   });
 
-  it('Create in-context PNG report from notebook', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.get('button.euiContextMenuItem:nth-child(2)')
-      .contains('Download PNG')
-      .click();
-    cy.get('body').contains('Please continue report generation in the new tab');
-  });
+  // it('Create in-context PNG report from notebook', () => {
+  //   cy.get('#reportingActionsButton').click();
+  //   cy.get('button.euiContextMenuItem:nth-child(2)')
+  //     .contains('Download PNG')
+  //     .click();
+  //   cy.get('body').contains('Please continue report generation in the new tab');
+  // });
 
-  it('Create on-demand report definition from context menu', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.get('button.euiContextMenuItem:nth-child(3)')
-      .contains('Create report definition')
-      .click();
-    cy.location('pathname', { timeout: delayTime * 3 }).should(
-      'include',
-      '/reports-dashboards'
-    );
-    cy.get('#reportSettingsName').type('Create notebook on-demand report');
-    cy.get('#createNewReportDefinition').click({ force: true });
-  });
+  // it('Create on-demand report definition from context menu', () => {
+  //   cy.get('#reportingActionsButton').click();
+  //   cy.get('button.euiContextMenuItem:nth-child(3)')
+  //     .contains('Create report definition')
+  //     .click();
+  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
+  //     'include',
+  //     '/reports-dashboards'
+  //   );
+  //   cy.get('#reportSettingsName').type('Create notebook on-demand report');
+  //   cy.get('#createNewReportDefinition').click({ force: true });
+  // });
 
-  it('View reports homepage from context menu', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.get('button.euiContextMenuItem:nth-child(4)')
-      .contains('View reports')
-      .click();
-    cy.location('pathname', { timeout: delayTime * 3 }).should(
-      'include',
-      '/reports-dashboards'
-    );
-  });
+  // it('View reports homepage from context menu', () => {
+  //   cy.get('#reportingActionsButton').click();
+  //   cy.get('button.euiContextMenuItem:nth-child(4)')
+  //     .contains('View reports')
+  //     .click();
+  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
+  //     'include',
+  //     '/reports-dashboards'
+  //   );
+  // });
 });

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -34,7 +34,7 @@ const makeTestNotebook = () => {
 
   cy.contains(`Notebook "${notebookName}" successfully created`);
 
-  cy.get('h1[data-test-subj="notebookTitle"]')
+  cy.get('[data-test-subj="notebookTitle"]')
     .contains(notebookName)
     .should('exist');
 
@@ -61,8 +61,7 @@ const deleteNotebook = (notebookName) => {
     .find('input[type="checkbox"]')
     .check();
 
-  cy.get('button[data-test-subj="notebookTableActionBtn"]').click();
-  cy.get('button[data-test-subj="deleteNotebookBtn"]').click();
+  cy.get('button[data-test-subj="deleteSelectedNotebooks"]').click();
 
   cy.get('input[data-test-subj="delete-notebook-modal-input"]').focus();
   cy.get('input[data-test-subj="delete-notebook-modal-input"]').type('delete');

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -130,35 +130,35 @@ describe('Test reporting integration if plugin installed', () => {
     cy.get('body').contains('Please continue report generation in the new tab');
   });
 
-  // it('Create in-context PNG report from notebook', () => {
-  //   cy.get('#reportingActionsButton').click();
-  //   cy.get('button.euiContextMenuItem:nth-child(2)')
-  //     .contains('Download PNG')
-  //     .click();
-  //   cy.get('body').contains('Please continue report generation in the new tab');
-  // });
+  it('Create in-context PNG report from notebook', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.get('button.euiContextMenuItem:nth-child(2)')
+      .contains('Download PNG')
+      .click();
+    cy.get('body').contains('Please continue report generation in the new tab');
+  });
 
-  // it('Create on-demand report definition from context menu', () => {
-  //   cy.get('#reportingActionsButton').click();
-  //   cy.get('button.euiContextMenuItem:nth-child(3)')
-  //     .contains('Create report definition')
-  //     .click();
-  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
-  //     'include',
-  //     '/reports-dashboards'
-  //   );
-  //   cy.get('#reportSettingsName').type('Create notebook on-demand report');
-  //   cy.get('#createNewReportDefinition').click({ force: true });
-  // });
+  it('Create on-demand report definition from context menu', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.get('button.euiContextMenuItem:nth-child(3)')
+      .contains('Create report definition')
+      .click();
+    cy.location('pathname', { timeout: delayTime * 3 }).should(
+      'include',
+      '/reports-dashboards'
+    );
+    cy.get('#reportSettingsName').type('Create notebook on-demand report');
+    cy.get('#createNewReportDefinition').click({ force: true });
+  });
 
-  // it('View reports homepage from context menu', () => {
-  //   cy.get('#reportingActionsButton').click();
-  //   cy.get('button.euiContextMenuItem:nth-child(4)')
-  //     .contains('View reports')
-  //     .click();
-  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
-  //     'include',
-  //     '/reports-dashboards'
-  //   );
-  // });
+  it('View reports homepage from context menu', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.get('button.euiContextMenuItem:nth-child(4)')
+      .contains('View reports')
+      .click();
+    cy.location('pathname', { timeout: delayTime * 3 }).should(
+      'include',
+      '/reports-dashboards'
+    );
+  });
 });

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -124,41 +124,41 @@ describe('Test reporting integration if plugin installed', () => {
 
   it('Create in-context PDF report from notebook', () => {
     cy.get('#reportingActionsButton').click();
-    // cy.get('button.euiContextMenuItem:nth-child(1)')
-    //   .contains('Download PDF')
-    //   .click();
-    // cy.get('body').contains('Please continue report generation in the new tab');
+    cy.get('button.euiContextMenuItem:nth-child(1)')
+      .contains('Download PDF')
+      .click();
+    cy.get('body').contains('Please continue report generation in the new tab');
   });
 
-  // it('Create in-context PNG report from notebook', () => {
-  //   cy.get('#reportingActionsButton').click();
-  //   cy.get('button.euiContextMenuItem:nth-child(2)')
-  //     .contains('Download PNG')
-  //     .click();
-  //   cy.get('body').contains('Please continue report generation in the new tab');
-  // });
+  it('Create in-context PNG report from notebook', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.get('button.euiContextMenuItem:nth-child(2)')
+      .contains('Download PNG')
+      .click();
+    cy.get('body').contains('Please continue report generation in the new tab');
+  });
 
-  // it('Create on-demand report definition from context menu', () => {
-  //   cy.get('#reportingActionsButton').click();
-  //   cy.get('button.euiContextMenuItem:nth-child(3)')
-  //     .contains('Create report definition')
-  //     .click();
-  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
-  //     'include',
-  //     '/reports-dashboards'
-  //   );
-  //   cy.get('#reportSettingsName').type('Create notebook on-demand report');
-  //   cy.get('#createNewReportDefinition').click({ force: true });
-  // });
+  it('Create on-demand report definition from context menu', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.get('button.euiContextMenuItem:nth-child(3)')
+      .contains('Create report definition')
+      .click();
+    cy.location('pathname', { timeout: delayTime * 3 }).should(
+      'include',
+      '/reports-dashboards'
+    );
+    cy.get('#reportSettingsName').type('Create notebook on-demand report');
+    cy.get('#createNewReportDefinition').click({ force: true });
+  });
 
-  // it('View reports homepage from context menu', () => {
-  //   cy.get('#reportingActionsButton').click();
-  //   cy.get('button.euiContextMenuItem:nth-child(4)')
-  //     .contains('View reports')
-  //     .click();
-  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
-  //     'include',
-  //     '/reports-dashboards'
-  //   );
-  // });
+  it('View reports homepage from context menu', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.get('button.euiContextMenuItem:nth-child(4)')
+      .contains('View reports')
+      .click();
+    cy.location('pathname', { timeout: delayTime * 3 }).should(
+      'include',
+      '/reports-dashboards'
+    );
+  });
 });

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -124,41 +124,41 @@ describe('Test reporting integration if plugin installed', () => {
 
   it('Create in-context PDF report from notebook', () => {
     cy.get('#reportingActionsButton').click();
-    cy.get('button.euiContextMenuItem:nth-child(1)')
-      .contains('Download PDF')
-      .click();
-    cy.get('body').contains('Please continue report generation in the new tab');
+    // cy.get('button.euiContextMenuItem:nth-child(1)')
+    //   .contains('Download PDF')
+    //   .click();
+    // cy.get('body').contains('Please continue report generation in the new tab');
   });
 
-  it('Create in-context PNG report from notebook', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.get('button.euiContextMenuItem:nth-child(2)')
-      .contains('Download PNG')
-      .click();
-    cy.get('body').contains('Please continue report generation in the new tab');
-  });
+  // it('Create in-context PNG report from notebook', () => {
+  //   cy.get('#reportingActionsButton').click();
+  //   cy.get('button.euiContextMenuItem:nth-child(2)')
+  //     .contains('Download PNG')
+  //     .click();
+  //   cy.get('body').contains('Please continue report generation in the new tab');
+  // });
 
-  it('Create on-demand report definition from context menu', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.get('button.euiContextMenuItem:nth-child(3)')
-      .contains('Create report definition')
-      .click();
-    cy.location('pathname', { timeout: delayTime * 3 }).should(
-      'include',
-      '/reports-dashboards'
-    );
-    cy.get('#reportSettingsName').type('Create notebook on-demand report');
-    cy.get('#createNewReportDefinition').click({ force: true });
-  });
+  // it('Create on-demand report definition from context menu', () => {
+  //   cy.get('#reportingActionsButton').click();
+  //   cy.get('button.euiContextMenuItem:nth-child(3)')
+  //     .contains('Create report definition')
+  //     .click();
+  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
+  //     'include',
+  //     '/reports-dashboards'
+  //   );
+  //   cy.get('#reportSettingsName').type('Create notebook on-demand report');
+  //   cy.get('#createNewReportDefinition').click({ force: true });
+  // });
 
-  it('View reports homepage from context menu', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.get('button.euiContextMenuItem:nth-child(4)')
-      .contains('View reports')
-      .click();
-    cy.location('pathname', { timeout: delayTime * 3 }).should(
-      'include',
-      '/reports-dashboards'
-    );
-  });
+  // it('View reports homepage from context menu', () => {
+  //   cy.get('#reportingActionsButton').click();
+  //   cy.get('button.euiContextMenuItem:nth-child(4)')
+  //     .contains('View reports')
+  //     .click();
+  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
+  //     'include',
+  //     '/reports-dashboards'
+  //   );
+  // });
 });

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -61,7 +61,7 @@ const deleteNotebook = (notebookName) => {
     .find('input[type="checkbox"]')
     .check();
 
-  cy.get('button[data-test-subj="deleteSelectedNotebooks"]').click();
+  cy.get('[data-test-subj="deleteSelectedNotebooks"]').click();
 
   cy.get('input[data-test-subj="delete-notebook-modal-input"]').focus();
   cy.get('input[data-test-subj="delete-notebook-modal-input"]').type('delete');

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -130,35 +130,35 @@ describe('Test reporting integration if plugin installed', () => {
     cy.get('body').contains('Please continue report generation in the new tab');
   });
 
-  it('Create in-context PNG report from notebook', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.get('button.euiContextMenuItem:nth-child(2)')
-      .contains('Download PNG')
-      .click();
-    cy.get('body').contains('Please continue report generation in the new tab');
-  });
+  // it('Create in-context PNG report from notebook', () => {
+  //   cy.get('#reportingActionsButton').click();
+  //   cy.get('button.euiContextMenuItem:nth-child(2)')
+  //     .contains('Download PNG')
+  //     .click();
+  //   cy.get('body').contains('Please continue report generation in the new tab');
+  // });
 
-  it('Create on-demand report definition from context menu', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.get('button.euiContextMenuItem:nth-child(3)')
-      .contains('Create report definition')
-      .click();
-    cy.location('pathname', { timeout: delayTime * 3 }).should(
-      'include',
-      '/reports-dashboards'
-    );
-    cy.get('#reportSettingsName').type('Create notebook on-demand report');
-    cy.get('#createNewReportDefinition').click({ force: true });
-  });
+  // it('Create on-demand report definition from context menu', () => {
+  //   cy.get('#reportingActionsButton').click();
+  //   cy.get('button.euiContextMenuItem:nth-child(3)')
+  //     .contains('Create report definition')
+  //     .click();
+  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
+  //     'include',
+  //     '/reports-dashboards'
+  //   );
+  //   cy.get('#reportSettingsName').type('Create notebook on-demand report');
+  //   cy.get('#createNewReportDefinition').click({ force: true });
+  // });
 
-  it('View reports homepage from context menu', () => {
-    cy.get('#reportingActionsButton').click();
-    cy.get('button.euiContextMenuItem:nth-child(4)')
-      .contains('View reports')
-      .click();
-    cy.location('pathname', { timeout: delayTime * 3 }).should(
-      'include',
-      '/reports-dashboards'
-    );
-  });
+  // it('View reports homepage from context menu', () => {
+  //   cy.get('#reportingActionsButton').click();
+  //   cy.get('button.euiContextMenuItem:nth-child(4)')
+  //     .contains('View reports')
+  //     .click();
+  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
+  //     'include',
+  //     '/reports-dashboards'
+  //   );
+  // });
 });

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -109,11 +109,11 @@ describe('Testing notebook actions', () => {
 describe('Test reporting integration if plugin installed', () => {
   beforeEach(() => {
     let notebookName = makeTestNotebook();
+    cy.wrap({ name: notebookName }).as('notebook');
     cy.get('body').then(($body) => {
       skipOn($body.find('#reportingActionsButton').length <= 0);
     });
     makePopulatedParagraph();
-    cy.wrap({ name: notebookName }).as('notebook');
   });
 
   afterEach(() => {
@@ -127,38 +127,38 @@ describe('Test reporting integration if plugin installed', () => {
     cy.get('button.euiContextMenuItem:nth-child(1)')
       .contains('Download PDF')
       .click();
-    // cy.get('body').contains('Please continue report generation in the new tab');
+    cy.get('body').contains('Please continue report generation in the new tab');
   });
 
-  // it('Create in-context PNG report from notebook', () => {
-  //   cy.get('#reportingActionsButton').click();
-  //   cy.get('button.euiContextMenuItem:nth-child(2)')
-  //     .contains('Download PNG')
-  //     .click();
-  //   cy.get('body').contains('Please continue report generation in the new tab');
-  // });
+  it('Create in-context PNG report from notebook', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.get('button.euiContextMenuItem:nth-child(2)')
+      .contains('Download PNG')
+      .click();
+    cy.get('body').contains('Please continue report generation in the new tab');
+  });
 
-  // it('Create on-demand report definition from context menu', () => {
-  //   cy.get('#reportingActionsButton').click();
-  //   cy.get('button.euiContextMenuItem:nth-child(3)')
-  //     .contains('Create report definition')
-  //     .click();
-  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
-  //     'include',
-  //     '/reports-dashboards'
-  //   );
-  //   cy.get('#reportSettingsName').type('Create notebook on-demand report');
-  //   cy.get('#createNewReportDefinition').click({ force: true });
-  // });
+  it('Create on-demand report definition from context menu', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.get('button.euiContextMenuItem:nth-child(3)')
+      .contains('Create report definition')
+      .click();
+    cy.location('pathname', { timeout: delayTime * 3 }).should(
+      'include',
+      '/reports-dashboards'
+    );
+    cy.get('#reportSettingsName').type('Create notebook on-demand report');
+    cy.get('#createNewReportDefinition').click({ force: true });
+  });
 
-  // it('View reports homepage from context menu', () => {
-  //   cy.get('#reportingActionsButton').click();
-  //   cy.get('button.euiContextMenuItem:nth-child(4)')
-  //     .contains('View reports')
-  //     .click();
-  //   cy.location('pathname', { timeout: delayTime * 3 }).should(
-  //     'include',
-  //     '/reports-dashboards'
-  //   );
-  // });
+  it('View reports homepage from context menu', () => {
+    cy.get('#reportingActionsButton').click();
+    cy.get('button.euiContextMenuItem:nth-child(4)')
+      .contains('View reports')
+      .click();
+    cy.location('pathname', { timeout: delayTime * 3 }).should(
+      'include',
+      '/reports-dashboards'
+    );
+  });
 });

--- a/cypress/utils/plugins/observability-dashboards/constants.js
+++ b/cypress/utils/plugins/observability-dashboards/constants.js
@@ -80,7 +80,8 @@ export const setTimeFilter = (setEndTime = false, refresh = true) => {
       timeout: TIMEOUT_DELAY,
     }).type('{selectall}' + endTime, { force: true });
   }
-  if (refresh) cy.get('.euiButton__text').contains('Refresh').click();
+  if (refresh)
+    cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
   cy.wait(delayTime);
 };
 
@@ -171,9 +172,7 @@ export const querySearch = (query, rangeSelected) => {
   cy.get(rangeSelected).click();
   cy.get('[data-test-subj="superDatePickerApplyTimeButton"]', {
     timeout: TIMEOUT_DELAY,
-  })
-    .contains('Refresh')
-    .click();
+  }).click();
 };
 
 export const landOnEventHome = () => {


### PR DESCRIPTION
### Description

Update traces and services tests to use data-test-subj instead of searching for string "Refresh" to click refresh button
Update notebooks to use just data-test-subj for checking header and updated delete button

Services:
![Screenshot 2024-12-16 at 11 24 20 AM](https://github.com/user-attachments/assets/a65cd7c8-3915-43c2-96a9-c6a055f19585)

Traces:
![Screenshot 2024-12-16 at 11 25 02 AM](https://github.com/user-attachments/assets/15adaf54-7b98-4bda-a96f-e1f2bf5950b9)

Notebooks:
![Screenshot 2024-12-16 at 11 30 06 AM](https://github.com/user-attachments/assets/2d8fe219-f814-4476-8c79-44cbe7fbc2fd)



### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
