### PR TITLE
[Fix] Fix flaky reports-dashboards edit tests by updating notebook API intercept path

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -31,7 +31,7 @@ describe('Cypress', () => {
       'search'
     );
 
-    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
+    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/savedNotebook`).as(
       'notebook'
     );
 
@@ -93,9 +93,7 @@ describe('Cypress', () => {
       'search'
     );
 
-    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
-      'notebook'
-    );
+    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/savedNotebook`).as('notebook');
 
     cy.get('#reportDefinitionDetailsLink').first().click();
 
@@ -152,7 +150,7 @@ describe('Cypress', () => {
       'search'
     );
 
-    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
+    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/savedNotebook`).as(
       'notebook'
     );
 

--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -31,9 +31,10 @@ describe('Cypress', () => {
       'search'
     );
 
-    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/savedNotebook`).as(
-      'notebook'
-    );
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
+    ).as('notebook');
 
     cy.get('#reportDefinitionDetailsLink').first().click({ force: true });
 
@@ -93,7 +94,10 @@ describe('Cypress', () => {
       'search'
     );
 
-    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/savedNotebook`).as('notebook');
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
+    ).as('notebook');
 
     cy.get('#reportDefinitionDetailsLink').first().click();
 
@@ -150,9 +154,10 @@ describe('Cypress', () => {
       'search'
     );
 
-    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/savedNotebook`).as(
-      'notebook'
-    );
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
+    ).as('notebook');
 
     cy.get('#reportDefinitionDetailsLink').first().click();
 


### PR DESCRIPTION
### Description

This PR fixes flaky Cypress tests in the reports-dashboards plugin by correcting the API intercept path for notebook requests.

The edit_spec was using an incomplete endpoint path (/api/observability/notebooks/) which could match unintended requests or miss the intended ones.
### Issues Resolved

###List any issues this PR will resolve

(https://github.com/opensearch-project/dashboards-reporting/issues/673)

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
