### PR TITLE
extract tenant-dialog helper & improve forecaster list test robustness

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/forecaster_list_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/forecaster_list_spec.js
@@ -135,16 +135,11 @@ context('list forecaster workflow', () => {
     });
 
     // Handles the optional "Select your tenant" pop-up
-    cy.get('body').then(($body) => {
-      // We look for an element containing "Select your tenant" to avoid being
-      // specific about which tag (e.g. h1, h2) is used for the title.
-      if ($body.find(':contains("Select your tenant")').length > 0) {
-        const confirmButton = $body.find('button:contains("Confirm")');
-        if (confirmButton.length) {
-          cy.wrap(confirmButton.first()).click();
-        }
-      }
-    });
+    cy.handleTenantDialog();
+
+    cy.contains('Loading OpenSearch Dashboards', { timeout: 120000 }).should(
+      'not.exist'
+    );
 
     // The application can sometimes re-render the header after loading or
     // dismissing initial pop-ups. To prevent a "detached from the DOM" error,
@@ -163,16 +158,8 @@ context('list forecaster workflow', () => {
     cy.contains('Forecasting').click();
 
     // Handles the optional "Select your tenant" pop-up
-    cy.get('body').then(($body) => {
-      // We look for an element containing "Select your tenant" to avoid being
-      // specific about which tag (e.g. h1, h2) is used for the title.
-      if ($body.find(':contains("Select your tenant")').length > 0) {
-        const confirmButton = $body.find('button:contains("Confirm")');
-        if (confirmButton.length) {
-          cy.wrap(confirmButton.first()).click();
-        }
-      }
-    });
+    // tenant dialog can appear at any time, so we need to handle it between each clicks
+    cy.handleTenantDialog();
 
     // Verify we're redirected to the forecasters list page
     // match ensures that the url ends with /forecasters
@@ -181,8 +168,10 @@ context('list forecaster workflow', () => {
     // ========== Scenario: CREATE FORECASTER ==========
     // Verify the title contains the word "Forecasters"
     cy.contains('Forecasters (0)').should('exist');
+    cy.handleTenantDialog();
     // we have two create forecaster buttons, click any one of them
     cy.getElementByTestId('createForecasterButton').first().click();
+    cy.handleTenantDialog();
 
     // Call the new reusable command to create the forecaster
     cy.createForecaster({
@@ -433,7 +422,7 @@ context('list forecaster workflow', () => {
       buttonCount
     ) => {
       if (buttonIndex >= buttonCount) {
-        throw new Error(
+        cy.log(
           `Could not open the "${modalTestSubj}" modal after trying all buttons.`
         );
       }
@@ -473,6 +462,7 @@ context('list forecaster workflow', () => {
           .click({ force: true });
 
         // Poll for the menu to appear
+        cy.wait(500);
         cy.get('body').then(($body) => {
           const $visibleMenu = $body.find('.euiContextMenuPanel:visible');
           if (
@@ -509,6 +499,7 @@ context('list forecaster workflow', () => {
             // Menu was not visible or was incorrect. Retry.
             cy.log('  Menu not visible or incorrect. Retrying.');
             if ($visibleMenu.length > 0) {
+              cy.log(`  Visible menu text: "${$visibleMenu.text()}"`);
               cy.get('body').click('topLeft', { force: true });
             }
             cy.wait(500);
@@ -560,6 +551,34 @@ context('list forecaster workflow', () => {
           throw new Error('No "Show actions" buttons found on the page.');
         }
       });
+
+    // After attempting with "Cancel forecast", check if the modal appeared.
+    // If not, try again with "Stop forecasting". "Cancel forecast" is present
+    // when state is "Initializing". "Stop forecasting" is present when state
+    // is "Running". We are not sure which state the forecaster is in when the
+    // real time run is triggered, so we try both.
+    cy.get('body').then(($body) => {
+      if (
+        $body.find('[data-test-subj="stopForecastersModal"]:visible').length ===
+        0
+      ) {
+        cy.log(
+          'Modal not found with "Cancel forecast", trying "Stop forecasting".'
+        );
+        cy.get('button[aria-label="Show actions"]')
+          .its('length')
+          .then((count) => {
+            if (count > 0) {
+              openActionModalWithRetries(
+                'Stop forecasting',
+                'stopForecastersModal',
+                0,
+                count
+              );
+            }
+          });
+      }
+    });
 
     // =====================================================================
     //  Scenario – STOP FORECASTER VIA ROW ACTIONS

--- a/cypress/utils/plugins/anomaly-detection-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/anomaly-detection-dashboards-plugin/commands.js
@@ -16,6 +16,26 @@ import {
 import { selectTopItemFromFilter } from './helpers';
 
 Cypress.Commands.add(
+  'handleTenantDialog',
+  {
+    prevSubject: 'optional',
+  },
+  () => {
+    // Handles the optional "Select your tenant" pop-up
+    cy.get('body').then(($body) => {
+      // We look for an element containing "Select your tenant" to avoid being
+      // specific about which tag (e.g. h1, h2) is used for the title.
+      if ($body.find(':contains("Select your tenant")').length > 0) {
+        const confirmButton = $body.find('button:contains("Confirm")');
+        if (confirmButton.length) {
+          cy.wrap(confirmButton.first()).click();
+        }
+      }
+    });
+  }
+);
+
+Cypress.Commands.add(
   'mockGetDetectorOnAction',
   function (fixtureFileName, funcMockedOn) {
     cy.intercept(AD_NODE_API_PATH.GET_DETECTORS, {
@@ -134,19 +154,6 @@ Cypress.Commands.add('createForecaster', (forecasterDetails) => {
     test = false,
     interval = 0,
   } = forecasterDetails;
-
-  // pop up for tenant selection
-  // Handles the optional "Select your tenant" pop-up
-  cy.get('body').then(($body) => {
-    // We look for an element containing "Select your tenant" to avoid being
-    // specific about which tag (e.g. h1, h2) is used for the title.
-    if ($body.find(':contains("Select your tenant")').length > 0) {
-      const confirmButton = $body.find('button:contains("Confirm")');
-      if (confirmButton.length) {
-        cy.wrap(confirmButton.first()).click();
-      }
-    }
-  });
 
   cy.getElementByTestId('defineOrEditForecasterTitle').should('exist');
   cy.getElementByTestId('forecasterNameTextInput').type(name);


### PR DESCRIPTION
### Description
This PR:

* Create `cy.handleTenantDialog` custom command to handle the optional  **"Select your tenant"** pop-up.
* Refactor `forecaster_list_spec.js` and `createForecaster` helper to leverage the new command, reducing duplicate code.
* Introduce explicit waits (`cy.contains('Loading OpenSearch Dashboards').should('not.exist')`, `cy.wait(500)`) and additional `cy.log` statements to handle cases where the home page loads slowly, improving stability and aiding debugging.
* Replace thrown error during action-menu retries with a `cy.log` to enable fallback logic in future enhancements.
* Implement fallback logic to use **"Stop forecasting"** when the **"Cancel forecast"** modal  
  does not appear, covering both *Initializing* and *Running* forecast states.


### Issues Resolved

https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/1072

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
