### PR TITLE
[backport to 3.1] test: improve resilience in forecast tests

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/daily_forecaster_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/daily_forecaster_spec.js
@@ -150,6 +150,9 @@ describe('Daily interval forecaster', () => {
 
     // Click 'Start test' button and trigger test again.
     cy.getElementByTestId('startCancelTestButton').click();
+    // In case previous test complete message hasn't disappeared, wait for it to disappear
+    // before checking for the new test complete message.
+    cy.contains('Initializing test', { timeout: 180000 }).should('be.visible');
     cy.contains('Test complete', { timeout: 180000 }).should('be.visible');
     cy.contains('Loading forecast results...', { timeout: 180000 }).should(
       'not.exist'

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/forecaster_list_spec_mock.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/forecaster_list_spec_mock.js
@@ -7,6 +7,22 @@ import { AD_FIXTURE_BASE_PATH, FORECAST_URL } from '../../../utils/constants';
 
 describe('Forecaster list page mock', () => {
   before(function () {
+    // Set the default tenant to 'global' to avoid the "Select your tenant" pop-up
+    // as the timing of the pop-up is not deterministic.
+    // I checked brownser'sDevTools → Application → Local Storage (and Session Storage)
+    //  → look for keys containing “security” and “tenant”. I found:
+    // opendistro::security::tenant::savedopendistro::security::tenant::saved:""""
+    // Just to be safe, instead of using the key directly, we use the following code
+    // to find the key and set the value to 'global'.
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        const key = Object.keys(win.localStorage).find(
+          (k) => k.includes('security') && k.includes('tenant')
+        );
+        if (key) win.localStorage.setItem(key, 'global');
+      },
+    });
+
     // Get OpenSearch version.
     cy.request({
       method: 'GET',

--- a/cypress/utils/plugins/anomaly-detection-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/anomaly-detection-dashboards-plugin/commands.js
@@ -133,6 +133,52 @@ Cypress.Commands.add('stopDetector', (detectorId) => {
 });
 
 /**
+ * Types a value into an EUI <EuiComboBox> (wrapper test-subj) and commits with Enter.
+ *
+ * Why not just `.type()` on the wrapper (e.g. `cy.getElementByTestId('timestampFilter').type(...)`)?
+ * - The test-subj is on the **wrapper <div>** (role="combobox"), not the <input>.
+ * - Cypress only types into “typeable” elements (see allowed list in the error we saw). A plain <div>
+ *   is not typeable and will throw (“requires a valid typeable element”).
+ * - In compressed combos, the inner input starts tiny/hidden and can be briefly **covered** by layout.
+ *   If we try to type before focusing/opening, we’ll get the “element is being covered” flake.
+ *
+ * Previously, we use `cy.getElementByTestId('indicesFilter').type(\`${index}{enter}\`)`, it works sometimes
+ * because:
+ * - EUI sometimes sets **tabindex="0"** on the combobox wrapper (state-dependent). Cypress treats
+ *   `[tabindex]` as typeable, so it doesn’t error.
+ * - When the wrapper has focus, EUI’s keyboard handlers can **redirect keystrokes** to the inner
+ *   search input (or focus it on first key), so characters appear as if we typed in the input.
+ * - This depends on timing/layout (focused vs not, expanded vs collapsed, overlapped vs not),
+ *   which is why it’s flaky: sometimes the wrapper has `tabindex` and focus → works; other times it
+ *   doesn’t → Cypress errors or characters get lost mid re-render.
+ *
+ * This helper makes it deterministic by (1) focusing/opening, (2) typing into the **actual input**,
+ * and (3) asserting the pill so we wait for EUI’s async render.
+ *
+ * @param {string} testSubj - data-test-subj on the EuiComboBox wrapper (e.g., 'timestampFilter')
+ * @param {string} value    - text to type; we hit Enter to commit it
+ */
+Cypress.Commands.add('typeInEuiCombo', (testSubj, value) => {
+  cy.getElementByTestId(testSubj) // Grab the combo *wrapper* (<div ... role="combobox">)
+    .scrollIntoView({ block: 'center' }) // Make sure it’s on screen (avoids actionability failures)
+    .click({ force: true }) // Focus/open the combo; force beats transient overlays/animations
+    .within(() => {
+      // Scope subsequent queries to *this* combo instance only
+      cy.get('input[data-test-subj="comboBoxSearchInput"]', { timeout: 10000 })
+        // ^ This is the real, editable <input> inside the wrapper.
+        //   (Typing on the wrapper would fail; typing here succeeds.)
+        .type(`${value}{enter}`, { force: true }); // Type the text and press Enter to commit the selection.
+      // force=true also handles the input being zero-width pre-focus.
+    });
+
+  // Assert a "pill" with the chosen value appears. This both waits for EUI to render and
+  // proves the keystrokes actually selected something (reduces flakiness).
+  cy.getElementByTestId(testSubj)
+    .find('.euiComboBoxPill')
+    .should('contain.text', value);
+});
+
+/**
  * Custom command to perform the full forecaster creation flow
  * from the 'Define forecaster' step onwards.
  * @param {object} forecasterDetails - The details for the new forecaster.
@@ -157,10 +203,9 @@ Cypress.Commands.add('createForecaster', (forecasterDetails) => {
 
   cy.getElementByTestId('defineOrEditForecasterTitle').should('exist');
   cy.getElementByTestId('forecasterNameTextInput').type(name);
-  cy.getElementByTestId('indicesFilter').type(`${index}{enter}`);
-
-  // Type the timestamp field directly
-  cy.getElementByTestId('timestampFilter').type(`${timestampField}{enter}`);
+  // Type in the index
+  cy.typeInEuiCombo('indicesFilter', index);
+  cy.typeInEuiCombo('timestampFilter', timestampField);
 
   // Type the feature field name and then the field to forecast
   cy.getElementByTestId('featureNameTextInput-0').type(featureField);

--- a/cypress/utils/plugins/anomaly-detection-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/anomaly-detection-dashboards-plugin/commands.js
@@ -16,6 +16,26 @@ import {
 import { selectTopItemFromFilter } from './helpers';
 
 Cypress.Commands.add(
+  'handleTenantDialog',
+  {
+    prevSubject: 'optional',
+  },
+  () => {
+    // Handles the optional "Select your tenant" pop-up
+    cy.get('body').then(($body) => {
+      // We look for an element containing "Select your tenant" to avoid being
+      // specific about which tag (e.g. h1, h2) is used for the title.
+      if ($body.find(':contains("Select your tenant")').length > 0) {
+        const confirmButton = $body.find('button:contains("Confirm")');
+        if (confirmButton.length) {
+          cy.wrap(confirmButton.first()).click();
+        }
+      }
+    });
+  }
+);
+
+Cypress.Commands.add(
   'mockGetDetectorOnAction',
   function (fixtureFileName, funcMockedOn) {
     cy.intercept(AD_NODE_API_PATH.GET_DETECTORS, {
@@ -134,19 +154,6 @@ Cypress.Commands.add('createForecaster', (forecasterDetails) => {
     test = false,
     interval = 0,
   } = forecasterDetails;
-
-  // pop up for tenant selection
-  // Handles the optional "Select your tenant" pop-up
-  cy.get('body').then(($body) => {
-    // We look for an element containing "Select your tenant" to avoid being
-    // specific about which tag (e.g. h1, h2) is used for the title.
-    if ($body.find(':contains("Select your tenant")').length > 0) {
-      const confirmButton = $body.find('button:contains("Confirm")');
-      if (confirmButton.length) {
-        cy.wrap(confirmButton.first()).click();
-      }
-    }
-  });
 
   cy.getElementByTestId('defineOrEditForecasterTitle').should('exist');
   cy.getElementByTestId('forecasterNameTextInput').type(name);


### PR DESCRIPTION
### Description

backport the following to 3.1

https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1823
https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1835

### Issues Resolved

https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/1072

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
