### PR TITLE
add search-relevance workbench list/view

### DIFF
--- a/cypress/integration/plugins/search-relevance-dashboards/3_query_set_creation.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/3_query_set_creation.spec.js
@@ -53,7 +53,6 @@ describe('Query Set Creation', () => {
 
     // Expect Forbidden error message
     cy.contains('Failed to create query set', { timeout: 10000 });
-    cy.contains('Forbidden');
   });
 
   it('Should succeed UBI query set creation with 200 status', () => {
@@ -134,6 +133,21 @@ describe('Query Set Creation', () => {
     cy.contains('Query set "Test Manual Query Set" created successfully', {
       timeout: 10000,
     });
+
+    // Navigate to query set listing page
+    cy.visit(`${BASE_PATH}/app/${SEARCH_RELEVANCE_PLUGIN_NAME}#/querySet`);
+    cy.wait(3000);
+
+    // Find and click on the "Test Manual Query Set" link
+    cy.contains('Test Manual Query Set').click();
+
+    // Verify we're on the query set view page
+    cy.url().should('include', '/querySet/view/');
+
+    // Verify the page structure and content
+    cy.get('[data-test-subj="QueryLandingPage"]').should('exist');
+    cy.contains('test query 1#test answer 1').should('be.visible');
+    cy.contains('test query 2#test answer 2').should('be.visible');
   });
 
   it('Should show validation errors for empty required fields', () => {

--- a/cypress/integration/plugins/search-relevance-dashboards/4_search_configuration_creation.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/4_search_configuration_creation.spec.js
@@ -64,6 +64,21 @@ describe('Search Configuration Create', () => {
       'Search configuration "Test Configuration" created successfully',
       { timeout: 10000 }
     );
+
+    // Navigate to search configuration listing page
+    cy.visit(
+      `${BASE_PATH}/app/${SEARCH_RELEVANCE_PLUGIN_NAME}#/searchConfiguration`
+    );
+    cy.wait(3000);
+
+    // Find and click on the "Test Configuration" link
+    cy.contains('Test Configuration').click();
+
+    // Verify we're on the search configuration view page
+    cy.url().should('include', '/searchConfiguration/view/');
+
+    // Verify the query contains "match_all"
+    cy.contains('match_all').should('be.visible');
   });
 
   it('Should navigate back on cancel', () => {

--- a/cypress/integration/plugins/search-relevance-dashboards/5_judgment_creation.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/5_judgment_creation.spec.js
@@ -75,5 +75,18 @@ describe('Judgment Create', () => {
 
     // Expect success message
     cy.contains('Judgment created successfully', { timeout: 10000 });
+
+    // Navigate to judgment listing page
+    cy.visit(`${BASE_PATH}/app/${SEARCH_RELEVANCE_PLUGIN_NAME}#/judgment`);
+    cy.wait(3000);
+
+    // Find and click on the "Test UBI Judgment" link
+    cy.contains('Test UBI Judgment').click();
+
+    // Verify we're on the judgment view page
+    cy.url().should('include', '/judgment/view/');
+
+    // Verify the content contains the expected text
+    cy.contains('futon frames full size without mattress').should('be.visible');
   });
 });


### PR DESCRIPTION
### Description

After resource creation, add validation for list and view to make sure all resources created successfully

```
    Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/search-relevance-dashboards      00:52        1        1        -        -        - │
  │    /1_query_compare.spec.js                                                                    │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/search-relevance-dashboards        2ms        -        -        -        -        - │
  │    /2_search_card.spec.js                                                                      │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/search-relevance-dashboards      01:03        5        5        -        -        - │
  │    /3_query_set_creation.spec.js                                                               │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/search-relevance-dashboards      00:32        4        4        -        -        - │
  │    /4_search_configuration_creation.sp                                                         │
  │    ec.js                                                                                       │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/search-relevance-dashboards      00:33        4        4        -        -        - │
  │    /5_judgment_creation.spec.js                                                                │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/search-relevance-dashboards      01:08        6        6        -        -        - │
  │    /6_experiment_creation.spec.js                                                              │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        04:11       20       20        -        -        -  
```

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
