### PR TITLE
Update notebooks and traces tests with dynamic wait

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
@@ -9,7 +9,6 @@ import {
   SERVICE_NAME,
   setTimeFilter,
   delayTime,
-  TIMEOUT_DELAY,
 } from '../../../utils/constants';
 
 describe('Testing services table', () => {
@@ -32,6 +31,7 @@ describe('Testing services table', () => {
   });
 
   it('Opens service flyout', () => {
+    cy.contains('6.42').should('exist');
     cy.get('button[data-test-subj^="service-flyout-action-btn"]')
       .first()
       .click();

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -138,7 +138,8 @@ describe('Test reporting integration if plugin installed', () => {
   });
 
   it('Create in-context PDF report from notebook', () => {
-    cy.get('#reportingActionsButton').click();
+    cy.get('button[data-test-subj="reporting-actions-button"]').click();
+    cy.get('.euiContextMenuPanel').should('be.visible');
     cy.get('button.euiContextMenuItem:nth-child(1)')
       .contains('Download PDF')
       .click();
@@ -146,7 +147,8 @@ describe('Test reporting integration if plugin installed', () => {
   });
 
   it('Create in-context PNG report from notebook', () => {
-    cy.get('#reportingActionsButton').click();
+    cy.get('button[data-test-subj="reporting-actions-button"]').click();
+    cy.get('.euiContextMenuPanel').should('be.visible');
     cy.get('button.euiContextMenuItem:nth-child(2)')
       .contains('Download PNG')
       .click();
@@ -154,7 +156,8 @@ describe('Test reporting integration if plugin installed', () => {
   });
 
   it('Create on-demand report definition from context menu', () => {
-    cy.get('#reportingActionsButton').click();
+    cy.get('button[data-test-subj="reporting-actions-button"]').click();
+    cy.get('.euiContextMenuPanel').should('be.visible');
     cy.get('button.euiContextMenuItem:nth-child(3)')
       .contains('Create report definition')
       .click();
@@ -167,7 +170,8 @@ describe('Test reporting integration if plugin installed', () => {
   });
 
   it('View reports homepage from context menu', () => {
-    cy.get('#reportingActionsButton').click();
+    cy.get('button[data-test-subj="reporting-actions-button"]').click();
+    cy.get('.euiContextMenuPanel').should('be.visible');
     cy.get('button.euiContextMenuItem:nth-child(4)')
       .contains('View reports')
       .click();

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -69,19 +69,15 @@ const deleteNotebook = () => {
 };
 
 const deleteAllNotebooks = () => {
-  cy.intercept('GET', '/api/observability/notebooks/savedNotebook').as(
-    'getNotebooks'
-  );
   cy.intercept(
     'DELETE',
     '/api/observability/notebooks/note/savedNotebook/*'
   ).as('deleteNotebook');
   moveToNotebookHome();
 
-  cy.wait('@getNotebooks').then(() => {
-    cy.contains(' (4)').should('exist');
-  });
+  cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
 
+  cy.get('input[data-test-subj="checkboxSelectAll"]').should('exist');
   cy.get('input[data-test-subj="checkboxSelectAll"]').click();
   cy.get('button[data-test-subj="deleteSelectedNotebooks"]')
     .contains('Delete 4 notebooks')

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -53,6 +53,8 @@ const makePopulatedParagraph = () => {
   cy.get('textarea[data-test-subj="editorArea-0"]').type(MARKDOWN_TEXT);
   cy.get('button[data-test-subj="runRefreshBtn-0"]').click();
   cy.get('textarea[data-test-subj="editorArea-0"]').should('not.exist');
+  cy.get(`a[href="${SAMPLE_URL}"]`).should('exist');
+  cy.get('code').contains('POST').should('exist');
 };
 
 const deleteNotebook = () => {
@@ -117,9 +119,6 @@ describe('Testing notebook actions', () => {
 
   it('Renders markdown', () => {
     makePopulatedParagraph();
-
-    cy.get(`a[href="${SAMPLE_URL}"]`).should('exist');
-    cy.get('code').contains('POST').should('exist');
     cy.get('td').contains('b2').should('exist');
   });
 });
@@ -132,6 +131,11 @@ describe('Test reporting integration if plugin installed', () => {
       skipOn($body.find('#reportingActionsButton').length <= 0);
     });
     makePopulatedParagraph();
+    cy.get('.euiContextMenuPanel').should('not.exist');
+    cy.get('button[data-test-subj="reporting-actions-button"]').should(
+      'be.visible'
+    );
+    cy.get('button[data-test-subj="reporting-actions-button"]').click();
   });
 
   after(() => {
@@ -139,29 +143,27 @@ describe('Test reporting integration if plugin installed', () => {
   });
 
   it('Create in-context PDF report from notebook', () => {
-    cy.get('button[data-test-subj="reporting-actions-button"]').click();
-    cy.get('.euiContextMenuPanel').should('be.visible');
     cy.get('button.euiContextMenuItem:nth-child(1)')
       .contains('Download PDF')
-      .click();
-    cy.get('body').contains('Please continue report generation in the new tab');
+      .click({ force: true });
+    cy.get('body')
+      .contains('Please continue report generation in the new tab')
+      .should('exist');
   });
 
   it('Create in-context PNG report from notebook', () => {
-    cy.get('button[data-test-subj="reporting-actions-button"]').click();
-    cy.get('.euiContextMenuPanel').should('be.visible');
     cy.get('button.euiContextMenuItem:nth-child(2)')
       .contains('Download PNG')
-      .click();
-    cy.get('body').contains('Please continue report generation in the new tab');
+      .click({ force: true });
+    cy.get('body')
+      .contains('Please continue report generation in the new tab')
+      .should('exist');
   });
 
   it('Create on-demand report definition from context menu', () => {
-    cy.get('button[data-test-subj="reporting-actions-button"]').click();
-    cy.get('.euiContextMenuPanel').should('be.visible');
     cy.get('button.euiContextMenuItem:nth-child(3)')
       .contains('Create report definition')
-      .click();
+      .click({ force: true });
     cy.location('pathname', { timeout: delayTime * 3 }).should(
       'include',
       '/reports-dashboards'
@@ -171,11 +173,9 @@ describe('Test reporting integration if plugin installed', () => {
   });
 
   it('View reports homepage from context menu', () => {
-    cy.get('button[data-test-subj="reporting-actions-button"]').click();
-    cy.get('.euiContextMenuPanel').should('be.visible');
     cy.get('button.euiContextMenuItem:nth-child(4)')
       .contains('View reports')
-      .click();
+      .click({ force: true });
     cy.location('pathname', { timeout: delayTime * 3 }).should(
       'include',
       '/reports-dashboards'

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -52,6 +52,7 @@ const makePopulatedParagraph = () => {
   cy.get('textarea[data-test-subj="editorArea-0"]').focus();
   cy.get('textarea[data-test-subj="editorArea-0"]').type(MARKDOWN_TEXT);
   cy.get('button[data-test-subj="runRefreshBtn-0"]').click();
+  cy.get('textarea[data-test-subj="editorArea-0"]').should('not.exist');
 };
 
 const deleteNotebook = () => {
@@ -116,7 +117,7 @@ describe('Testing notebook actions', () => {
 
   it('Renders markdown', () => {
     makePopulatedParagraph();
-    cy.get('textarea[data-test-subj="editorArea-0"]').should('not.exist');
+
     cy.get(`a[href="${SAMPLE_URL}"]`).should('exist');
     cy.get('code').contains('POST').should('exist');
     cy.get('td').contains('b2').should('exist');


### PR DESCRIPTION
### Description

Update notebooks and traces tests with dynamic wait. This helps to verify existence of DOM and only then clicking them

### Issues Resolved

We saw in the latest 2.19 RCs the notebooks test and trace services test fail for the below cases:

- https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.19.0/8251/linux/x64/tar/test-results/6948/integ-test/observabilityDashboards/with-security/cypress-screenshots/plugins/observability-dashboards/2_trace_analytics_services.spec.js/Testing+services+table+--+Opens+service+flyout+%28failed%29.png
- https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.19.0/8251/linux/x64/tar/test-results/6948/integ-test/observabilityDashboards/with-security/cypress-screenshots/plugins/observability-dashboards/6_notebooks.spec.js/Testing+notebook+actions+--+Creates+a+code+paragraph+--+after+each+hook+%28failed%29.png
- https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.19.0/8251/linux/x64/tar/test-results/6948/integ-test/observabilityDashboards/with-security/cypress-screenshots/plugins/observability-dashboards/6_notebooks.spec.js/Test+reporting+integration+if+plugin+installed+--+View+reports+homepage+from+context+menu+--+after+each+hook+%28failed%29.png

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
