### PR TITLE
[CVE] serialize-javascript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-dashboards-functional-test",
-  "version": "3.0.0-beta1",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-dashboards-functional-test",
-      "version": "3.0.0-beta1",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -3446,9 +3446,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmmirror.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -6240,7 +6240,7 @@
         "minimatch": "5.0.1",
         "ms": "2.1.3",
         "nanoid": "^3.3.8",
-        "serialize-javascript": "6.0.0",
+        "serialize-javascript": "^6.0.2",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "workerpool": "6.2.1",
@@ -6753,9 +6753,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmmirror.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "peer": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "tough-cookie": "^4.1.3",
     "optionator": "^0.9.3",
     "cross-spawn": "^7.0.5",
-    "nanoid": "^3.3.8"
+    "nanoid": "^3.3.8",
+    "serialize-javascript": "^6.0.2"
   }
 }


### PR DESCRIPTION
### Description

Bump serialize-javascript version to greater than 6.0.2 to avoid XSS.

The dependency comes from mocha 10.2.0, and mocha is the dependency of `cypress-multi-reporters` and `mocha-junit-reporter`
```
├─┬ cypress-multi-reporters@1.5.0
│ └── mocha@10.2.0
└─┬ mocha-junit-reporter@2.0.0
  └── mocha@10.2.0 deduped
```

So we choose overrides to upgrade the deep dependency.

### Issues Resolved


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
