### PR TITLE
update the logic for hits check

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/discover.spec.js
@@ -133,14 +133,17 @@ describe('discover app', { scrollBehavior: false }, () => {
     });
 
     it('should reload the saved search with persisted query to show the initial hit count', function () {
+      // set current hit count as alias
+      cy.getElementByTestId('discoverQueryHits').invoke('text').as('hits');
       // apply query some changes
       cy.setTopNavQuery('test');
       cy.verifyHitCount('22');
 
       // reset to persisted state
       cy.getElementByTestId('resetSavedSearch').click();
-      const expectedHitCount = '14,004';
-      cy.verifyHitCount(expectedHitCount);
+      cy.get('@hits').then((hits) => {
+        cy.verifyHitCount(hits);
+      });
     });
   });
 


### PR DESCRIPTION
### Description

- This test has been failing a lot. See https://github.com/opensearch-project/OpenSearch-Dashboards/actions/runs/15307580055/job/43077057735?pr=9813 as an example.
- This updates the logic so that we are actually only checking the hit count goes back to the correct number as that is what the test is testing for.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
