### PR TITLE
Decouple connector creation for FF tests

### DIFF
--- a/cypress/fixtures/plugins/dashboards-flow-framework/search_models_response.json
+++ b/cypress/fixtures/plugins/dashboards-flow-framework/search_models_response.json
@@ -1,0 +1,77 @@
+{
+    "models": {
+        "d9VHdpgBSV4mi45KsG7a": {
+            "id": "d9VHdpgBSV4mi45KsG7a",
+            "name": "BedRock Titan embedding model",
+            "algorithm": "Remote",
+            "state": "Deployed",
+            "modelConfig": {},
+            "interface": {
+                "input": {
+                    "type": "object",
+                    "properties": {
+                        "parameters": {
+                            "additionalProperties": true,
+                            "type": "object",
+                            "properties": {
+                                "inputText": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "output": {
+                    "type": "object",
+                    "properties": {
+                        "inference_results": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "output": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "dataAsMap": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "embedding": {
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "embedding"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "name",
+                                                "dataAsMap"
+                                            ]
+                                        }
+                                    },
+                                    "status_code": {
+                                        "type": "integer"
+                                    }
+                                },
+                                "required": [
+                                    "output",
+                                    "status_code"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "inference_results"
+                    ]
+                }
+            },
+            "connectorId": "-VJHdpgBWQNCYG3iro2a"
+        }
+    }
+}

--- a/cypress/integration/plugins/dashboards-flow-framework/create_workflow_spec.js
+++ b/cypress/integration/plugins/dashboards-flow-framework/create_workflow_spec.js
@@ -23,14 +23,13 @@ describe('Creating Workflows Using Various Methods', () => {
         return cy.registerModel({
           body: {
             ...registerModelBody,
-            connector_id:
-              connectorResponse?.connector_id || 'test_connector_id',
+            connector_id: connectorResponse.connector_id || 'test_connector_id',
             function_name: 'remote',
           },
         });
       })
       .then((modelResponse) => {
-        modelId = modelResponse?.model_id;
+        modelId = modelResponse.model_id;
         return cy.deployMLCommonsModel(modelId);
       });
   });

--- a/cypress/integration/plugins/dashboards-flow-framework/create_workflow_spec.js
+++ b/cypress/integration/plugins/dashboards-flow-framework/create_workflow_spec.js
@@ -30,7 +30,7 @@ describe('Creating Workflows Using Various Methods', () => {
         });
       })
       .then((modelResponse) => {
-        modelId = modelResponse.model_id;
+        modelId = modelResponse?.model_id;
         return cy.deployMLCommonsModel(modelId);
       });
   });

--- a/cypress/utils/plugins/dashboards-flow-framework/commands.js
+++ b/cypress/utils/plugins/dashboards-flow-framework/commands.js
@@ -6,6 +6,7 @@
 import {
   FF_FIXTURE_BASE_PATH,
   INGEST_NODE_API_PATH,
+  SEARCH_MODELS_API_PATH,
   SEARCH_NODE_API_PATH,
 } from '../../../utils/constants';
 
@@ -13,6 +14,7 @@ Cypress.Commands.add('createConnector', (connectorBody) =>
   cy
     .request({
       method: 'POST',
+      failOnStatusCode: false, // may fail for envs where connector creation is prohibited
       form: false,
       url: 'api/console/proxy',
       headers: {
@@ -124,40 +126,17 @@ Cypress.Commands.add('mockIngestion', (funcMockedOn) => {
   });
 });
 
-Cypress.Commands.add('mockAllIngestActions', (funcMockedOn) => {
-  cy.fixture(
-    FF_FIXTURE_BASE_PATH + 'semantic_search/simulate_pipeline_response.json'
-  ).then((simulatePipelineResponse) => {
-    cy.intercept('POST', /simulatePipeline/, {
-      statusCode: 200,
-      body: simulatePipelineResponse,
-    }).as('simulatePipelineRequest');
-    cy.fixture(
-      FF_FIXTURE_BASE_PATH + 'semantic_search/ingest_response.json'
-    ).then((ingestResponse) => {
-      cy.intercept('POST', INGEST_NODE_API_PATH, {
+Cypress.Commands.add('mockModelSearch', (funcMockedOn) => {
+  cy.fixture(FF_FIXTURE_BASE_PATH + 'search_models_response.json').then(
+    (searchModelsResponse) => {
+      cy.intercept('POST', SEARCH_MODELS_API_PATH, {
         statusCode: 200,
-        body: ingestResponse,
-      }).as('ingestionRequest');
+        body: searchModelsResponse,
+      }).as('searchModelsRequest');
+
       funcMockedOn();
 
-      cy.wait('@simulatePipelineRequest');
-      cy.wait('@ingestionRequest');
-    });
-  });
-});
-
-Cypress.Commands.add('mockSemanticSearchIndexSearch', (funcMockedOn) => {
-  cy.fixture(
-    FF_FIXTURE_BASE_PATH + 'semantic_search/search_response.json'
-  ).then((searchResults) => {
-    cy.intercept('POST', SEARCH_NODE_API_PATH + '/*', {
-      statusCode: 200,
-      body: searchResults,
-    }).as('searchRequest');
-
-    funcMockedOn();
-
-    cy.wait('@searchRequest');
-  });
+      cy.wait('@searchModelsRequest');
+    }
+  );
 });

--- a/cypress/utils/plugins/dashboards-flow-framework/commands.js
+++ b/cypress/utils/plugins/dashboards-flow-framework/commands.js
@@ -7,7 +7,6 @@ import {
   FF_FIXTURE_BASE_PATH,
   INGEST_NODE_API_PATH,
   SEARCH_MODELS_API_PATH,
-  SEARCH_NODE_API_PATH,
 } from '../../../utils/constants';
 
 Cypress.Commands.add('createConnector', (connectorBody) =>

--- a/cypress/utils/plugins/dashboards-flow-framework/constants.js
+++ b/cypress/utils/plugins/dashboards-flow-framework/constants.js
@@ -42,6 +42,7 @@ export const APIS_MLC = {
 
 export const BASE_FF_NODE_API_PATH = BASE_PATH + '/api/flow_framework';
 export const INGEST_NODE_API_PATH = BASE_FF_NODE_API_PATH + '/opensearch/bulk';
+export const SEARCH_MODELS_API_PATH = BASE_FF_NODE_API_PATH + '/model/search';
 export const SEARCH_NODE_API_PATH =
   BASE_FF_NODE_API_PATH + '/opensearch/search';
 

--- a/cypress/utils/plugins/dashboards-flow-framework/constants.js
+++ b/cypress/utils/plugins/dashboards-flow-framework/constants.js
@@ -43,8 +43,6 @@ export const APIS_MLC = {
 export const BASE_FF_NODE_API_PATH = BASE_PATH + '/api/flow_framework';
 export const INGEST_NODE_API_PATH = BASE_FF_NODE_API_PATH + '/opensearch/bulk';
 export const SEARCH_MODELS_API_PATH = BASE_FF_NODE_API_PATH + '/model/search';
-export const SEARCH_NODE_API_PATH =
-  BASE_FF_NODE_API_PATH + '/opensearch/search';
 
 /**
  *****************************


### PR DESCRIPTION
### Description
Improves the Flow Framework OSD plugin tests by decoupling the connector creation step for improved flexibility & less flakiness when running the tests against different endpoints with different security standards. For example, an Amazon OpenSearch Service (AOS) domain prohibits remote connector creation, so these tests cannot run out-of-the-box against such endpoints. This fixes that, by mocking the connector creation entirely if the step fails.

Includes several other minor improvements to minimize flakiness, such as the model deployment call and scoped-down mocking checks during ingest and search. 

Tested against local domain with no security, and against an AOS domain with basic auth. Both scenarios succeed without any changes to the test file:
```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/dashboards-flow-framework/c      02:41        6        6        -        -        - │
  │    reate_workflow_spec.js                                                                      │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        02:41        6        6        -        -        -  
```

### Issues Resolved


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
