### PR TITLE
add tests for ui setting

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_ui_settings.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/workspace-plugin/mds_workspace_ui_settings.spec.js
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { UiSettingsTestCases } from '../../../../utils/dashboards/workspace-plugin/test-cases/mds_workspace_ui_settings.cases';
+
+UiSettingsTestCases();

--- a/cypress/utils/dashboards/workspace-plugin/test-cases/mds_workspace_ui_settings.cases.js
+++ b/cypress/utils/dashboards/workspace-plugin/test-cases/mds_workspace_ui_settings.cases.js
@@ -1,0 +1,262 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BASE_PATH } from '../../../base_constants';
+import { ADMIN_AUTH } from '../../../commands';
+import workspaceTestUser from '../../../../fixtures/dashboard/opensearch_dashboards/workspace/workspaceTestUser.json';
+import workspaceTestRole from '../../../../fixtures/dashboard/opensearch_dashboards/workspace/workspaceTestRole.json';
+
+export const UiSettingsTestCases = () => {
+  let ownerWorkspaceName = 'owner_workspace';
+
+  let ownerWorkspaceId = '';
+  let datasourceId1 = '';
+  let datasourceId2 = '';
+
+  const NON_DASHBOARDS_ADMIN_USERNAME = 'workspace-uisetting-test';
+  const WORKSPACE_TEST_ROLE_NAME = 'workspace-uisetting-test-role';
+
+  const setupWorkspace = (workspaceName, datasourceId) => {
+    return cy
+      .createWorkspace({
+        name: workspaceName,
+        features: ['use-case-observability'],
+        settings: {
+          ...(datasourceId ? { dataSources: [datasourceId] } : {}),
+          permissions: {
+            library_write: { users: [workspaceName] },
+            write: { users: [workspaceName] },
+          },
+        },
+      })
+      .then((value) => {
+        // load sample data
+        cy.loadSampleDataForWorkspace('ecommerce', value, '');
+        cy.loadSampleDataForWorkspace('logs', value, '');
+        cy.wrap(value);
+      });
+  };
+
+  if (
+    Cypress.env('WORKSPACE_ENABLED') &&
+    Cypress.env('SAVED_OBJECTS_PERMISSION_ENABLED') &&
+    Cypress.env('SECURITY_ENABLED') &&
+    Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')
+  ) {
+    describe('Workspace UI Settings', () => {
+      const originalUser = ADMIN_AUTH.username;
+      const originalPassword = ADMIN_AUTH.password;
+
+      before(() => {
+        cy.deleteWorkspaceByName(ownerWorkspaceName);
+
+        cy.createInternalUser(NON_DASHBOARDS_ADMIN_USERNAME, workspaceTestUser);
+        cy.createRole(WORKSPACE_TEST_ROLE_NAME, workspaceTestRole);
+        cy.createRoleMapping(WORKSPACE_TEST_ROLE_NAME, {
+          users: [NON_DASHBOARDS_ADMIN_USERNAME],
+        });
+
+        cy.deleteAllDataSources();
+        cy.setAdvancedSetting({
+          defaultDataSource: '',
+        });
+
+        cy.createDataSourceNoAuth().then((result) => {
+          datasourceId1 = result[0];
+          expect(datasourceId1).to.be.a('string').that.is.not.empty;
+          setupWorkspace(ownerWorkspaceName, datasourceId1).then(
+            (value) => (ownerWorkspaceId = value)
+          );
+        });
+        cy.createDataSourceNoAuth().then((result) => {
+          datasourceId2 = result[0];
+          expect(datasourceId2).to.be.a('string').that.is.not.empty;
+        });
+      });
+
+      after(() => {
+        ADMIN_AUTH.newUser = originalUser;
+        ADMIN_AUTH.newPassword = originalPassword;
+        cy.removeSampleDataForWorkspace('ecommerce', ownerWorkspaceId, '');
+        cy.removeSampleDataForWorkspace('logs', ownerWorkspaceId, '');
+        cy.deleteWorkspaceByName(ownerWorkspaceName);
+        cy.deleteAllDataSources();
+        cy.setAdvancedSetting({
+          defaultDataSource: '',
+        });
+        cy.deleteRoleMapping(WORKSPACE_TEST_ROLE_NAME);
+        cy.deleteInternalUser(NON_DASHBOARDS_ADMIN_USERNAME);
+        cy.deleteRole(WORKSPACE_TEST_ROLE_NAME);
+      });
+
+      describe('Default data source', () => {
+        it('Default data source setting inside data source management page should work as expected', () => {
+          cy.visit(`${BASE_PATH}/app/dataSources/${datasourceId1}`);
+          cy.getElementByTestId('editSetDefaultDataSource')
+            .should('be.exist')
+            .should('be.enabled')
+            .click({ force: true });
+          cy.wait(1000);
+          cy.getElementByTestId('editSetDefaultDataSource')
+            .should('be.exist')
+            .should('be.disabled');
+
+          cy.visit(`${BASE_PATH}/app/dataSources/${datasourceId2}`);
+
+          cy.getElementByTestId('editSetDefaultDataSource')
+            .should('be.exist')
+            .should('be.enabled')
+            .click({ force: true });
+          cy.wait(1000);
+          cy.getElementByTestId('editSetDefaultDataSource')
+            .should('be.exist')
+            .should('be.disabled');
+
+          cy.visit(`${BASE_PATH}/app/dataSources/${datasourceId1}`);
+          cy.getElementByTestId('editSetDefaultDataSource')
+            .should('be.exist')
+            .should('be.enabled');
+        });
+
+        it('Default data source setting inside application pages should work as expected', () => {
+          cy.visit(`${BASE_PATH}/app/settings`);
+          cy.get(
+            '[data-test-subj="advancedSetting-editField-defaultDataSource"]'
+          ).then(($input) => {
+            if ($input.prop('disabled')) {
+              cy.log('Input field is disabled and cannot be changed.');
+            } else {
+              cy.wrap($input).clear().type(datasourceId1);
+              cy.get('[data-test-subj="advancedSetting-saveButton"]').click();
+              cy.wrap($input).should('have.value', datasourceId1);
+            }
+          });
+        });
+      });
+
+      describe('Application settings', () => {
+        it('CRUD operations inside application settings should work as expected', () => {
+          cy.visit(`${BASE_PATH}/app/settings`);
+
+          cy.get(
+            '[data-test-subj="advancedSetting-editField-csv:quoteValues"]'
+          ).then(($switch) => {
+            if ($switch.prop('disabled')) {
+              cy.log('Switch is disabled and cannot be changed.');
+            } else if ($switch.attr('aria-checked') === 'true') {
+              cy.wrap($switch).click();
+              cy.get('[data-test-subj="advancedSetting-saveButton"]').click();
+              cy.get('button.euiButton--primary.euiButton--small').click();
+              cy.get($switch).should('have.attr', 'aria-checked', 'false');
+            } else {
+              cy.log('The switch is already on.');
+            }
+          });
+
+          cy.get(
+            '[data-test-subj="advancedSetting-editField-theme:darkMode"]'
+          ).then(($switch) => {
+            if ($switch.prop('disabled')) {
+              cy.log('Switch is disabled and cannot be changed.');
+            } else if ($switch.attr('aria-checked') === 'false') {
+              cy.wrap($switch).click();
+              cy.get('[data-test-subj="advancedSetting-saveButton"]').click();
+              cy.get('button.euiButton--primary.euiButton--small').click();
+              cy.get($switch).should('have.attr', 'aria-checked', 'true');
+            } else {
+              cy.log('The switch is already on.');
+            }
+          });
+        });
+      });
+
+      describe('Default data source', () => {
+        it('Default data source setting inside application pages should work as expected', () => {
+          cy.visit(`${BASE_PATH}/app/settings`);
+          cy.get(
+            '[data-test-subj="advancedSetting-editField-defaultDataSource"]'
+          ).then(($input) => {
+            if ($input.prop('disabled')) {
+              cy.log('Input field is disabled and cannot be changed.');
+            } else {
+              cy.wrap($input).clear().type('newDataSource');
+              cy.get('[data-test-subj="advancedSetting-saveButton"]').click();
+              cy.wrap($input).should('have.value', 'newDataSource');
+            }
+          });
+        });
+      });
+
+      describe('Default index pattern', () => {
+        it('Default index pattern in index pattern list page should work as expected', () => {
+          cy.visit(`${BASE_PATH}/w/${ownerWorkspaceId}/app/indexPatterns`);
+          cy.contains('opensearch_dashboards_sample_data_ecommerce').click();
+          cy.getElementByTestId('setDefaultIndexPatternButton')
+            .should('be.exist')
+            .should('be.enabled')
+            .click();
+          cy.get('div[data-test-subj="headerBadgeControl"]')
+            .contains('span', 'Default')
+            .should('exist');
+
+          cy.visit(`${BASE_PATH}/w/${ownerWorkspaceId}/app/indexPatterns`);
+          cy.contains('opensearch_dashboards_sample_data_logs').click();
+          cy.getElementByTestId('setDefaultIndexPatternButton')
+            .should('be.exist')
+            .should('be.enabled')
+            .click();
+          cy.get('div[data-test-subj="headerBadgeControl"]')
+            .contains('span', 'Default')
+            .should('exist');
+        });
+
+        it('Default index pattern in discover page should work as expected', () => {
+          cy.visit(`${BASE_PATH}/w/${ownerWorkspaceId}/app/discover`);
+          cy.get('div[data-test-subj="comboBoxInput"]')
+            .contains('span', 'opensearch_dashboards_sample_data_ecommerce')
+            .click();
+
+          cy.get(
+            'div[data-test-subj="comboBoxOptionsList dataExplorerDSSelect-optionsList"]'
+          )
+            .contains('button', 'opensearch_dashboards_sample_data_logs')
+            .click();
+
+          cy.get('div[data-test-subj="comboBoxInput"]')
+            .contains('span', 'opensearch_dashboards_sample_data_logs')
+            .should('exist');
+
+          cy.get('div[data-test-subj="comboBoxInput"]')
+            .contains('span', 'opensearch_dashboards_sample_data_ecommerce')
+            .click();
+          cy.get(
+            'div[data-test-subj="comboBoxOptionsList dataExplorerDSSelect-optionsList"]'
+          )
+            .contains('button', 'opensearch_dashboards_sample_data_ecommerce')
+            .click();
+
+          cy.get('div[data-test-subj="comboBoxInput"]')
+            .contains('span', 'opensearch_dashboards_sample_data_ecommerce')
+            .should('exist');
+        });
+      });
+
+      describe('Dismiss Get started', () => {
+        it('Dismiss get started button in the top of each overview page should work as expected', () => {
+          cy.visit(
+            `${BASE_PATH}/w/${ownerWorkspaceId}/app/observability-overview/`
+          );
+          cy.get('div[data-test-subj="headerRightControl"]').should('exist');
+          cy.get('div[data-test-subj="headerRightControl"]')
+            .contains('button', 'Dismiss Get started')
+            .click();
+          cy.get('div[data-test-subj="headerRightControl"]')
+            .contains('button', 'Dismiss Get started')
+            .should('not.exist');
+        });
+      });
+    });
+  }
+};


### PR DESCRIPTION
### Description

Add tests for ui setting.

test cases:

* Application settings: The CRUD operation inside application settings should work as it is today.
* Default data source: Default data source setting inside: 1. application pages, 2. data source list page should work as expected without any error.
* Default index pattern: default index pattern in index pattern list page and discover page should work as it is.
* Dismiss Get started: the dismiss get started button in the top of each overview page should work as it is.
* Please feel free to add any missing test cases.



### Issues Resolved

none

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
