### PR TITLE
Add model selection in Flow Framework tests

### DIFF
--- a/cypress/integration/plugins/dashboards-flow-framework/create_workflow_spec.js
+++ b/cypress/integration/plugins/dashboards-flow-framework/create_workflow_spec.js
@@ -205,6 +205,8 @@ function createPreset(presetName) {
         .clear()
         .type(presetName.toLowerCase().replace(/\s/g, ''));
     });
+  cy.getElementByDataTestId('selectDeployedModel').should('be.visible').click();
+  cy.get('.euiSuperSelect__item').contains('BedRock').click();
   cy.getElementByDataTestId('quickConfigureCreateButton')
     .should('be.visible')
     .click();


### PR DESCRIPTION
### Description

https://github.com/opensearch-project/dashboards-flow-framework/pull/604 changed the logic such that a model _must_ be selected before creating presets, when the preset require them. This updates the tests to select the deployed model before trying to create.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
