### PR TITLE
fix dashboards-search-relevance integ tests by adding a visit to base…

### DIFF
--- a/cypress/integration/plugins/search-relevance-dashboards/1_query_compare.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/1_query_compare.spec.js
@@ -14,20 +14,28 @@ import {
   NO_RESULTS,
 } from '../../../utils/plugins/search-relevance-dashboards/constants';
 import { BASE_PATH } from '../../../utils/base_constants';
+import { CURRENT_TENANT } from '../../../utils/commands';
 
 describe('Compare queries', () => {
   before(() => {
+    CURRENT_TENANT.newTenant = 'global';
+    // visit base url
+    cy.visit(Cypress.config().baseUrl, { timeout: 10000 });
     const miscUtils = new MiscUtils(cy);
     cy.deleteAllIndices();
     miscUtils.addSampleData();
+    cy.wait(10000);
   });
 
   after(() => {
+    CURRENT_TENANT.newTenant = 'global';
     const miscUtils = new MiscUtils(cy);
     miscUtils.removeSampleData();
   });
 
   it('Should get comparison results', () => {
+    CURRENT_TENANT.newTenant = 'global';
+    cy.wait(10000);
     cy.visit(`${BASE_PATH}/app/${SEARCH_RELEVANCE_PLUGIN_NAME}/`);
 
     // Type search text in search box


### PR DESCRIPTION
### Description
- add baseUrl visit to fix the integ tests failure
- tested with command
- `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"`
```

       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/search-relevance-dashboards      00:58        1        1        -        -        - │
  │    /1_query_compare.spec.js                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/search-relevance-dashboards        2ms        -        -        -        -        - │
  │    /2_search_card.spec.js                                                                      │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:58        1        1        -        -        -  

```

https://github.com/user-attachments/assets/67b30f0d-88a1-4c56-a9fc-e4ab4d669260



### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
