### PR TITLE
Update notebooks test with delay for delete

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -73,7 +73,10 @@ const deleteAllNotebooks = () => {
     'DELETE',
     '/api/observability/notebooks/note/savedNotebook/*'
   ).as('deleteNotebook');
+  
+  cy.wait(delayTime*3);
   moveToNotebookHome();
+  cy.wait(delayTime*3);
 
   cy.get('[data-test-subj="globalLoadingIndicator"]').should('not.exist');
 


### PR DESCRIPTION
### Description
Update notebooks tests with wait for delete. This helps to ensure page renders before running delete flow.

### Issues Resolved
https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/2.19.0/8256/linux/arm64/tar/test-results/6964/integ-test/observabilityDashboards/with-security/cypress-screenshots/plugins/observability-dashboards/6_notebooks.spec.js/Test+reporting+integration+if+plugin+installed+--+View+reports+homepage+from+context+menu+--+after+all+hook+%28failed%29.png

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
