### PR TITLE
ReportingDashboard - Test fix

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/04-download.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/04-download.spec.js
@@ -50,7 +50,7 @@ describe('Cypress', () => {
     });
 
     // download PDF
-    cy.get('#generatePDF > span:nth-child(1) > span:nth-child(2)').click({
+    cy.get('#generatePDF').click({
       force: true,
     });
 


### PR DESCRIPTION
### Description
Fix reporting dashboard test,
Download pdf from in-context menu
was failing because cypress was looking for nested structure.

Now passing:
<img width="747" alt="FixedTest" src="https://github.com/user-attachments/assets/b523d9ab-3eac-480f-a11a-9f72cf924e84" />


### Issues Resolved

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
