### PR TITLE
fix dashboards-observability 2.3 tests

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
@@ -68,6 +68,8 @@ describe('Testing traces table', () => {
   it('Searches correctly', () => {
     cy.get('input[type="search"]').focus().type(`${TRACE_ID}{enter}`);
     cy.get('.euiButton__text').contains('Refresh').click();
+    cy.intercept('POST', '/_dashboards/api/observability/trace_analytics/query').as('queryResult');
+    cy.wait('@queryResult');
     cy.contains(' (1)').should('exist');
     cy.get('.euiTableCellContent')
       .eq(11)

--- a/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
@@ -61,9 +61,11 @@ describe('Creating visualizations', () => {
       .type(PPL_VISUALIZATIONS_NAMES[0], {
         delay: 50,
       });
+    cy.intercept('POST', '/_dashboards/api/observability/event_analytics/saved_objects/vis').as('savedVisFetch');
     cy.get('[data-test-subj="eventExplorer__querySaveConfirm"]')
       .trigger('mouseover')
       .click();
+    cy.wait('@savedVisFetch');
     cy.wait(delay);
     cy.get('.euiToastHeader__title').contains('successfully').should('exist');
   });
@@ -133,10 +135,12 @@ describe('Testing panels table', () => {
       .trigger('mouseover')
       .click();
     cy.wait(delay);
+    cy.intercept('POST', '/_dashboards/api/observability/operational_panels/panels/clone').as('clonePanel');
     cy.get('.euiButton__text')
       .contains('Duplicate')
       .trigger('mouseover')
       .click();
+    cy.wait('@clonePanel');
     cy.wait(delay);
 
     cy.get('.euiCheckbox__input[title="Select this row"]')

--- a/cypress/utils/plugins/observability-dashboards/constants.js
+++ b/cypress/utils/plugins/observability-dashboards/constants.js
@@ -10,7 +10,7 @@ export const delayTime = 1500;
 export const TRACE_ID = '8832ed6abbb2a83516461960c89af49d';
 export const SPAN_ID = 'a673bc074b438374';
 export const SERVICE_NAME = 'frontend-client';
-export const SERVICE_SPAN_ID = '7df5609a6d104736';
+export const SERVICE_SPAN_ID = 'a43d5066600179db';
 
 export const testIndexDataSet = [
   {


### PR DESCRIPTION
### Description

To fix `2_trace_analytics_services`, SERVICE_SPAN_ID (which only only used for this one instance) was changed to be the first sample trace instead of the last, hidden one.

To fix `3_trace_analytics_traces`, the network call outgoing from the refresh button was intercepted and waited on for completion.

To fix `4_panels_space`, an intercept for the saved object visualization wait waited on, and for a later failing point, a clone panel network call was intercepted and waited on.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
