### PR TITLE
Improve the assertion in left navigation recent history test to avoid flakiness

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/left-navigation/left_navigation.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/left-navigation/left_navigation.spec.js
@@ -267,11 +267,13 @@ describe('Left navigation menu', () => {
 
       // open recent history dialog
       cy.get('.headerRecentItemsButton').should('exist').click();
-      cy.get('div[role="dialog"]').within(() => {
-        // dialog displays correct visited content
-        cy.contains(/Recent assets/).should('exist');
-        cy.contains(visualizationName).should('exist');
-      });
+      cy.get('div[role="dialog"][data-autofocus="true"]')
+        .should('have.class', 'euiPanel')
+        .within(() => {
+          // dialog displays correct visited content
+          cy.contains(/Recent assets/).should('exist');
+          cy.contains(visualizationName).should('exist');
+        });
 
       // back to dashboard
       cy.get('.left-navigation-wrapper').within(() => {
@@ -283,10 +285,14 @@ describe('Left navigation menu', () => {
       // wait for the page to be loaded
       cy.get('.application').should('exist');
       cy.get('.headerRecentItemsButton--loadingIndicator').should('not.exist');
+      // wait for the dashboards list loaded, avoid flaky loading icon
+      cy.getElementByTestId('dashboardLandingPage').within(() => {
+        cy.get('.euiBasicTable .euiTableRow').should('exist');
+      });
 
       // open recent history dialog again
       cy.get('.headerRecentItemsButton').should('exist').click();
-      cy.get('div[role="dialog"]').within(() => {
+      cy.get('div[role="dialog"][data-autofocus="true"]').within(() => {
         // click recent visited visualization in the dialog
         cy.contains(visualizationName).should('exist').click({ force: true });
       });


### PR DESCRIPTION
### Description

Add additional assertion to avoid flakiness.

This is caused by loading icon can appear/hide twice on the screen, once for loading the page (first loading) and once for loading the visualisation list (second loading). Between two loading period, the recent history button could appear on the screen for milliseconds and then being replaced by loading icon again by the second loading. 

In a rare slow network case, Cypress can potentially got the recent history button successfully during the interval between two loading period. However, when Cypress attempt to click on the button it already selected, the button itself could already disappear and being replaced by loading icon during the second loading, result in test failure.

This PR adds an additional assertion to ensure the page is fully loaded (i.e. the visualisation list finish loading completely) so that avoids the falkiness test result.

https://github.com/user-attachments/assets/e385ffb8-b840-4be6-8c10-a76fdeefdbf0

### Issues Resolved

N/A

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
