### PR TITLE
[Bug] Added security sanity test

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/05-security.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/05-security.spec.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BASE_PATH } from '../../../utils/constants';
+
+if (Cypress.env('security_enabled')) {
+  describe('Reporting Security - Internal User with reports_full_access', () => {
+    const username = 'reportuser';
+    const password = 'TestPassword123!';
+    const roleName = `reports_full_access_${Math.random()
+      .toString(36)
+      .substring(2, 10)}`;
+
+    it('creates a new internal user', () => {
+      cy.visit(`${BASE_PATH}/app/security-dashboards-plugin#/users`);
+      cy.contains('Internal users');
+      cy.get('a[href="#/users/create"]').click({ force: true });
+
+      cy.get('input[data-test-subj="name-text"]').type(username);
+      cy.get('input[data-test-subj="password"]').type(password);
+      cy.get('input[data-test-subj="re-enter-password"]').type(password);
+      cy.get('button').contains('Create').click();
+
+      cy.contains(username).should('exist');
+    });
+
+    it('creates a new role with reports_full_access permissions', () => {
+      Cypress.on('uncaught:exception', (err) => {
+        return false;
+      });
+
+      cy.visit(`${BASE_PATH}/app/security-dashboards-plugin#/roles/create`);
+
+      cy.get('input[data-test-subj="name-text"]').type(roleName);
+
+      const permissions = [
+        'cluster:admin/opendistro/reports/definition/create',
+        'cluster:admin/opendistro/reports/definition/delete',
+        'cluster:admin/opendistro/reports/definition/get',
+        'cluster:admin/opendistro/reports/definition/list',
+        'cluster:admin/opendistro/reports/definition/on_demand',
+        'cluster:admin/opendistro/reports/definition/update',
+        'cluster:admin/opendistro/reports/instance/get',
+        'cluster:admin/opendistro/reports/instance/list',
+        'cluster:admin/opendistro/reports/menu/download',
+      ];
+
+      permissions.forEach((perm) => {
+        cy.get('input[data-test-subj="comboBoxSearchInput"]')
+          .eq(0)
+          .type(`${perm}{downArrow}{enter}`);
+      });
+
+      cy.get('button').contains('Create').click();
+      cy.contains(roleName).should('exist');
+    });
+
+    it('maps the user to the reports_full_access role', () => {
+      cy.visit(
+        `${BASE_PATH}/app/security-dashboards-plugin#/roles/edit/${roleName}/mapuser`
+      );
+      cy.contains('Map users');
+
+      cy.get('div[data-test-subj="comboBoxInput"]').type(username);
+      cy.get('button[id="map"]').click();
+
+      cy.contains(username).should('exist');
+    });
+
+    it.skip('verifies the user can access reporting', () => {
+      cy.visit(`${BASE_PATH}/logout`);
+      cy.visit(BASE_PATH);
+
+      cy.get('input[name="username"]').type(username);
+      cy.get('input[name="password"]').type(password);
+      cy.get('button[type="submit"]').click();
+
+      cy.visit(`${BASE_PATH}/app/reports-dashboards#/`);
+      cy.contains('Reporting').should('exist');
+      cy.get('#createReportHomepageButton').should('exist').click();
+      cy.contains('Create new report').should('exist');
+    });
+  });
+}


### PR DESCRIPTION
### Description

This Cypress test verifies that an internal user with the reports_full_access role can be created, assigned the correct permissions, and mapped to the role in a security-enabled OpenSearch Dashboards environment. The test is especially relevant due to a regression introduced in OpenSearch 2.19, where a refactor of the PrivilegesEvaluator class in the security plugin removed the logic for setting or reading the requestTenantAccess field. This field is critical for the reporting plugin to determine which tenants a user can access. Without it, the reporting plugin receives a null value and denies access to reporting features, even for users who should have permission. This test helps ensure that user and role setup works as expected and highlights the impact of the missing requestTenantAccess logic on reporting access.

====================================================================================================

(Run Finished)

   Spec                                              Tests  Passing  Failing  Pending  Skipped  
┌────────────────────────────────────────────────────────────────────────────────────────────────┐
│ ✔ 01-create.spec.ts 01:55 15 15 - - - │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ✔ 02-edit.spec.ts 01:20 3 3 - - - │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ✔ 03-details.spec.ts 00:31 6 6 - - - │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ✔ 04-download.spec.ts 00:50 5 5 - - - │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ ✔ 05-security.spec.ts 00:16 4 3 - 1 - │
└────────────────────────────────────────────────────────────────────────────────────────────────┘
✔ All specs passed! 04:53 33 32 - 1 -
### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
