### PR TITLE
Fix shared link test in 2.x for 2.19

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js
@@ -94,7 +94,7 @@ describe('shared links', () => {
 
     it('should allow for copying the saved object URL', function () {
       const url =
-        "http://localhost:5601/app/data-explorer/discover/#/view/ab12e3c0-f231-11e6-9486-733b1ac9221a?_g=(filters%3A!()%2CrefreshInterval%3A(pause%3A!t%2Cvalue%3A0)%2Ctime%3A(from%3A'2015-09-19T13%3A31%3A44.000Z'%2Cto%3A'2015-09-24T01%3A31%3A44.000Z'))";
+        'http://localhost:5601/app/data-explorer/discover/#/view/ab12e3c0-f231-11e6-9486-733b1ac9221a?_g=%28filters%3A%21%28%29%2CrefreshInterval%3A%28pause%3A%21t%2Cvalue%3A0%29%2Ctime%3A%28from%3A%272015-09-19T13%3A31%3A44.000Z%27%2Cto%3A%272015-09-24T01%3A31%3A44.000Z%27%29%29';
 
       cy.getElementByTestId('exportAsSavedObject')
         .get('.euiRadio__input')


### PR DESCRIPTION
### Description

Revert https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/932 as 2.x can correctly decode. Currently this test causes ciGroup9 fail and block CI.

### Issues Resolved

NA

### Check List

```
ananzh@88665a1f0502 opensearch-dashboards-functional-test % yarn cypress run --spec "cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js"
yarn run v1.22.21
warning ../../package.json: No license field
$ /Users/ananzh/Work/opensearch-dashboards-functional-test/node_modules/.bin/cypress run --spec cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links.spec.js

====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        9.5.4                                                                          │
  │ Browser:        Electron 94 (headless)                                                         │
  │ Node Version:   v18.20.5 (/Users/ananzh/.nvm/versions/node/v18.20.5/bin/node)                  │
  │ Specs:          1 found (core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/s │
  │                 hared_links.spec.js)                                                           │
  │ Searched:       cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data │
  │                 _explorer/shared_links.spec.js                                                 │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/            (1 of 1)
            shared_links.spec.js                                                                    
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating


  shared links
    shared links with state in query
      ✓ should allow for copying the snapshot URL (50803ms)
      ✓ should allow for copying the snapshot URL as a short URL
      ✓ should allow for copying the saved object URL (5559ms)
    shared links with state in sessionStorage
      ✓ should allow for copying the snapshot URL (12507ms)
      ✓ should allow for copying the snapshot URL as a short URL
      ✓ should allow for copying the saved object URL


  6 passing (1m)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        6                                                                                │
  │ Passing:      6                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     1 minute, 25 seconds                                                             │
  │ Spec Ran:     core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/shared_links │
  │               .spec.js                                                                         │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/ananzh/Work/opensearch-dashboards-functional-test/cy   (10 seconds)
                          press/videos/core-opensearch-dashboards/opensearch-dashboar               
                          ds/apps/data_explorer/shared_links.spec.js.mp4                            

    Compression progress:  100%

====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  core-opensearch-dashboards/opensear      01:25        6        6        -        -        - │
  │    ch-dashboards/apps/data_explorer/sh                                                         │
  │    ared_links.spec.js                                                                          │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        01:25        6        6        -        -        -  

✨  Done in 112.05s.
```

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
