### PR TITLE
fix dashboards-maps integ tests by adding a visit to base url

### DIFF
--- a/cypress/integration/plugins/custom-import-map-dashboards/0_add_saved_object.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/0_add_saved_object.js
@@ -11,6 +11,8 @@ const miscUtils = new MiscUtils(cy);
 
 describe('Add flights dataset saved object', () => {
   before(() => {
+    // visit base url
+    cy.visit(Cypress.config().baseUrl, { timeout: 10000 });
     CURRENT_TENANT.newTenant = 'global';
     cy.deleteAllIndices();
     miscUtils.addSampleData();
@@ -26,6 +28,7 @@ describe('Add flights dataset saved object', () => {
     cy.contains(
       '[Flights] Flights Status on Maps Destination Location'
     ).click();
+    cy.wait(1000);
     cy.get('[data-test-subj="layerControlPanel"]').should(
       'contain',
       'Flights On Time'

--- a/cypress/integration/plugins/custom-import-map-dashboards/1_import_vector_map_tab.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/1_import_vector_map_tab.spec.js
@@ -13,6 +13,8 @@ const miscUtils = new MiscUtils(cy);
 
 describe('Verify the presence of import custom map tab in region map plugin', () => {
   before(() => {
+    // visit base url
+    cy.visit(Cypress.config().baseUrl, { timeout: 10000 });
     CURRENT_TENANT.newTenant = 'global';
     cy.deleteAllIndices();
     miscUtils.addSampleData();

--- a/cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js
@@ -11,6 +11,8 @@ const miscUtils = new MiscUtils(cy);
 
 describe('Default OpenSearch base map layer', () => {
   before(() => {
+    // visit base url
+    cy.visit(Cypress.config().baseUrl, { timeout: 10000 });
     CURRENT_TENANT.newTenant = 'global';
     cy.deleteAllIndices();
     miscUtils.addSampleData();

--- a/cypress/integration/plugins/custom-import-map-dashboards/3_add_saved_object.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/3_add_saved_object.spec.js
@@ -11,6 +11,8 @@ const miscUtils = new MiscUtils(cy);
 
 describe('Add flights dataset saved object', () => {
   before(() => {
+    // visit base url
+    cy.visit(Cypress.config().baseUrl, { timeout: 10000 });
     CURRENT_TENANT.newTenant = 'global';
     cy.deleteAllIndices();
     miscUtils.addSampleData();

--- a/cypress/integration/plugins/custom-import-map-dashboards/4_documentsLayer.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/4_documentsLayer.spec.js
@@ -11,6 +11,8 @@ const miscUtils = new MiscUtils(cy);
 
 describe('Documents layer', () => {
   before(() => {
+    // visit base url
+    cy.visit(Cypress.config().baseUrl, { timeout: 10000 });
     CURRENT_TENANT.newTenant = 'global';
     cy.deleteAllIndices();
     miscUtils.addSampleData();

--- a/cypress/integration/plugins/custom-import-map-dashboards/5_add_map_to_dashboard.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/5_add_map_to_dashboard.spec.js
@@ -11,6 +11,8 @@ const miscUtils = new MiscUtils(cy);
 
 describe('Add map to dashboard', () => {
   before(() => {
+    // visit base url
+    cy.visit(Cypress.config().baseUrl, { timeout: 10000 });
     CURRENT_TENANT.newTenant = 'global';
     cy.deleteAllIndices();
     miscUtils.addSampleData();

--- a/cypress/integration/plugins/custom-import-map-dashboards/6_geojson_file_upload.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/6_geojson_file_upload.spec.js
@@ -12,6 +12,8 @@ const miscUtils = new MiscUtils(cy);
 
 describe('Verify successful custom geojson file upload', () => {
   before(() => {
+    // visit base url
+    cy.visit(Cypress.config().baseUrl, { timeout: 10000 });
     CURRENT_TENANT.newTenant = 'global';
     cy.deleteAllIndices();
     miscUtils.addSampleData();

--- a/cypress/integration/plugins/custom-import-map-dashboards/7_enable_new_home_ui.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/7_enable_new_home_ui.spec.js
@@ -11,6 +11,8 @@ const miscUtils = new MiscUtils(cy);
 
 describe('Add flights dataset saved object', function () {
   before(function () {
+    // visit base url
+    cy.visit(Cypress.config().baseUrl, { timeout: 10000 });
     CURRENT_TENANT.newTenant = 'global';
     cy.deleteAllIndices();
     miscUtils.addSampleData();


### PR DESCRIPTION
### Description
dashboards-maps integration tests failed to load home page when using cypress while the home page is loading normally without cypress.
- adding cy.visit to base url in before function to fix the issue
- all integ tests passed

<img width="1026" alt="cypress not loading" src="https://github.com/user-attachments/assets/5da298f4-1774-4079-a6d8-41905f1c5d11" />
 


### Issues Resolved

https://github.com/opensearch-project/dashboards-maps/issues/710

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
