### PR TITLE
[Bug]Fix flakey reports test in 2.7

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -17,6 +17,24 @@ describe('Cypress', () => {
 
     cy.wait(12500);
 
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
+    ).as('dashboard');
+
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/reporting/getReportSource/visualization`
+    ).as('visualization');
+
+    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
+      'search'
+    );
+
+    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
+      'notebook'
+    );
+
     cy.get('#reportDefinitionDetailsLink').first().click({ force: true });
 
     cy.get('#editReportDefinitionButton').should('exist');
@@ -26,14 +44,23 @@ describe('Cypress', () => {
     cy.url().should('include', 'edit');
 
     cy.wait(1000);
+    cy.wait('@dashboard');
+    cy.wait('@visualization');
+    cy.wait('@search');
+    cy.wait('@notebook');
 
     // update the report name
-    cy.get('#reportSettingsName').type(' update name');
+    cy.get('#reportSettingsName').type('{selectall}{backspace} update name');
 
     // update report description
-    cy.get('#reportSettingsDescription').type(' update description');
+    cy.get('#reportSettingsDescription').type(
+      '{selectall}{backspace} update description'
+    );
 
-    cy.get('#editReportDefinitionButton').click({ force: true });
+    cy.get('#editReportDefinitionButton')
+      .contains('Save Changes')
+      .trigger('mouseover')
+      .click({ force: true });
 
     cy.wait(12500);
 
@@ -52,6 +79,24 @@ describe('Cypress', () => {
 
     cy.wait(12500);
 
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
+    ).as('dashboard');
+
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/reporting/getReportSource/visualization`
+    ).as('visualization');
+
+    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
+      'search'
+    );
+
+    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
+      'notebook'
+    );
+
     cy.get('#reportDefinitionDetailsLink').first().click();
 
     cy.get('#editReportDefinitionButton').should('exist');
@@ -61,12 +106,20 @@ describe('Cypress', () => {
     cy.url().should('include', 'edit');
 
     cy.wait(1000);
+
+    cy.wait('@dashboard');
+    cy.wait('@visualization');
+    cy.wait('@search');
+    cy.wait('@notebook');
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(2)').click({
       force: true,
     });
 
     cy.get('#Schedule').check({ force: true });
-    cy.get('#editReportDefinitionButton').click({ force: true });
+    cy.get('#editReportDefinitionButton')
+      .contains('Save Changes')
+      .trigger('mouseover')
+      .click({ force: true });
 
     cy.wait(12500);
 
@@ -85,6 +138,24 @@ describe('Cypress', () => {
 
     cy.wait(12500);
 
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
+    ).as('dashboard');
+
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/reporting/getReportSource/visualization`
+    ).as('visualization');
+
+    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
+      'search'
+    );
+
+    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
+      'notebook'
+    );
+
     cy.get('#reportDefinitionDetailsLink').first().click();
 
     cy.get('#editReportDefinitionButton').should('exist');
@@ -95,11 +166,19 @@ describe('Cypress', () => {
 
     cy.wait(1000);
 
+    cy.wait('@dashboard');
+    cy.wait('@visualization');
+    cy.wait('@search');
+    cy.wait('@notebook');
+
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(1)').click({
       force: true,
     });
 
-    cy.get('#editReportDefinitionButton').click({ force: true });
+    cy.get('#editReportDefinitionButton')
+      .contains('Save Changes')
+      .trigger('mouseover')
+      .click({ force: true });
 
     cy.wait(12500);
 

--- a/cypress/integration/plugins/reports-dashboards/04-download.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/04-download.spec.js
@@ -110,6 +110,9 @@ describe('Cypress', () => {
 
   it('Download from Report definition details page', () => {
     // create an on-demand report definition
+    cy.intercept('POST', '/_dashboards/api/reporting/generateReport/*').as(
+      'generateReport'
+    );
 
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
       waitForGetTenant: true,
@@ -134,6 +137,6 @@ describe('Cypress', () => {
 
     cy.get('#generateReportFromDetailsFileFormat').click({ force: true });
 
-    cy.get('#downloadInProgressLoadingModal');
+    cy.wait('@generateReport').its('response.statusCode').should('eq', 200);
   });
 });


### PR DESCRIPTION
### Description

Updated edit spec and download test in 2.7(match gitfarm)
Cypress ✓ Download from reporting homepage (22386ms) 2025-02-21 20:29:25.546 Cypress[60505:67188855] +[IMKClient subclass]: chose IMKClient_Modern 2025-02-21 20:29:25.546 Cypress[60505:67188855] +[IMKInputSession subclass]: chose IMKInputSession_Modern ✓ Download pdf from in-context menu (6225ms) ✓ Download png from in-context menu (6357ms) ✓ Download csv from saved search in-context menu (18554ms) ✓ Download from Report definition details page (63990ms)

5 passing (2m)

(Results)

┌────────────────────────────────────────────────────────────────────────────────────────────────┐ │ Tests: 5 │ │ Passing: 5 │ │ Failing: 0 │ │ Pending: 0 │ │ Skipped: 0 │ │ Screenshots: 0 │ │ Video: true │ │ Duration: 1 minute, 58 seconds │ │ Spec Ran: plugins/reports-dashboards/04-download.spec.js │ └────────────────────────────────────────────────────────────────────────────────────────────────┘

(Video)

Started processing: Compressing to 32 CRF Finished processing: /Users/sumukhhs/Desktop/opensearch-2.12.0/OpenSearch-Dashbo (6 seconds) ards/plugins/opensearch-dashboards-functional-test/cypress/

         videos/plugins/reports-dashboards/04-download.spec.js.mp4                 
====================================================================================================

(Run Finished)

Spec Tests Passing Failing Pending Skipped ┌────────────────────────────────────────────────────────────────────────────────────────────────┐ │ ✔ plugins/reports-dashboards/04-downl 01:58 5 5 - - - │ │ oad.spec.js │ └────────────────────────────────────────────────────────────────────────────────────────────────┘ ✔ All specs passed! 01:58 5 5

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
