### PR TITLE
Ensure windows install cypress based on ci bucket source

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -108,6 +108,13 @@ fi
 
 . ./test_finder.sh
 
+# Windows have issues installing cypress in parallel (during integTest) by design
+# And is not baked in images due to slow startup time
+# We are forcing the installation from opensearch ci bucket
+if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "win32" ]; then
+    CYPRESS_INSTALL_BINARY=https://ci.opensearch.org/ci/dbc/tools/Cypress-9.5.4-x64-windows.zip npm install cypress
+fi
+
 npm install
 
 TEST_FILES=`get_test_list $TEST_COMPONENTS`


### PR DESCRIPTION
### Description

Ensure windows install cypress based on ci bucket source

### Issues Resolved

https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test-opensearch-dashboards/detail/integ-test-opensearch-dashboards/7659/pipeline/
```
npm ERR! Platform: win32-x64 (10.0.17763)

npm ERR! Cypress Version: 9.5.4

npm ERR! [FAILED] The Cypress App could not be downloaded.

```

Test by force cypress in package.json to be 9.7.0 but 9.5.4 still installed.
```
npm info run cypress@9.7.0 postinstall node_modules/cypress node index.js --exec install
npm info run cypress@9.7.0 postinstall { code: 0, signal: null }


$ cypress --version
Cypress package version: 9.7.0
Cypress binary version: 9.5.4
Electron version: 15.3.5
Bundled Node version:
16.5.0
```

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
