### PR TITLE
Fix Discover Flaky Tests

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/data.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/data.spec.js
@@ -192,6 +192,7 @@ describe('table visualization data', () => {
         timestamp: '2022-08-30T23:20:41.280Z',
         username: 'missing',
       });
+      cy.forceMergeSegments();
       cy.reload();
       cy.tbGetTableDataFromVisualization().then((data) => {
         expect(data).to.deep.eq(['10,001']);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/embed.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/embed.spec.js
@@ -63,6 +63,7 @@ describe('table visualization in embedded mode', () => {
     cy.deleteIndexPattern(TABLE_INDEX_PATTERN);
     cy.bulkUploadDocs(TABLE_PATH_INDEX_DATA);
     cy.importSavedObjects(TABLE_PATH_SO_DATA);
+    cy.forceMergeSegments();
     // Load table visualization
     cy.visit(`${BASE_PATH}/app/visualize`);
     cy.get('input[type="search"]').type(`${TABLE_BASIC_VIS_TITLE}{enter}`);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/options.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/options.spec.js
@@ -25,6 +25,7 @@ describe('Table visualization options', () => {
     cy.deleteIndexPattern(TABLE_INDEX_PATTERN);
     cy.bulkUploadDocs(TABLE_PATH_INDEX_DATA);
     cy.importSavedObjects(TABLE_PATH_SO_DATA);
+    cy.forceMergeSegments();
     // Load table visualization
     cy.visit(`${BASE_PATH}/app/visualize`);
     cy.get('input[type="search"]').type(`${TABLE_BASIC_VIS_TITLE}{enter}`);

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/split.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/split.spec.js
@@ -68,6 +68,7 @@ describe.skip('Split table', () => {
     cy.deleteIndexPattern(TABLE_INDEX_PATTERN);
     cy.bulkUploadDocs(TABLE_PATH_INDEX_DATA);
     cy.importSavedObjects(TABLE_PATH_SO_DATA);
+    cy.forceMergeSegments();
     // Load table visualization
     cy.visit(`${BASE_PATH}/app/visualize`);
     cy.get('input[type="search"]').type(`${TABLE_BASIC_VIS_TITLE}{enter}`);


### PR DESCRIPTION
### Description

This aims to fix flaky Discover tests. 
```
yarn cypress run --headless --spec "cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/*"

yarn run v1.22.22
$ /Users/suchsah/Documents/Dashboards-tests/node_modules/.bin/cypress run --headless --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/*'

====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        9.5.4                                                                          │
  │ Browser:        Electron 94 (headless)                                                         │
  │ Node Version:   v18.18.2 (/Users/suchsah/.local/share/mise/installs/node/18.18.2/bin/node      │
  │                 )                                                                              │
  │ Specs:          5 found (core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/ │
  │                 basic.spec.js, core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_ │
  │                 table/data.spec.js, core-opensearch-dashboards/opensearch-dashboards/apps/vis_ │
  │                 type_table/embed.spec....)                                                     │
  │ Searched:       cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/vis_ │
  │                 type_table/*                                                                   │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table            (1 of 5)
            /basic.spec.js                                                                          
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating


  table visualization basic functions
    ✓ Should apply changed params and allow to reset (33974ms)
    ✓ Should be able to save and load
    ✓ Should have inspector enabled
    ✓ Should show correct data in inspector


  4 passing (37s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        4                                                                                │
  │ Passing:      4                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     37 seconds                                                                       │
  │ Spec Ran:     core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/basic.spec. │
  │               js                                                                               │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/suchsah/Documents/Dashboards-tests/cypress/videos/co    (2 seconds)
                          re-opensearch-dashboards/opensearch-dashboards/apps/vis_typ               
                          e_table/basic.spec.js.mp4                                                 


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table            (2 of 5)
            /data.spec.js                                                                           


  table visualization data
    Check Range aggregation and Percentage Col functions
      ✓ Should show correct range (34486ms)
      ✓ Should show correct average metrics
    Check Average Pipeline aggregation
      ✓ Should show correct data when using average pipeline aggregation (5401ms)
    Check Date Histogram aggregation and filter functons
      ✓ Should show correct data for a data table with date histogram
      ✓ Should correctly filter for applied time filter on the main timefield (6621ms)
      ✓ Should correctly filter for pinned filters
    Check Terms aggregation and missing values
      ✓ Should show correct data before and after adding doc
      ✓ Should group data in other (11876ms)
      ✓ Should include missing data


  9 passing (1m)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        9                                                                                │
  │ Passing:      9                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     1 minute, 22 seconds                                                             │
  │ Spec Ran:     core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/data.spec.j │
  │               s                                                                                │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/suchsah/Documents/Dashboards-tests/cypress/videos/co    (4 seconds)
                          re-opensearch-dashboards/opensearch-dashboards/apps/vis_typ               
                          e_table/data.spec.js.mp4                                                  


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table            (3 of 5)
            /embed.spec.js                                                                          


  table visualization in embedded mode
    ✓ Should open table vis in embedded mode (38312ms)
    ✓ Should allow to filter in embedded mode (12982ms)
    ✓ Should filter for value in embedded mode (24719ms)
    - Should filter out value in embedded mode


  3 passing (1m)
  1 pending


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        4                                                                                │
  │ Passing:      3                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      1                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     1 minute, 16 seconds                                                             │
  │ Spec Ran:     core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/embed.spec. │
  │               js                                                                               │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/suchsah/Documents/Dashboards-tests/cypress/videos/co    (4 seconds)
                          re-opensearch-dashboards/opensearch-dashboards/apps/vis_typ               
                          e_table/embed.spec.js.mp4                                                 


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table            (4 of 5)
            /options.spec.js                                                                        


  Table visualization options
    Show percentage column
      ✓ Should show correct range (35935ms)
      ✓ Should show percentage columns
      ✓ Should remove percentage columns
    Show metrics for every bucket/level and partial
      ✓ Should show correct data without showMetricsAtAllLevels (6818ms)
      ✓ Should show correct data without showMetricsAtAllLevels even if showPartialRows is selected
      ✓ Should show metrics on each level
      ✓ Should show metrics other than count on each level
    Show Total
      ✓ Should not show total function if not enabled
      ✓ Should show total function if enabled
      ✓ Should show correct data if Count is selected
      ✓ Should show correct data if Average is selected


  11 passing (59s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        11                                                                               │
  │ Passing:      11                                                                               │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     59 seconds                                                                       │
  │ Spec Ran:     core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/options.spe │
  │               c.js                                                                             │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/suchsah/Documents/Dashboards-tests/cypress/videos/co    (3 seconds)
                          re-opensearch-dashboards/opensearch-dashboards/apps/vis_typ               
                          e_table/options.spec.js.mp4                                               


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table            (5 of 5)
            /split.spec.js                                                                          


  Split table
    - Should have a splitted table in rows
    - Should filter for value in all tables
    - Should filter out value in all tables
    - Should show metrics for split bucket when using showMetricsAtAllLevels
    - Should update a splitted table in columns
    - Should sort column in all tables
    - Should adjust column width in all tables


  0 passing (214ms)
  7 pending


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        7                                                                                │
  │ Passing:      0                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      7                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     0 seconds                                                                        │
  │ Spec Ran:     core-opensearch-dashboards/opensearch-dashboards/apps/vis_type_table/split.spec. │
  │               js                                                                               │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/suchsah/Documents/Dashboards-tests/cypress/videos/co    (0 seconds)
                          re-opensearch-dashboards/opensearch-dashboards/apps/vis_typ               
                          e_table/split.spec.js.mp4                                                 


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  core-opensearch-dashboards/opensear      00:37        4        4        -        -        - │
  │    ch-dashboards/apps/vis_type_table/b                                                         │
  │    asic.spec.js                                                                                │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  core-opensearch-dashboards/opensear      01:22        9        9        -        -        - │
  │    ch-dashboards/apps/vis_type_table/d                                                         │
  │    ata.spec.js                                                                                 │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  core-opensearch-dashboards/opensear      01:16        4        3        -        1        - │
  │    ch-dashboards/apps/vis_type_table/e                                                         │
  │    mbed.spec.js                                                                                │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  core-opensearch-dashboards/opensear      00:59       11       11        -        -        - │
  │    ch-dashboards/apps/vis_type_table/o                                                         │
  │    ptions.spec.js                                                                              │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  core-opensearch-dashboards/opensear      129ms        7        -        -        7        - │
  │    ch-dashboards/apps/vis_type_table/s                                                         │
  │    plit.spec.js                                                                                │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        04:15       35       27        -        8        -  

✨  Done in 313.58s.
```
### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
