### PR TITLE
search-relevance plugin bypass modal window check

### DIFF
--- a/cypress/integration/plugins/search-relevance-dashboards/1_query_compare.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/1_query_compare.spec.js
@@ -32,6 +32,12 @@ describe('Compare queries', () => {
 
   it('Should get comparison results', () => {
     cy.visit(`${BASE_PATH}/app/${SEARCH_RELEVANCE_PLUGIN_NAME}`);
+    // Check for modal window and dismiss if present
+    cy.get('body').then(($body) => {
+      if ($body.find('button:contains("Dismiss")').length > 0) {
+        cy.get('button:contains("Dismiss")').click();
+      }
+    });
 
     // Check for euiCard with fail-safe
     cy.get('body').then(($body) => {


### PR DESCRIPTION
### Description
Flaky integration tests are found due to home page modal window check, bypassing modal window check


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
