### PR TITLE
[dashboards-notification][3.2] Wait for SES channel to load before starting to edit

### DIFF
--- a/cypress/integration/plugins/notifications-dashboards/1_email_senders_and_groups.spec.js
+++ b/cypress/integration/plugins/notifications-dashboards/1_email_senders_and_groups.spec.js
@@ -128,6 +128,7 @@ describe('Test edit senders', () => {
   });
 
   it('edits ses sender region', () => {
+    cy.contains('test-ses-sender', { timeout: 10000 });
     cy.get('.euiCheckbox__input[aria-label="Select this row"]').eq(2).click(); // ses sender
     cy.get('[data-test-subj="ses-senders-table-edit-button"]').click();
     cy.wait(NOTIFICATIONS_DELAY);


### PR DESCRIPTION
### Description
Sometime when the sender list page loads slowly, the SES channels have not completely loaded before we get the list of checkable channel rows. Hence the check cy.get(...).eq(2) fails because the channel in the second table for SES has not finished loading yet. Added a check for the channel name to be present before we get the row to edit.

### Issues Resolved
https://github.com/opensearch-project/dashboards-notifications/issues/368

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
