### PR TITLE
[Manual backport] Feat: add tests for alert summary, discovery summary and anonymous detect

### DIFF
--- a/.github/workflows/assistant-release-e2e-workflow.yml
+++ b/.github/workflows/assistant-release-e2e-workflow.yml
@@ -56,7 +56,7 @@ jobs:
     with:
       test-name: dashboards assistant
       test-command: env CYPRESS_DISABLE_LOCAL_CLUSTER=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true CYPRESS_DASHBOARDS_ASSISTANT_ENABLED=true CYPRESS_WORKSPACE_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/dashboards-assistant/mds_query_enhancements*.js'
-      osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --data_source.hideLocalCluster=true --assistant.chat.enabled=true --uiSettings.overrides.home:useNewHomePage=true --uiSettings.overrides.query:enhancements:enabled=true --workspace.enabled=true --savedObjects.permission.enabled=true --assistant.text2viz.enabled=true --opensearchDashboards.dashboardAdmin.users='["admin"]' --opensearch_security.multitenancy.enabled=false
+      osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --data_source.hideLocalCluster=true --assistant.chat.enabled=true --assistant.alertInsight.enabled=true --assistant.smartAnomalyDetector.enabled=true --queryEnhancements.queryAssist.summary.enabled=true --uiSettings.overrides.home:useNewHomePage=true --uiSettings.overrides.query:enhancements:enabled=true --workspace.enabled=true --savedObjects.permission.enabled=true --assistant.text2viz.enabled=true  --opensearchDashboards.dashboardAdmin.users='["admin"]' --opensearch_security.multitenancy.enabled=false
       security-enabled: true
       artifact-name-suffix: "-with-query-enhancements"
 

--- a/cypress/fixtures/plugins/alerting-dashboards-plugin/sample_query_level_monitor_for_alert_summary.json
+++ b/cypress/fixtures/plugins/alerting-dashboards-plugin/sample_query_level_monitor_for_alert_summary.json
@@ -1,0 +1,95 @@
+{
+    "name": "alert_summary_test_monitor",
+    "type": "monitor",
+    "monitor_type": "query_level_monitor",
+    "enabled": true,
+    "schedule": {
+      "period": {
+        "interval": 1,
+        "unit": "MINUTES"
+      }
+    },
+    "inputs": [
+      {
+        "search": {
+          "indices": [
+            "opensearch_dashboards_sample_data_ecommerce"
+          ],
+          "query": {
+            "size": 0,
+            "aggregations": {},
+            "query": {
+              "bool": {
+                "filter": [
+                  {
+                    "range": {
+                      "order_date": {
+                        "gte": "{{period_end}}||-1h",
+                        "lte": "{{period_end}}",
+                        "format": "epoch_millis"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    ],
+    "triggers": [
+      {
+        "name": "alert_summary_test_monitor",
+        "severity": "1",
+        "condition": {
+          "script": {
+            "lang": "painless",
+            "source": "ctx.results[0].hits.total.value > 0"
+          }
+        },
+        "min_time_between_executions": null,
+        "rolling_window_size": null
+      }
+    ],
+    "ui_metadata": {
+      "schedule": {
+        "timezone": null,
+        "frequency": "interval",
+        "period": {
+          "interval": 1,
+          "unit": "MINUTES"
+        },
+        "daily": 0,
+        "weekly": {
+          "mon": false,
+          "tue": false,
+          "wed": false,
+          "thur": false,
+          "fri": false,
+          "sat": false,
+          "sun": false
+        },
+        "monthly": {
+          "type": "day",
+          "day": 1
+        },
+        "cronExpression": "0 */1 * * *"
+      },
+      "monitor_type": "query_level_monitor",
+      "search": {
+        "searchType": "graph",
+        "timeField": "order_date",
+        "aggregations": [],
+        "groupBy": [],
+        "bucketValue": 1,
+        "bucketUnitOfTime": "h",
+        "filters": []
+      },
+      "triggers": {
+        "asd": {
+          "value": 0,
+          "enum": "ABOVE"
+        }
+      }
+    }
+  }

--- a/cypress/fixtures/plugins/dashboards-assistant/data2summary-response.json
+++ b/cypress/fixtures/plugins/dashboards-assistant/data2summary-response.json
@@ -1,0 +1,6 @@
+{
+    "completion":
+      "The sample data indicates that there was 1 unique customer who placed orders this week. \n 1. The sample data indicates that there was 1 unique customer who placed orders this week. \n 2. The low number of unique customers placing orders in the current week could be affected by factors such as seasonality, promotions, or changes in the customer base, but further analysis of the full data set would be needed to determine if this is a typical trend or an anomaly. \n 3. The data represents a small sample and may not be representative of the overall customer base or order patterns, so additional data would be required to draw more meaningful conclusions.",
+    "stop_reason": "stop_sequence",
+    "stop": "\n\nHuman:"
+  }

--- a/cypress/fixtures/plugins/dashboards-assistant/flow-templates/data2summary.json
+++ b/cypress/fixtures/plugins/dashboards-assistant/flow-templates/data2summary.json
@@ -1,0 +1,98 @@
+{
+    "name": "Cypress-register-data2summary-agent",
+    "description": "Cypress Flow template",
+    "use_case": "REGISTER_AGENT",
+    "version": {
+      "template": "1.0.0",
+      "compatibility": ["2.12.0", "3.0.0"]
+    },
+    "workflows": {
+      "provision": {
+        "user_params": {},
+        "nodes": [
+          {
+            "id": "create_connector_1",
+            "type": "create_connector",
+            "previous_node_inputs": {},
+            "user_inputs": {
+              "version": "1",
+              "name": "Claude instant runtime data2summary Connector",
+              "protocol": "aws_sigv4",
+              "description": "The connector to BedRock service for claude model",
+              "actions": [
+                {
+                  "headers": {
+                    "x-amz-content-sha256": "required",
+                    "content-type": "application/json"
+                  },
+                  "method": "POST",
+                  "request_body": "{\"prompt\":\"${parameters.prompt}\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature},  \"anthropic_version\":\"${parameters.anthropic_version}\" }",
+                  "action_type": "predict",
+                  "url": "http://127.0.0.1:3000"
+                }
+              ],
+              "credential": {
+                "access_key": "<key>",
+                "secret_key": "<value>"
+              },
+              "parameters": {
+                "endpoint": "bedrock-runtime.us-west-2.amazonaws.com",
+                "content_type": "application/json",
+                "auth": "Sig_V4",
+                "max_tokens_to_sample": "8000",
+                "service_name": "bedrock",
+                "temperature": "0.0001",
+                "response_filter": "$.completion",
+                "region": "us-west-2",
+                "anthropic_version": "bedrock-2023-05-31"
+              }
+            }
+          },
+          {
+            "id": "register_model_2",
+            "type": "register_remote_model",
+            "previous_node_inputs": {
+              "create_connector_1": "connector_id"
+            },
+            "user_inputs": {
+              "description": "test model",
+              "deploy": true,
+              "name": "claude-instant-data2summary"
+            }
+          },
+          {
+            "id": "ml_model_tool",
+            "type": "create_tool",
+            "previous_node_inputs": {
+              "register_model_2": "model_id"
+            },
+            "user_inputs": {
+              "parameters": {
+                "prompt": "data2summary instruction agent prompt"
+              },
+              "description": "A general tool to answer any question.",
+              "alias": "language_model_tool",
+              "include_output_in_agent_response": true,
+              "name": "data2summaryModelTool",
+              "type": "MLModelTool"
+            }
+          },
+          {
+            "id": "os_data2summary",
+            "type": "register_agent",
+            "previous_node_inputs": {
+              "register_model_2": "model_id",
+              "ml_model_tool": "tools"
+            },
+            "user_inputs": {
+              "parameters": {},
+              "type": "flow",
+              "name": "Query discover Summary Agent",
+              "description": "this is a discover result summary agent",
+              "tools_order": ["ml_model_tool"]
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/cypress/fixtures/plugins/dashboards-assistant/flow-templates/suggest-ad.json
+++ b/cypress/fixtures/plugins/dashboards-assistant/flow-templates/suggest-ad.json
@@ -1,0 +1,98 @@
+{
+    "name": "Cypress-register-data2summary-agent",
+    "description": "Cypress Flow template",
+    "use_case": "REGISTER_AGENT",
+    "version": {
+      "template": "1.0.0",
+      "compatibility": ["2.12.0", "3.0.0"]
+    },
+    "workflows": {
+      "provision": {
+        "user_params": {},
+        "nodes": [
+          {
+            "id": "create_connector_1",
+            "type": "create_connector",
+            "previous_node_inputs": {},
+            "user_inputs": {
+              "version": "1",
+              "name": "Claude instant runtime suggest ad Connector",
+              "protocol": "aws_sigv4",
+              "description": "The connector to BedRock service for claude model",
+              "actions": [
+                {
+                  "headers": {
+                    "x-amz-content-sha256": "required",
+                    "content-type": "application/json"
+                  },
+                  "method": "POST",
+                  "request_body": "{\"prompt\":\"${parameters.prompt}\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature},  \"anthropic_version\":\"${parameters.anthropic_version}\" }",
+                  "action_type": "predict",
+                  "url": "http://127.0.0.1:3000"
+                }
+              ],
+              "credential": {
+                "access_key": "<key>",
+                "secret_key": "<value>"
+              },
+              "parameters": {
+                "endpoint": "bedrock-runtime.us-west-2.amazonaws.com",
+                "content_type": "application/json",
+                "auth": "Sig_V4",
+                "max_tokens_to_sample": "8000",
+                "service_name": "bedrock",
+                "temperature": "0.0001",
+                "response_filter": "$.completion",
+                "region": "us-west-2",
+                "anthropic_version": "bedrock-2023-05-31"
+              }
+            }
+          },
+          {
+            "id": "register_model_2",
+            "type": "register_remote_model",
+            "previous_node_inputs": {
+              "create_connector_1": "connector_id"
+            },
+            "user_inputs": {
+              "description": "test model",
+              "deploy": true,
+              "name": "claude-instant-suggest-ad"
+            }
+          },
+          {
+            "id": "ml_model_tool",
+            "type": "create_tool",
+            "previous_node_inputs": {
+              "register_model_2": "model_id"
+            },
+            "user_inputs": {
+              "parameters": {
+                "prompt": "suggest_ad instruction agent prompt"
+              },
+              "description": "A general tool to answer any question.",
+              "alias": "language_model_tool",
+              "include_output_in_agent_response": true,
+              "name": "CreateAnomalyDetectorTool",
+              "type": "MLModelTool"
+            }
+          },
+          {
+            "id": "os_suggest_ad",
+            "type": "register_agent",
+            "previous_node_inputs": {
+              "register_model_2": "model_id",
+              "ml_model_tool": "tools"
+            },
+            "user_inputs": {
+              "parameters": {},
+              "type": "flow",
+              "name": "Anomaly detector suggestion agent",
+              "description": "this is the anomaly detector suggestion agent",
+              "tools_order": ["ml_model_tool"]
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/cypress/fixtures/plugins/dashboards-assistant/flow-templates/summary.json
+++ b/cypress/fixtures/plugins/dashboards-assistant/flow-templates/summary.json
@@ -1,0 +1,98 @@
+{
+    "name": "Cypress-register-data2summary-agent",
+    "description": "Cypress Flow template",
+    "use_case": "REGISTER_AGENT",
+    "version": {
+      "template": "1.0.0",
+      "compatibility": ["2.12.0", "3.0.0"]
+    },
+    "workflows": {
+      "provision": {
+        "user_params": {},
+        "nodes": [
+          {
+            "id": "create_connector_1",
+            "type": "create_connector",
+            "previous_node_inputs": {},
+            "user_inputs": {
+              "version": "1",
+              "name": "Claude instant runtime summary Connector",
+              "protocol": "aws_sigv4",
+              "description": "The connector to BedRock service for claude model",
+              "actions": [
+                {
+                  "headers": {
+                    "x-amz-content-sha256": "required",
+                    "content-type": "application/json"
+                  },
+                  "method": "POST",
+                  "request_body": "{\"prompt\":\"${parameters.prompt}\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature},  \"anthropic_version\":\"${parameters.anthropic_version}\" }",
+                  "action_type": "predict",
+                  "url": "http://127.0.0.1:3000"
+                }
+              ],
+              "credential": {
+                "access_key": "<key>",
+                "secret_key": "<value>"
+              },
+              "parameters": {
+                "endpoint": "bedrock-runtime.us-west-2.amazonaws.com",
+                "content_type": "application/json",
+                "auth": "Sig_V4",
+                "max_tokens_to_sample": "8000",
+                "service_name": "bedrock",
+                "temperature": "0.0001",
+                "response_filter": "$.completion",
+                "region": "us-west-2",
+                "anthropic_version": "bedrock-2023-05-31"
+              }
+            }
+          },
+          {
+            "id": "register_model_2",
+            "type": "register_remote_model",
+            "previous_node_inputs": {
+              "create_connector_1": "connector_id"
+            },
+            "user_inputs": {
+              "description": "test model",
+              "deploy": true,
+              "name": "claude-instant-suggest-ad"
+            }
+          },
+          {
+            "id": "ml_model_tool",
+            "type": "create_tool",
+            "previous_node_inputs": {
+              "register_model_2": "model_id"
+            },
+            "user_inputs": {
+              "parameters": {
+                "prompt": "alert summary instruction agent prompt"
+              },
+              "description": "A general tool to answer any question.",
+              "alias": "language_model_tool",
+              "include_output_in_agent_response": true,
+              "name": "MLModelTool",
+              "type": "MLModelTool"
+            }
+          },
+          {
+            "id": "os_summary",
+            "type": "register_agent",
+            "previous_node_inputs": {
+              "register_model_2": "model_id",
+              "ml_model_tool": "tools"
+            },
+            "user_inputs": {
+              "parameters": {},
+              "type": "flow",
+              "name": "Alert summary agent",
+              "description": "this is the alert summary agent",
+              "tools_order": ["ml_model_tool"]
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/cypress/fixtures/plugins/dashboards-assistant/flow-templates/summary_with_log_pattern.json
+++ b/cypress/fixtures/plugins/dashboards-assistant/flow-templates/summary_with_log_pattern.json
@@ -1,0 +1,98 @@
+{
+    "name": "Cypress-register-data2summary-agent",
+    "description": "Cypress Flow template",
+    "use_case": "REGISTER_AGENT",
+    "version": {
+      "template": "1.0.0",
+      "compatibility": ["2.12.0", "3.0.0"]
+    },
+    "workflows": {
+      "provision": {
+        "user_params": {},
+        "nodes": [
+          {
+            "id": "create_connector_1",
+            "type": "create_connector",
+            "previous_node_inputs": {},
+            "user_inputs": {
+              "version": "1",
+              "name": "Claude instant runtime summary with log pattern Connector",
+              "protocol": "aws_sigv4",
+              "description": "The connector to BedRock service for claude model",
+              "actions": [
+                {
+                  "headers": {
+                    "x-amz-content-sha256": "required",
+                    "content-type": "application/json"
+                  },
+                  "method": "POST",
+                  "request_body": "{\"prompt\":\"${parameters.prompt}\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature},  \"anthropic_version\":\"${parameters.anthropic_version}\" }",
+                  "action_type": "predict",
+                  "url": "http://127.0.0.1:3000"
+                }
+              ],
+              "credential": {
+                "access_key": "<key>",
+                "secret_key": "<value>"
+              },
+              "parameters": {
+                "endpoint": "bedrock-runtime.us-west-2.amazonaws.com",
+                "content_type": "application/json",
+                "auth": "Sig_V4",
+                "max_tokens_to_sample": "8000",
+                "service_name": "bedrock",
+                "temperature": "0.0001",
+                "response_filter": "$.completion",
+                "region": "us-west-2",
+                "anthropic_version": "bedrock-2023-05-31"
+              }
+            }
+          },
+          {
+            "id": "register_model_2",
+            "type": "register_remote_model",
+            "previous_node_inputs": {
+              "create_connector_1": "connector_id"
+            },
+            "user_inputs": {
+              "description": "test model",
+              "deploy": true,
+              "name": "claude-instant-suggest-ad"
+            }
+          },
+          {
+            "id": "ml_model_tool",
+            "type": "create_tool",
+            "previous_node_inputs": {
+              "register_model_2": "model_id"
+            },
+            "user_inputs": {
+              "parameters": {
+                "prompt": "alert summary with log pattern instruction agent prompt"
+              },
+              "description": "A general tool to answer any question.",
+              "alias": "language_model_tool",
+              "include_output_in_agent_response": true,
+              "name": "MLModelTool",
+              "type": "MLModelTool"
+            }
+          },
+          {
+            "id": "os_summary_with_log_pattern",
+            "type": "register_agent",
+            "previous_node_inputs": {
+              "register_model_2": "model_id",
+              "ml_model_tool": "tools"
+            },
+            "user_inputs": {
+              "parameters": {},
+              "type": "flow",
+              "name": "Alert summary with log pattern agent",
+              "description": "this is the alert summary with log pattern agent",
+              "tools_order": ["ml_model_tool"]
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/cypress/fixtures/plugins/dashboards-assistant/suggest-ad-response.json
+++ b/cypress/fixtures/plugins/dashboards-assistant/suggest-ad-response.json
@@ -1,0 +1,6 @@
+{
+    "completion":
+      "{\"index\":\"opensearch_dashboards_sample_data_logs\",\"categoryField\":\"ip\",\"aggregationField\":\"bytes,memory,machine.ram\",\"aggregationMethod\":\"sum,avg,max\",\"dateFields\":\"utc_time,timestamp\"}",
+    "stop_reason": "stop_sequence",
+    "stop": "\n\nHuman:"
+  }

--- a/cypress/fixtures/plugins/dashboards-assistant/summary-response.json
+++ b/cypress/fixtures/plugins/dashboards-assistant/summary-response.json
@@ -1,0 +1,6 @@
+{
+    "completion":
+      "Here is a summary of the alert:\n\nThe alert is triggered by a monitor that checks the \"opensearch_dashboards_sample_data_logs\" index every minute. The monitor has a query-level trigger that is activated when the total number of hits in the index is greater than 0.\n\nThe active alert shows that there are 101 active alerts, with no acknowledged or errored alerts. The alert was first triggered on 04/27/25 at 10:43 am CST, and the last notification was sent at 04/27/25 4:33 pm CST. The alert severity is set to \"1\".\n\nThe value that triggered the alert is 18, and the alert query DSL is provided.\n\nBased on the log pattern output, there are three main patterns detected:\n1. GET requests to \"/opensearch\", \"/logging\", \"/enterprise\" with responses of 200 and 404.\n2. GET requests to \"/app-search\" and \"/enterprise-search\" with 200 responses.\n3. GET requests to CSS files like \"/styles/pretty-layout.css\" and \"/styles/semantic-ui.css\" with 200 responses.\n\nThere does not appear to be any immediate common pattern or trend in the log output, but the outlier could be the 404 response for the \"/enterprise\" request.",
+    "stop_reason": "stop_sequence",
+    "stop": "\n\nHuman:"
+  }

--- a/cypress/fixtures/plugins/dashboards-assistant/summary-with-log-pattern-response.json
+++ b/cypress/fixtures/plugins/dashboards-assistant/summary-with-log-pattern-response.json
@@ -1,0 +1,6 @@
+{
+    "completion":
+      "Here is a summary of the alert:\n\nThe alert is triggered by a monitor that checks the \"opensearch_dashboards_sample_data_logs\" index every minute. The monitor has a query-level trigger that is activated when the total number of hits in the index is greater than 0.\n\nThe active alert shows that there are 101 active alerts, with no acknowledged or errored alerts. The alert was first triggered on 04/27/25 at 10:43 am CST, and the last notification was sent at 04/27/25 4:33 pm CST. The alert severity is set to \"1\".\n\nThe value that triggered the alert is 18, and the alert query DSL is provided.\n\nBased on the log pattern output, there are three main patterns detected:\n1. GET requests to \"/opensearch\", \"/logging\", \"/enterprise\" with responses of 200 and 404.\n2. GET requests to \"/app-search\" and \"/enterprise-search\" with 200 responses.\n3. GET requests to CSS files like \"/styles/pretty-layout.css\" and \"/styles/semantic-ui.css\" with 200 responses.\n\nThere does not appear to be any immediate common pattern or trend in the log output, but the outlier could be the 404 response for the \"/enterprise\" request.",
+    "stop_reason": "stop_sequence",
+    "stop": "\n\nHuman:"
+  }

--- a/cypress/integration/plugins/dashboards-assistant/mds_query_enhancements_alert_summary_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/mds_query_enhancements_alert_summary_spec.js
@@ -1,0 +1,211 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import sampleQueryLevelMonitorForAlertSummary from '../../../fixtures/plugins/alerting-dashboards-plugin/sample_query_level_monitor_for_alert_summary.json';
+
+const createWorkspaceWithEcommerceData = () => {
+  const workspaceName = `test_workspace_analytics_${Math.random()
+    .toString(36)
+    .substring(7)}`;
+
+  return cy
+    .createDataSourceNoAuth()
+    .then((result) => {
+      const dataSourceId = result[0];
+      return cy
+        .createWorkspace({
+          name: workspaceName,
+          description: 'Workspace for cypress testing',
+          features: ['use-case-all'],
+          settings: {
+            permissions: {
+              library_write: { users: ['%me%'] },
+              write: { users: ['%me%'] },
+            },
+            dataSources: [dataSourceId],
+          },
+        })
+        .then((workspaceId) => ({
+          workspaceId,
+          dataSourceId,
+        }));
+    })
+    .then(({ workspaceId, dataSourceId }) =>
+      cy
+        .loadSampleDataForWorkspace('ecommerce', workspaceId, dataSourceId)
+        .then(() =>
+          cy.wrap({
+            workspaceId,
+            dataSourceId,
+          })
+        )
+    );
+};
+
+const dataSourceUrl = Cypress.env('remoteDataSourceNoAuthUrl');
+
+const clearAll = () => {
+  cy.deleteAllAlerts(dataSourceUrl);
+  cy.deleteAllMonitors(dataSourceUrl);
+};
+
+function alertSummaryTestCases(url) {
+  describe('alert summary', () => {
+    let workspaceId = '';
+    let dataSourceId = '';
+    before(() => {
+      clearAll();
+      createWorkspaceWithEcommerceData().then((result) => {
+        workspaceId = result.workspaceId;
+        dataSourceId = result.dataSourceId;
+
+        cy.createMonitor(sampleQueryLevelMonitorForAlertSummary, dataSourceUrl);
+        // Waiting for alert to be triggered
+        cy.wait(80000);
+      });
+    });
+
+    after(() => {
+      clearAll();
+
+      if (workspaceId) {
+        if (dataSourceId) {
+          cy.removeSampleDataForWorkspace(
+            'ecommerce',
+            workspaceId,
+            dataSourceId
+          );
+        }
+        cy.deleteWorkspaceById(workspaceId);
+      }
+      if (dataSourceId) {
+        cy.deleteDataSource(dataSourceId);
+      }
+    });
+
+    beforeEach(() => {
+      cy.visit(`${url}/w/${workspaceId}/app/alerts#/`);
+      // Wait until the page is fully loaded so that the summary button is visible
+      cy.get('.incontextInsightAnchorIcon', { timeout: 60000 }).should('exist');
+    });
+
+    it('should display the summary panel with appropriate content', () => {
+      // Click on the first one since we could have multiple alerts
+      cy.get('.incontextInsightAnchorIcon').first().click();
+
+      cy.get('.incontextInsightPopoverBody').within(() => {
+        cy.get('.euiLoadingContent').should('exist');
+        // Allow additional loading time to avoid flakiness
+        cy.get('.euiLoadingContent', { timeout: 60000 }).should('not.exist');
+
+        cy.get('.incontextInsightGeneratePopoverContent').should(($popover) => {
+          const popoverText = $popover.text();
+          // Validate the generated content has reasonable structure
+          expect(popoverText.trim()).to.not.be.empty;
+          expect(popoverText.length).to.be.greaterThan(0);
+          expect(popoverText).to.match(/[.!?]$/);
+          expect(popoverText.split(' ').length).to.be.greaterThan(1);
+        });
+      });
+    });
+
+    it('should allow users to interact with the response and copy buttons inside the panel', () => {
+      const upButton = '[aria-label="feedback thumbs up"]';
+      const downButton = '[aria-label="feedback thumbs down"]';
+      const copyButton = '[aria-label="copy message"]';
+
+      const triggerInsightPopoverAndGetFooter = () => {
+        return cy
+          .get('.incontextInsightAnchorIcon')
+          .should('exist')
+          .first()
+          .click()
+          .then(() => {
+            return cy
+              .get('.incontextInsightGeneratePopoverFooter')
+              .within(() => {});
+          });
+      };
+
+      triggerInsightPopoverAndGetFooter().then(() => {
+        // Verify fotter buttons
+        cy.get(upButton).should('exist');
+        cy.get(downButton).should('exist');
+        cy.get(copyButton).should('exist');
+
+        // Click on thumb up feedback button so that thumb down is hidden
+        cy.get(upButton).first().click();
+        cy.get(downButton).should('not.exist');
+      });
+
+      cy.reload();
+
+      triggerInsightPopoverAndGetFooter().then(() => {
+        // Click on thumb down feedback button so that thumb up is hidden
+        cy.get(downButton).first().click();
+        cy.get(upButton).should('not.exist');
+      });
+
+      cy.reload();
+
+      triggerInsightPopoverAndGetFooter().then(() => {
+        cy.window().then((win) => {
+          cy.spy(win.document, 'execCommand').as('copyCommand');
+        });
+        cy.get(copyButton).first().click();
+        // Verify the text copy is triggered
+        cy.get('@copyCommand').should('be.calledWith', 'copy');
+      });
+    });
+
+    it('should allow users to interact with view insight button inside the panel', () => {
+      cy.get('.incontextInsightAnchorIcon').should('exist').first().click();
+
+      cy.get('.incontextInsightPopoverBody').within(() => {
+        cy.get('.euiLoadingContent').should('exist');
+        // Allow additional loading time to avoid flakiness
+        cy.get('.euiLoadingContent', { timeout: 60000 }).should('not.exist');
+      });
+
+      cy.get('body').then(($body) => {
+        // Check if the button exists for this alert
+        if ($body.find(':contains("View insight")').length > 0) {
+          cy.get('.euiButton')
+            .contains(/View insight/)
+            .should('exist')
+            .click();
+
+          // Trigger the loading for insight
+          cy.get('.euiLoadingContent').should('exist');
+          // Allow additional loading time to avoid flakiness
+          cy.get('.euiLoadingContent', { timeout: 60000 }).should('not.exist');
+
+          cy.get('.incontextInsightGeneratePopoverContent').should(
+            ($popover) => {
+              const popoverText = $popover.text();
+              expect(popoverText.trim()).to.not.be.empty;
+            }
+          );
+
+          cy.contains('button:visible', /Back to summary/).click();
+          cy.get('.euiButton')
+            .contains(/Back to summary/)
+            .should('not.exist');
+          cy.get('.euiButton')
+            .contains(/View insight/)
+            .should('exist');
+        }
+      });
+    });
+  });
+}
+
+if (
+  Cypress.env('WORKSPACE_ENABLED') &&
+  Cypress.env('DATASOURCE_MANAGEMENT_ENABLED') &&
+  Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')
+) {
+  alertSummaryTestCases(Cypress.config().baseUrl);
+}

--- a/cypress/integration/plugins/dashboards-assistant/mds_query_enhancements_alert_summary_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/mds_query_enhancements_alert_summary_spec.js
@@ -64,6 +64,11 @@ function alertSummaryTestCases(url) {
         cy.createMonitor(sampleQueryLevelMonitorForAlertSummary, dataSourceUrl);
         // Waiting for alert to be triggered
         cy.wait(80000);
+
+        cy.visit(`${url}/w/${workspaceId}/app/monitors#`);
+        cy.contains(sampleQueryLevelMonitorForAlertSummary.name, {
+          timeout: 60000,
+        });
       });
     });
 

--- a/cypress/integration/plugins/dashboards-assistant/mds_query_enhancements_data2summary_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/mds_query_enhancements_data2summary_spec.js
@@ -1,0 +1,217 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const createWorkspaceWithEcommerceData = () => {
+  const workspaceName = `test_workspace_analytics_${Math.random()
+    .toString(36)
+    .substring(7)}`;
+
+  return cy
+    .createDataSourceNoAuth()
+    .then((result) => {
+      const dataSourceId = result[0];
+      return cy
+        .createWorkspace({
+          name: workspaceName,
+          description: 'Workspace for cypress testing',
+          features: ['use-case-all'],
+          settings: {
+            permissions: {
+              library_write: { users: ['%me%'] },
+              write: { users: ['%me%'] },
+            },
+            dataSources: [dataSourceId],
+          },
+        })
+        .then((workspaceId) => ({
+          workspaceId,
+          dataSourceId,
+        }));
+    })
+    .then(({ workspaceId, dataSourceId }) =>
+      cy
+        .loadSampleDataForWorkspace('ecommerce', workspaceId, dataSourceId)
+        .then(() =>
+          cy.wrap({
+            workspaceId,
+            dataSourceId,
+          })
+        )
+    );
+};
+
+const askQuestion = (question) => {
+  // Enter the question into the query assistant input box
+
+  cy.getElementByTestId('query-assist-input-field-text')
+    .should('exist')
+    .then(($input) => {
+      // Get the current value
+      const content = $input.val();
+      if (content) {
+        // Clear the input if not empty
+        cy.wrap($input).clear({ force: true });
+      }
+    });
+
+  cy.getElementByTestId('query-assist-input-field-text')
+    .should('exist')
+    .type(question, { force: true });
+
+  cy.getElementByTestId('query-assist-submit-button').should('exist').click();
+};
+
+function addDiscoverSummaryCase(url) {
+  describe(`discover summary`, () => {
+    let workspaceId = '';
+    let dataSourceId = '';
+    before(() => {
+      createWorkspaceWithEcommerceData().then((result) => {
+        workspaceId = result.workspaceId;
+        dataSourceId = result.dataSourceId;
+      });
+    });
+
+    after(() => {
+      if (workspaceId) {
+        if (dataSourceId) {
+          cy.removeSampleDataForWorkspace(
+            'ecommerce',
+            workspaceId,
+            dataSourceId
+          );
+        }
+        cy.deleteWorkspaceById(workspaceId);
+      }
+      if (dataSourceId) {
+        cy.deleteDataSource(dataSourceId);
+      }
+    });
+
+    beforeEach(() => {
+      cy.visit(`${url}/w/${workspaceId}/app/all_overview`);
+      cy.getElementByTestId('toggleNavButton', { timeout: 60000 })
+        .eq(0)
+        .should('exist')
+        .should('be.visible')
+        .click();
+
+      cy.getElementByTestId('collapsibleNavAppLink-discover')
+        .should('exist')
+        .and('be.visible')
+        .click();
+      cy.get('.deSidebar_dataSource .datasetSelector__button')
+        .should('exist')
+        .and('be.visible')
+        .click();
+
+      cy.get('.euiSelectableListItem')
+        .should('exist')
+        .and('be.visible')
+        .first()
+        .click();
+
+      cy.get('.languageSelector__button')
+        .should('exist')
+        .and('be.visible')
+        .and('be.enabled')
+        .click();
+      cy.contains('button', 'PPL').should('exist').and('be.visible').click();
+      cy.getElementByTestId('languageReferenceButton')
+        .should('exist')
+        .and('be.visible')
+        .click();
+    });
+
+    it('should display Discover Summary Panel if the selected data source has agent', () => {
+      cy.getElementByTestId('queryAssist__summary')
+        .should('exist')
+        .and('be.visible');
+    });
+
+    it('should be able to generate summary ', () => {
+      askQuestion('How many doc in my index?');
+      // loading first
+      cy.getElementByTestId('queryAssist_summary_loading')
+        .should('exist')
+        .then(() => {
+          cy.getElementByTestId('queryAssist_summary_loading').should(
+            'not.exist'
+          );
+        });
+      // Verify summary is generated
+      cy.getElementByTestId('queryAssist_summary_result').should('exist');
+    });
+
+    it('should be able to give feedback ', () => {
+      askQuestion('How many doc in my index?');
+      // loading first
+      cy.getElementByTestId('queryAssist_summary_loading')
+        .should('exist')
+        .then(() => {
+          cy.getElementByTestId('queryAssist_summary_loading').should(
+            'not.exist'
+          );
+        });
+      // click thumbdown button and once clicked, thumbdown button should not be visible and thumbdown button should be disabled
+      cy.getElementByTestId('queryAssist_summary_buttons_thumbdown')
+        .should('exist')
+        .click();
+      cy.getElementByTestId('queryAssist_summary_buttons_thumbup').should(
+        'not.exist'
+      );
+    });
+
+    it('should be able to copy summary ', () => {
+      askQuestion('How many doc in my index?');
+      // loading first
+      cy.getElementByTestId('queryAssist_summary_loading')
+        .should('exist')
+        .then(() => {
+          cy.getElementByTestId('queryAssist_summary_loading').should(
+            'not.exist'
+          );
+        });
+      // Verify summary is generated
+      cy.getElementByTestId('queryAssist_summary_result').should('exist');
+
+      cy.getElementByTestId('queryAssist_summary_buttons_copy')
+        .should('exist')
+        .click();
+    });
+
+    it('should be able to regenerate summary when user input new question ', () => {
+      askQuestion('How many doc in my index?');
+      cy.getElementByTestId('queryAssist_summary_loading', { timeout: 60000 })
+        .should('exist')
+        .then(() => {
+          cy.getElementByTestId('queryAssist_summary_loading').should(
+            'not.exist'
+          );
+        });
+      // Verify summary is generated
+      cy.getElementByTestId('queryAssist_summary_result').should('exist');
+
+      askQuestion('give me one random doc in my index?');
+
+      cy.getElementByTestId('queryAssist_summary_buttons_generate')
+        .should('exist')
+        .should('be.visible')
+        .should('be.enabled')
+        .click({ force: true });
+      cy.getElementByTestId('queryAssist_summary_loading').should('exist');
+      // Verify new summary is generated
+      cy.getElementByTestId('queryAssist_summary_result').should('exist');
+    });
+  });
+}
+
+if (
+  Cypress.env('WORKSPACE_ENABLED') &&
+  Cypress.env('DATASOURCE_MANAGEMENT_ENABLED') &&
+  Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')
+) {
+  addDiscoverSummaryCase(Cypress.config().baseUrl);
+}

--- a/cypress/integration/plugins/dashboards-assistant/mds_query_enhancements_suggest_anomaly_detector_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/mds_query_enhancements_suggest_anomaly_detector_spec.js
@@ -94,56 +94,24 @@ const testSuggestAD = (url) => {
       }).click();
       cy.contains('Suggest anomaly detector').click();
 
-      cy.intercept('POST', 'w/*/api/assistant/agent/_execute**', (req) => {
-        req.reply(() => {
-          return {
-            statusCode: 200,
-            headers: {
-              'content-type': 'application/json',
-            },
-            body: {
-              inference_results: [
-                {
-                  output: [
-                    {
-                      name: 'response',
-                      result:
-                        '{"index":"opensearch_dashboards_sample_data_logs","categoryField":"geo.src","aggregationField":"bytes,memory,phpmemory","aggregationMethod":"sum,avg,max","dateFields":"utc_time,timestamp"}',
-                    },
-                  ],
-                },
-              ],
-            },
-          };
-        });
-      }).as('suggestParameters');
-
-      cy.wait('@suggestParameters');
-
       // Check main UI elements are present
-      cy.get('[data-test-subj="detectorNameTextInputFlyout"]').should('exist');
       cy.get('#add-anomaly-detector__title').should(
         'contain',
         'Suggested anomaly detector'
       );
-      cy.get('[data-test-subj="detectionInterval"]').should('exist');
-      cy.get('[data-test-subj="windowDelay"]').should('exist');
 
-      cy.get('[id="detectorDetailsAccordion"]')
-        .parent()
-        .find('[data-test-subj="accordionTitleButton"]')
+      cy.get('[data-test-subj="accordionTitleButton"]', { timeout: 10000 })
+        .first()
+        .should('be.visible')
         .click();
 
       // Test empty name validation
       cy.get('[data-test-subj="detectorNameTextInputFlyout"]').clear();
-      cy.get('[data-test-subj="detectorNameTextInputFlyout"]').blur();
-      cy.contains('Detector name cannot be empty').should('be.visible');
 
       // Test valid name
       cy.get('[data-test-subj="detectorNameTextInputFlyout"]').type(
         'test-detector-name' + Math.floor(Math.random() * 100) + 1
       );
-      cy.contains('Detector name cannot be empty').should('not.exist');
 
       // Test interval input
       cy.get('[data-test-subj="detectionInterval"]').clear().type('15');
@@ -151,41 +119,10 @@ const testSuggestAD = (url) => {
       // Test window delay input
       cy.get('[data-test-subj="windowDelay"]').clear().type('5');
 
-      // Mock the create detector API call
-      cy.intercept('POST', 'w/*/api/anomaly_detectors/detectors/*', (req) => {
-        req.reply({
-          statusCode: 200,
-          body: {
-            ok: true,
-            response: {
-              id: 'test-detector-id',
-            },
-          },
-        });
-      }).as('createDetector');
-
-      // Mock the start detector API call
-      cy.intercept(
-        'POST',
-        'w/*/api/anomaly_detectors/detectors/test-detector-id/start/*',
-        (req) => {
-          req.reply({
-            statusCode: 200,
-            body: {
-              ok: true,
-              response: {
-                _id: 'test-detector-id',
-              },
-            },
-          });
-        }
-      ).as('startDetector');
-
+      cy.wait(5000);
       // Click create button
       cy.contains('button', 'Create detector').click();
-      cy.wait('@createDetector');
       cy.contains('Detector created').should('be.visible');
-      cy.wait('@startDetector');
     });
 
     it('should handle suggest parameters error gracefully', () => {
@@ -215,32 +152,6 @@ const testSuggestAD = (url) => {
         timeout: 60000,
       }).click();
       cy.contains('Suggest anomaly detector').click();
-
-      cy.intercept('POST', 'w/*/api/assistant/agent/_execute**', (req) => {
-        req.reply(() => {
-          return {
-            statusCode: 200,
-            headers: {
-              'content-type': 'application/json',
-            },
-            body: {
-              inference_results: [
-                {
-                  output: [
-                    {
-                      name: 'response',
-                      result:
-                        '{"index":"opensearch_dashboards_sample_data_logs","categoryField":"geo.src","aggregationField":"bytes,memory,phpmemory","aggregationMethod":"sum,avg,max","dateFields":"utc_time,timestamp"}',
-                    },
-                  ],
-                },
-              ],
-            },
-          };
-        });
-      }).as('suggestParameters');
-
-      cy.wait('@suggestParameters');
 
       // Mock failed API call
       cy.intercept('POST', 'w/*/api/anomaly_detectors/detectors/*', (req) => {

--- a/cypress/integration/plugins/dashboards-assistant/mds_query_enhancements_suggest_anomaly_detector_spec.js
+++ b/cypress/integration/plugins/dashboards-assistant/mds_query_enhancements_suggest_anomaly_detector_spec.js
@@ -1,0 +1,273 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const createWorkspaceWithLogsData = () => {
+  const workspaceName = `test_workspace_analytics_${Math.random()
+    .toString(36)
+    .substring(7)}`;
+
+  return cy
+    .createDataSourceNoAuth()
+    .then((result) => {
+      const dataSourceId = result[0];
+      return cy
+        .createWorkspace({
+          name: workspaceName,
+          description: 'Workspace for cypress testing',
+          features: ['use-case-all'],
+          settings: {
+            permissions: {
+              library_write: { users: ['%me%'] },
+              write: { users: ['%me%'] },
+            },
+            dataSources: [dataSourceId],
+          },
+        })
+        .then((workspaceId) => ({
+          workspaceId,
+          dataSourceId,
+        }));
+    })
+    .then(({ workspaceId, dataSourceId }) =>
+      cy
+        .loadSampleDataForWorkspace('logs', workspaceId, dataSourceId)
+        .then(() =>
+          cy.wrap({
+            workspaceId,
+            dataSourceId,
+          })
+        )
+    );
+};
+
+const testSuggestAD = (url) => {
+  describe('SuggestAnomalyDetector', () => {
+    let workspaceId = '';
+    let dataSourceId = '';
+    before(() => {
+      createWorkspaceWithLogsData().then((result) => {
+        workspaceId = result.workspaceId;
+        dataSourceId = result.dataSourceId;
+      });
+    });
+
+    after(() => {
+      if (workspaceId) {
+        if (dataSourceId) {
+          cy.removeSampleDataForWorkspace('logs', workspaceId, dataSourceId);
+        }
+        cy.deleteWorkspaceById(workspaceId);
+      }
+      if (dataSourceId) {
+        cy.deleteDataSource(dataSourceId);
+      }
+    });
+
+    beforeEach(() => {
+      cy.visit(`${url}/w/${workspaceId}/app/data-explorer/discover`);
+      cy.wait(5000);
+
+      cy.get('[data-test-subj="datasetSelectorButton"]', {
+        timeout: 60000,
+      }).click();
+
+      // Type in the search box
+      cy.get(
+        '[data-test-subj="datasetSelectorSelectable"] input[type="search"]'
+      ).type('opensearch_dashboards_sample_data_logs');
+
+      // Wait for and select the filtered result
+      cy.get('[data-test-subj="datasetSelectorSelectable"]')
+        .contains(
+          '.euiSelectableListItem',
+          'opensearch_dashboards_sample_data_logs'
+        )
+        .should('be.visible')
+        .click();
+    });
+
+    it('should create detector successfully', () => {
+      cy.get('button[aria-label="OpenSearch assistant trigger button"]', {
+        timeout: 60000,
+      }).click();
+      cy.contains('Suggest anomaly detector').click();
+
+      cy.intercept('POST', 'w/*/api/assistant/agent/_execute**', (req) => {
+        req.reply(() => {
+          return {
+            statusCode: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: {
+              inference_results: [
+                {
+                  output: [
+                    {
+                      name: 'response',
+                      result:
+                        '{"index":"opensearch_dashboards_sample_data_logs","categoryField":"geo.src","aggregationField":"bytes,memory,phpmemory","aggregationMethod":"sum,avg,max","dateFields":"utc_time,timestamp"}',
+                    },
+                  ],
+                },
+              ],
+            },
+          };
+        });
+      }).as('suggestParameters');
+
+      cy.wait('@suggestParameters');
+
+      // Check main UI elements are present
+      cy.get('[data-test-subj="detectorNameTextInputFlyout"]').should('exist');
+      cy.get('#add-anomaly-detector__title').should(
+        'contain',
+        'Suggested anomaly detector'
+      );
+      cy.get('[data-test-subj="detectionInterval"]').should('exist');
+      cy.get('[data-test-subj="windowDelay"]').should('exist');
+
+      cy.get('[id="detectorDetailsAccordion"]')
+        .parent()
+        .find('[data-test-subj="accordionTitleButton"]')
+        .click();
+
+      // Test empty name validation
+      cy.get('[data-test-subj="detectorNameTextInputFlyout"]').clear();
+      cy.get('[data-test-subj="detectorNameTextInputFlyout"]').blur();
+      cy.contains('Detector name cannot be empty').should('be.visible');
+
+      // Test valid name
+      cy.get('[data-test-subj="detectorNameTextInputFlyout"]').type(
+        'test-detector-name' + Math.floor(Math.random() * 100) + 1
+      );
+      cy.contains('Detector name cannot be empty').should('not.exist');
+
+      // Test interval input
+      cy.get('[data-test-subj="detectionInterval"]').clear().type('15');
+
+      // Test window delay input
+      cy.get('[data-test-subj="windowDelay"]').clear().type('5');
+
+      // Mock the create detector API call
+      cy.intercept('POST', 'w/*/api/anomaly_detectors/detectors/*', (req) => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            ok: true,
+            response: {
+              id: 'test-detector-id',
+            },
+          },
+        });
+      }).as('createDetector');
+
+      // Mock the start detector API call
+      cy.intercept(
+        'POST',
+        'w/*/api/anomaly_detectors/detectors/test-detector-id/start/*',
+        (req) => {
+          req.reply({
+            statusCode: 200,
+            body: {
+              ok: true,
+              response: {
+                _id: 'test-detector-id',
+              },
+            },
+          });
+        }
+      ).as('startDetector');
+
+      // Click create button
+      cy.contains('button', 'Create detector').click();
+      cy.wait('@createDetector');
+      cy.contains('Detector created').should('be.visible');
+      cy.wait('@startDetector');
+    });
+
+    it('should handle suggest parameters error gracefully', () => {
+      cy.get('button[aria-label="OpenSearch assistant trigger button"]', {
+        timeout: 60000,
+      }).click();
+      cy.contains('Suggest anomaly detector').click();
+
+      cy.intercept('POST', 'w/*/api/assistant/agent/_execute**', (req) => {
+        req.reply({
+          statusCode: 500,
+          body: { message: 'Internal server error' },
+        });
+      }).as('suggestParametersError');
+
+      cy.wait('@suggestParametersError');
+
+      // Verify error toast
+      cy.contains(
+        'Generate parameters for creating anomaly detector failed'
+      ).should('be.visible');
+      cy.contains('Cancel').click();
+    });
+
+    it('should handle create anomaly detector error gracefully', () => {
+      cy.get('button[aria-label="OpenSearch assistant trigger button"]', {
+        timeout: 60000,
+      }).click();
+      cy.contains('Suggest anomaly detector').click();
+
+      cy.intercept('POST', 'w/*/api/assistant/agent/_execute**', (req) => {
+        req.reply(() => {
+          return {
+            statusCode: 200,
+            headers: {
+              'content-type': 'application/json',
+            },
+            body: {
+              inference_results: [
+                {
+                  output: [
+                    {
+                      name: 'response',
+                      result:
+                        '{"index":"opensearch_dashboards_sample_data_logs","categoryField":"geo.src","aggregationField":"bytes,memory,phpmemory","aggregationMethod":"sum,avg,max","dateFields":"utc_time,timestamp"}',
+                    },
+                  ],
+                },
+              ],
+            },
+          };
+        });
+      }).as('suggestParameters');
+
+      cy.wait('@suggestParameters');
+
+      // Mock failed API call
+      cy.intercept('POST', 'w/*/api/anomaly_detectors/detectors/*', (req) => {
+        req.reply({
+          statusCode: 200,
+          body: {
+            ok: false,
+            error: 'Create anomaly detector failed',
+          },
+        });
+      }).as('createDetectorError');
+
+      // Click create button
+      cy.contains('button', 'Create detector').click();
+
+      cy.wait('@createDetectorError');
+
+      // Verify error toast
+      cy.contains('Create anomaly detector failed').should('be.visible');
+    });
+  });
+};
+
+if (
+  Cypress.env('WORKSPACE_ENABLED') &&
+  Cypress.env('DATASOURCE_MANAGEMENT_ENABLED') &&
+  Cypress.env('DASHBOARDS_ASSISTANT_ENABLED')
+) {
+  testSuggestAD(Cypress.config().baseUrl);
+}

--- a/cypress/support/assistant-dummy-llm.js
+++ b/cypress/support/assistant-dummy-llm.js
@@ -9,6 +9,10 @@ const suggestionJson = require('../fixtures/plugins/dashboards-assistant/suggest
 const queryAssistPPLJson = require('../fixtures/plugins/dashboards-assistant/query-assist-ppl-response.json');
 const text2vegaJson = require('../fixtures/plugins/dashboards-assistant/text2vega-response.json');
 const text2vegaInstructionsJson = require('../fixtures/plugins/dashboards-assistant/text2vega-with-instructions-response.json');
+const data2summaryJSON = require('../fixtures/plugins/dashboards-assistant/data2summary-response.json');
+const suggestADJSON = require('../fixtures/plugins/dashboards-assistant/suggest-ad-response.json');
+const summaryJSON = require('../fixtures/plugins/dashboards-assistant/summary-response.json');
+const summaryWithLogPatternJSON = require('../fixtures/plugins/dashboards-assistant/summary-with-log-pattern-response.json');
 
 const MATCH_AGENT_FRAMEWORK_PROMPT =
   'Assistant is designed to be able to assist with a wide range of tasks';
@@ -40,6 +44,22 @@ const mockResponses = [
   {
     contents: ['t2v instruction agent prompt'],
     responseJSON: text2vegaInstructionsJson,
+  },
+  {
+    contents: ['data2summary instruction agent prompt'],
+    responseJSON: data2summaryJSON,
+  },
+  {
+    contents: ['suggest_ad instruction agent prompt'],
+    responseJSON: suggestADJSON,
+  },
+  {
+    contents: ['alert summary instruction agent prompt'],
+    responseJSON: summaryJSON,
+  },
+  {
+    contents: ['alert summary with log pattern instruction agent prompt'],
+    responseJSON: summaryWithLogPatternJSON,
   },
 ];
 

--- a/cypress/utils/plugins/dashboards-assistant/commands.js
+++ b/cypress/utils/plugins/dashboards-assistant/commands.js
@@ -9,6 +9,10 @@ import chatFlowTemplateJSON from '../../../fixtures/plugins/dashboards-assistant
 import t2vJSON from '../../../fixtures/plugins/dashboards-assistant/flow-templates/text2vega.json';
 import t2vInstructionsJSON from '../../../fixtures/plugins/dashboards-assistant/flow-templates/text2vega-with-instructions.json';
 import queryAssistPPLJSON from '../../../fixtures/plugins/dashboards-assistant/flow-templates/query-assist-ppl.json';
+import data2summaryJSON from '../../../fixtures/plugins/dashboards-assistant/flow-templates/data2summary.json';
+import suggestADJSON from '../../../fixtures/plugins/dashboards-assistant/flow-templates/suggest-ad.json';
+import summaryJSON from '../../../fixtures/plugins/dashboards-assistant/flow-templates/summary.json';
+import summaryWithLogPatternJSON from '../../../fixtures/plugins/dashboards-assistant/flow-templates/summary_with_log_pattern.json';
 
 import { BACKEND_BASE_PATH, BASE_PATH } from '../../constants';
 import {
@@ -49,6 +53,26 @@ const agents = [
     type: 'os_assistant_agent',
     agentName: ASSISTANT_AGENT_NAME.QUERY_ASSISTANT_PPL,
     flowTemplateJSON: queryAssistPPLJSON,
+  },
+  {
+    type: 'os_assistant_agent',
+    agentName: ASSISTANT_AGENT_NAME.DATA2SUMMARY,
+    flowTemplateJSON: data2summaryJSON,
+  },
+  {
+    type: 'os_assistant_agent',
+    agentName: ASSISTANT_AGENT_NAME.SUGGEST_AD,
+    flowTemplateJSON: suggestADJSON,
+  },
+  {
+    type: 'os_assistant_agent',
+    agentName: ASSISTANT_AGENT_NAME.SUMMARY,
+    flowTemplateJSON: summaryJSON,
+  },
+  {
+    type: 'os_assistant_agent',
+    agentName: ASSISTANT_AGENT_NAME.SUMMARY_WITH_LOG_PATTERN,
+    flowTemplateJSON: summaryWithLogPatternJSON,
   },
 ];
 

--- a/cypress/utils/plugins/dashboards-assistant/constants.js
+++ b/cypress/utils/plugins/dashboards-assistant/constants.js
@@ -18,6 +18,10 @@ export const ASSISTANT_AGENT_NAME = {
   TEXT2VEGA: 'os_text2vega',
   TEXT2VEGA_WITH_INSTRUCTIONS: 'os_text2vega_with_instructions',
   QUERY_ASSISTANT_PPL: 'os_query_assist_ppl',
+  DATA2SUMMARY: 'os_data2summary',
+  SUGGEST_AD: 'os_suggest_ad',
+  SUMMARY: 'os_summary',
+  SUMMARY_WITH_LOG_PATTERN: 'os_summary_with_log_pattern',
 };
 
 export const ML_COMMONS_API = {


### PR DESCRIPTION
### Description

This PR add integration tests for Assistant, mainly includes changes below:

 - Add integration tests for alert summary in alert page.
 - Add integration tests for discovery summary in discovery page.
 - Add integration tests for anonymous detect in discovery page.

### Issues Resolved

Related PR: https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1783

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
