### PR TITLE
Fix Discover Saved Search Test

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
@@ -66,6 +66,7 @@ describe('discover app', { scrollBehavior: false }, () => {
     after(() => {
       cy.get('[data-test-subj~="filter-key-extension.raw"]').click();
       cy.getElementByTestId(`deleteFilter`).click();
+      cy.clearTopNavQuery(); // clear the query before we proceed
     });
     it('should persist across refresh', function () {
       // Set up query and filter


### PR DESCRIPTION
### Description

Fix `should reload the saved search with persisted query to show the initial hit count` tests which was failing due to previous test suite not cleaning up the query bar upon completion.

![image](https://github.com/user-attachments/assets/1f32f80e-d871-4956-9389-d11209a62690)


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
