### PR TITLE
Move search relevance card tests to search plugin

### DIFF
--- a/cypress/integration/plugins/search-relevance-dashboards/2_search_card.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/2_search_card.spec.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+
+const miscUtils = new MiscUtils(cy);
+const workspaceName = `test_workspace_search_${Math.random()
+  .toString(36)
+  .substring(7)}`;
+let workspaceId;
+let datasourceId;
+
+if (Cypress.env('WORKSPACE_ENABLED')) {
+  const createWorkspace = (datasourceId) => {
+    cy.createWorkspace({
+      name: workspaceName,
+      features: ['use-case-search'],
+      settings: {
+        permissions: {
+          library_write: { users: ['%me%'] },
+          write: { users: ['%me%'] },
+        },
+        ...(datasourceId ? { dataSources: [datasourceId] } : {}),
+      },
+    }).then((value) => {
+      workspaceId = value;
+    });
+  };
+
+  describe('Search card', () => {
+    before(() => {
+      cy.deleteWorkspaceByName(workspaceName);
+      if (Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')) {
+        cy.deleteAllDataSources();
+        cy.createDataSourceNoAuth().then((result) => {
+          datasourceId = result[0];
+          expect(datasourceId).to.be.a('string').that.is.not.empty;
+          createWorkspace(datasourceId);
+        });
+      } else {
+        createWorkspace();
+      }
+    });
+
+    after(() => {
+      if (workspaceId) {
+        cy.deleteWorkspaceById(workspaceId);
+      }
+      cy.deleteAllDataSources();
+    });
+
+    beforeEach(() => {
+      // Visit workspace overview page
+      miscUtils.visitPage(`w/${workspaceId}/app/search_overview`);
+      // wait for page load
+      cy.contains('h1', 'Overview');
+    });
+
+    it('Configure and evaluate search cards should display correctly', () => {
+      cy.contains('Compare search results').should('be.visible').click();
+      cy.url().should('contains', 'app/searchRelevance');
+    });
+  });
+}

--- a/cypress/utils/dashboards/workspace-plugin/test-cases/mds_workspace_search_overviews.cases.js
+++ b/cypress/utils/dashboards/workspace-plugin/test-cases/mds_workspace_search_overviews.cases.js
@@ -84,11 +84,6 @@ export const WorkspaceSearchOverviewTestCases = () => {
         cy.contains('h3', 'Neural sparse search').should('be.visible');
         cy.contains('h3', 'Hybrid search').should('be.visible');
       });
-
-      it('Configure and evaluate search cards display correctly', () => {
-        cy.contains('Compare search results').should('be.visible').click();
-        cy.url().should('contains', 'app/searchRelevance');
-      });
     });
   }
 };


### PR DESCRIPTION
### Description

Move search relevance card to search plugin

```
yarn cypress run --spec cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_search_overviews.spec.js

  Search workspace overview
    ✓ Set up search cards display correctly (19982ms)
    ✓ Different search techniques section display correctly (5940ms)

  2 passing (29s)
```

```
yarn cypress run --spec cypress/integration/plugins/search-relevance-dashboards/2_search_card.spec.js  

 Search card
    ✓ Configure and evaluate search cards should display correctly (20396ms)


  1 passing (23s)
```

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
