### PR TITLE
[Maps Plugin] Fix disable check in Maps new home integ tests

### DIFF
--- a/cypress/integration/plugins/custom-import-map-dashboards/7_enable_new_home_ui.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/7_enable_new_home_ui.spec.js
@@ -21,7 +21,7 @@ describe('Add flights dataset saved object', function () {
     cy.get(
       '[data-test-subj="advancedSetting-editField-home:useNewHomePage"]'
     ).then(($switch) => {
-      if ($switch.attr('disabled') === 'disabled') {
+      if ($switch.prop('disabled')) {
         cy.log('Switch is disabled and cannot be changed.');
         this.skip(); // Skip all tests in this suite
       } else if ($switch.attr('aria-checked') === 'false') {
@@ -43,7 +43,7 @@ describe('Add flights dataset saved object', function () {
     cy.get(
       '[data-test-subj="advancedSetting-editField-home:useNewHomePage"]'
     ).then(($switch) => {
-      if ($switch.attr('disabled') === 'disabled') {
+      if ($switch.prop('disabled')) {
         cy.log('Switch is disabled and cannot be changed.');
       } else if ($switch.attr('aria-checked') === 'true') {
         cy.wrap($switch).click();


### PR DESCRIPTION
### Description
Fix overly strict disable check in flaky integ test added in #1587

When an element is disabled, the disabled property is not always set to `disabled='disabled'`. Sometimes it is set with `disabled=''` or as a property without a value, `disabled`. In those cases, the test would not be skipped and the integ test fails since the switch is still disabled.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
