### PR TITLE
query workbench intercept ppl query network call

### DIFF
--- a/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
+++ b/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js
@@ -83,6 +83,7 @@ describe('Test PPL UI', () => {
   });
 
   it('Test full screen view', () => {
+    cy.route2('**/api/sql_console/pplquery').as('pplQuery');
     cy.get('.euiButton__text').contains('Full screen view').should('not.exist');
     cy.get('.euiTitle').contains('Query Workbench').should('exist');
 
@@ -90,6 +91,7 @@ describe('Test PPL UI', () => {
     cy.wait(delay);
     cy.get('.euiButton__text').contains('Run').click({ force: true });
     cy.wait(delay);
+    cy.wait('@pplQuery');
     cy.get('.euiButton__text').contains('Full screen view').click({ force: true });
 
     cy.get('.euiTitle').should('not.exist');


### PR DESCRIPTION
### Description

Fixes the query workbench test to intercept the ppl query network call for the results to disseminate and the needed element to appear.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
