### PR TITLE
dashboards-observability flakey test mitigation

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
@@ -66,9 +66,15 @@ describe('Testing traces table', () => {
   });
 
   it('Searches correctly', () => {
-    cy.get('input[type="search"]').focus().type(`${TRACE_ID}{enter}`);
-    cy.get('.euiButton__text').contains('Refresh').click();
-    cy.intercept('POST', '/_dashboards/api/observability/trace_analytics/query').as('queryResult');
+    cy.intercept(
+      'POST',
+      '/_dashboards/api/observability/trace_analytics/query'
+    ).as('queryResult');
+    cy.get('input[type="search"]')
+      .focus()
+      .type(`${TRACE_ID}{enter}`, { delay: 100 });
+    cy.get('input[type="search"]').should('have.value', TRACE_ID);
+    cy.get('[data-test-subj="superDatePickerApplyTimeButton"]').click();
     cy.wait('@queryResult');
     cy.contains(' (1)').should('exist');
     cy.get('.euiTableCellContent')

--- a/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
@@ -41,6 +41,11 @@ describe('Creating visualizations', () => {
   });
 
   it('Create first visualization in event analytics', () => {
+    cy.intercept(
+      'POST',
+      '/_dashboards/api/observability/event_analytics/saved_objects/vis'
+    ).as('savedVisFetch');
+    cy.intercept('POST', '/_dashboards/api/ppl/search').as('searchFinished');
     cy.get('[id^=autocomplete-textarea]').focus().type(PPL_VISUALIZATIONS[0], {
       delay: 50,
     });
@@ -52,6 +57,7 @@ describe('Creating visualizations', () => {
       .trigger('mouseover')
       .click();
     cy.wait(delay * 2);
+    cy.wait('@searchFinished');
     cy.get('[data-test-subj="eventExplorer__saveManagementPopover"]')
       .trigger('mouseover')
       .click();
@@ -61,10 +67,6 @@ describe('Creating visualizations', () => {
       .type(PPL_VISUALIZATIONS_NAMES[0], {
         delay: 50,
       });
-    cy.intercept(
-      'POST',
-      '/_dashboards/api/observability/event_analytics/saved_objects/vis'
-    ).as('savedVisFetch');
     cy.get('[data-test-subj="eventExplorer__querySaveConfirm"]')
       .trigger('mouseover')
       .click();

--- a/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/4_panels.spec.js
@@ -61,7 +61,10 @@ describe('Creating visualizations', () => {
       .type(PPL_VISUALIZATIONS_NAMES[0], {
         delay: 50,
       });
-    cy.intercept('POST', '/_dashboards/api/observability/event_analytics/saved_objects/vis').as('savedVisFetch');
+    cy.intercept(
+      'POST',
+      '/_dashboards/api/observability/event_analytics/saved_objects/vis'
+    ).as('savedVisFetch');
     cy.get('[data-test-subj="eventExplorer__querySaveConfirm"]')
       .trigger('mouseover')
       .click();
@@ -135,7 +138,10 @@ describe('Testing panels table', () => {
       .trigger('mouseover')
       .click();
     cy.wait(delay);
-    cy.intercept('POST', '/_dashboards/api/observability/operational_panels/panels/clone').as('clonePanel');
+    cy.intercept(
+      'POST',
+      '/_dashboards/api/observability/operational_panels/panels/clone'
+    ).as('clonePanel');
     cy.get('.euiButton__text')
       .contains('Duplicate')
       .trigger('mouseover')

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -382,7 +382,12 @@ describe('Testing paragraphs', () => {
 
 describe('clean up all test data', () => {
   it('Delete visualizations from event analytics', () => {
+    cy.intercept(
+      'GET',
+      '*/api/observability/event_analytics/saved_objects?*'
+    ).as('savedObjSearch');
     moveToEventsHome();
+    cy.wait('@savedObjSearch');
     cy.get('[data-test-subj="tablePaginationPopoverButton"]')
       .trigger('mouseover')
       .click();


### PR DESCRIPTION
### Description

Added a typing delay to traces test as to not miss letters.

Added a ppl search call intercept for panels, for the entire page to load.

Added a saved object search intercept for it to finish in notebooks test clean up.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
