### PR TITLE
Observability test fixes for 3.1

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/3_trace_analytics_traces.spec.js
@@ -37,7 +37,7 @@ describe('Testing traces table', () => {
     cy.get('[data-test-subj="trace-table-mode-selector"]').click();
     cy.get('.euiSelectableListItem__content').contains('Traces').click();
     cy.contains(' (1)').should('exist');
-    cy.contains('Mar 25, 2021 @ 10:21:22.896').should('exist');
+    cy.get('.euiLink--primary').contains(TRACE_ID).should('exist');
   });
 });
 

--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -71,7 +71,7 @@ const deleteNotebook = () => {
 const deleteAllNotebooks = () => {
   cy.intercept(
     'DELETE',
-    '/api/observability/notebooks/note/savedNotebook/*'
+    `${BASE_PATH}/api/observability/notebooks/note/savedNotebook/**`
   ).as('deleteNotebook');
 
   cy.wait(delayTime * 3);

--- a/cypress/utils/plugins/observability-dashboards/constants.js
+++ b/cypress/utils/plugins/observability-dashboards/constants.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import { BASE_PATH } from '../../base_constants';
+import dayjs from 'dayjs';
 
 export const OBSERVABILITY_INDEX_NAME = '.opensearch-observability';
 export const delayTime = 1500;
@@ -52,8 +53,15 @@ export const suppressResizeObserverIssue = () => {
 };
 
 export const setTimeFilter = (setEndTime = false, refresh = true) => {
-  const startTime = 'Mar 25, 2021 @ 10:00:00.000';
-  const endTime = 'Mar 25, 2021 @ 11:00:00.000';
+  const baseStartTimeUTC = '2021-03-25T17:00:00.000Z';
+  const baseEndTimeUTC = '2021-03-25T19:00:00.000Z';
+
+  // Convert UTC to local timezone and format for the date picker
+  const startTime = dayjs(baseStartTimeUTC).format(
+    'MMM DD, YYYY @ HH:mm:ss.SSS'
+  );
+  const endTime = dayjs(baseEndTimeUTC).format('MMM DD, YYYY @ HH:mm:ss.SSS');
+
   cy.get('button.euiButtonEmpty[aria-label="Date quick select"]', {
     timeout: TIMEOUT_DELAY,
   }).click();


### PR DESCRIPTION
### Description

* Updated trace analytics test to verify trace ID instead of hardcoded timestamp
* Added BASE_PATH to notebook deletion API endpoint for proper routing
* Enhanced time filter handling by converting UTC timestamps to local timezone using dayjs for consistent test execution across different environments

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
