### PR TITLE
[Flow Framework] Add containsModels param to handle custom/empty template

### DIFF
--- a/cypress/integration/plugins/dashboards-flow-framework/create_workflow_spec.js
+++ b/cypress/integration/plugins/dashboards-flow-framework/create_workflow_spec.js
@@ -168,15 +168,15 @@ describe('Creating Workflows Using Various Methods', () => {
   });
 
   it('Create workflow from hybrid search template', () => {
-    createPreset('Hybrid Search');
+    createPreset('Hybrid Search', true);
   });
 
   it('Create workflow from multimodal template', () => {
-    createPreset('Multimodal Search');
+    createPreset('Multimodal Search', true);
   });
 
   it('Create workflow from custom template', () => {
-    createPreset('Custom Search');
+    createPreset('Custom Search', false);
   });
 
   after(() => {
@@ -188,7 +188,7 @@ describe('Creating Workflows Using Various Methods', () => {
 });
 
 // Reusable fn to check the preset exists, and able to create it, and navigate to its details page.
-function createPreset(presetName) {
+function createPreset(presetName, containsModels = false) {
   cy.getElementByDataTestId('createWorkflowButton', { timeout: FF_TIMEOUT })
     .should('be.visible')
     .click();
@@ -205,8 +205,12 @@ function createPreset(presetName) {
         .clear()
         .type(presetName.toLowerCase().replace(/\s/g, ''));
     });
-  cy.getElementByDataTestId('selectDeployedModel').should('be.visible').click();
-  cy.get('.euiSuperSelect__item').contains('BedRock').click();
+  if (containsModels) {
+    cy.getElementByDataTestId('selectDeployedModel')
+      .should('be.visible')
+      .click();
+    cy.get('.euiSuperSelect__item').contains('BedRock').click();
+  }
   cy.getElementByDataTestId('quickConfigureCreateButton')
     .should('be.visible')
     .click();


### PR DESCRIPTION
### Description

Add containsModels param to handle custom/empty template. We don't want to search for models for this template, which does not require one.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
