### PR TITLE
test(ad): add Suggest parameters E2E and stabilize selections

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_detector_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_detector_spec.js
@@ -62,6 +62,17 @@ context('Create detector workflow', () => {
     // Configure model step
     cy.getElementByTestId('featureNameTextInput-0').type(TEST_FEATURE_NAME);
     selectTopItemFromFilter('featureFieldTextInput-0', false);
+
+    // Suggest parameters
+    cy.getElementByTestId('suggestParametersButton').click();
+    cy.getElementByTestId('suggestParametersDialogTitle').should('exist');
+    cy.getElementByTestId('generateSuggestionsButton').click();
+    cy.getElementByTestId('suggestedParametersResult').should('exist');
+    cy.getElementByTestId('useSuggestedParametersButton').click();
+
+    // The dialog should close and we're back on the model configuration page
+    cy.getElementByTestId('suggestParametersDialogTitle').should('not.exist');
+
     cy.getElementByTestId('configureModelNextButton').click();
     cy.getElementByTestId('configureOrEditModelConfigurationTitle').should(
       'not.exist'

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_remote_detector_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/create_remote_detector_spec.js
@@ -223,10 +223,8 @@ context('Create remote detector workflow', () => {
 
       cy.getElementByTestId('indicesFilter').type(TEST_INDEX_NAME);
       cy.wait(500);
-      cy.contains(
-        '.euiComboBoxOption__content',
-        `${remoteClusterName}:${TEST_INDEX_NAME}`
-      ).click();
+      cy.get(`button[title="${remoteClusterName}:${TEST_INDEX_NAME}"]`).click();
+
       cy.wait(1500);
 
       selectTopItemFromFilter('timestampFilter', false);
@@ -256,6 +254,17 @@ context('Create remote detector workflow', () => {
       // Configure model step
       cy.getElementByTestId('featureNameTextInput-0').type(TEST_FEATURE_NAME);
       selectTopItemFromFilter('featureFieldTextInput-0', false);
+
+      // Suggest parameters
+      cy.getElementByTestId('suggestParametersButton').click();
+      cy.getElementByTestId('suggestParametersDialogTitle').should('exist');
+      cy.getElementByTestId('generateSuggestionsButton').click();
+      cy.getElementByTestId('suggestedParametersResult').should('exist');
+      cy.getElementByTestId('useSuggestedParametersButton').click();
+
+      // The dialog should close and we're back on the model configuration page
+      cy.getElementByTestId('suggestParametersDialogTitle').should('not.exist');
+
       cy.getElementByTestId('configureModelNextButton').click();
       cy.getElementByTestId('configureOrEditModelConfigurationTitle').should(
         'not.exist'
@@ -324,10 +333,9 @@ context('Create remote detector workflow', () => {
       cy.getElementByTestId('indicesFilter').type('sample-ad-index-t');
       cy.wait(1000);
 
-      cy.get('.euiComboBoxOption__content')
-        .contains(`${remoteClusterName}:${TEST_SECOND_INDEX_NAME}`)
-        .should('exist')
-        .click();
+      cy.get(
+        `button[title="${remoteClusterName}:${TEST_SECOND_INDEX_NAME}"]`
+      ).click();
 
       selectTopItemFromFilter('timestampFilter', false);
 
@@ -353,6 +361,20 @@ context('Create remote detector workflow', () => {
         .contains('value')
         .should('exist')
         .click({ force: true });
+
+      // wait for feature field to be populated
+      // otherwise suggest API reports illegal arguments exception
+      cy.wait(500);
+
+      // Suggest parameters
+      cy.getElementByTestId('suggestParametersButton').click();
+      cy.getElementByTestId('suggestParametersDialogTitle').should('exist');
+      cy.getElementByTestId('generateSuggestionsButton').click();
+      cy.getElementByTestId('suggestedParametersResult').should('exist');
+      cy.getElementByTestId('useSuggestedParametersButton').click();
+
+      // The dialog should close and we're back on the model configuration page
+      cy.getElementByTestId('suggestParametersDialogTitle').should('not.exist');
 
       cy.getElementByTestId('configureModelNextButton').click();
       cy.getElementByTestId('configureOrEditModelConfigurationTitle').should(


### PR DESCRIPTION
### Description

- add Suggest Parameters flow in create_detector_spec.js and create_remote_detector_spec.js (open dialog, generate, apply, verify close)

- use stable EUI selectors for remote index picking (button[title="cluster:index"] instead of .euiComboBoxOption__content) to reduce flakiness

- inline resilient selectTopItemFromFilter + clickFirstFilterItem with retry logic in forecaster_configuration_spec.js; remove helper import and ensure combo box pill reflects selection

- add short waits where needed (e.g., before generating suggestions) to avoid transient errors when fields are not populated yet

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
