### PR TITLE
[Fix] Fix flaky reports-dashboards edit tests by updating notebook API intercept path

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -31,9 +31,10 @@ describe('Cypress', () => {
       'search'
     );
 
-    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
-      'notebook'
-    );
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
+    ).as('notebook');
 
     cy.get('#reportDefinitionDetailsLink').first().click({ force: true });
 
@@ -95,9 +96,10 @@ describe('Cypress', () => {
       'search'
     );
 
-    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
-      'notebook'
-    );
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
+    ).as('notebook');
 
     cy.get('#reportDefinitionDetailsLink').first().click();
 
@@ -154,9 +156,10 @@ describe('Cypress', () => {
       'search'
     );
 
-    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
-      'notebook'
-    );
+    cy.intercept(
+      'GET',
+      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
+    ).as('notebook');
 
     cy.get('#reportDefinitionDetailsLink').first().click();
 

--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -31,10 +31,14 @@ describe('Cypress', () => {
       'search'
     );
 
+    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
+      'notebook'
+    );
+
     cy.intercept(
       'GET',
       `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
+    ).as('savedNotebook');
 
     cy.get('#reportDefinitionDetailsLink').first().click({ force: true });
 
@@ -49,6 +53,7 @@ describe('Cypress', () => {
     cy.wait('@visualization');
     cy.wait('@search');
     cy.wait('@notebook');
+    cy.wait('@savedNotebook');
 
     // update the report name
     cy.get('#reportSettingsName')
@@ -96,10 +101,14 @@ describe('Cypress', () => {
       'search'
     );
 
+    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
+      'notebook'
+    );
+
     cy.intercept(
       'GET',
       `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
+    ).as('savedNotebook');
 
     cy.get('#reportDefinitionDetailsLink').first().click();
 
@@ -115,6 +124,7 @@ describe('Cypress', () => {
     cy.wait('@visualization');
     cy.wait('@search');
     cy.wait('@notebook');
+    cy.wait('@savedNotebook');
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(2)').click({
       force: true,
     });
@@ -156,10 +166,14 @@ describe('Cypress', () => {
       'search'
     );
 
+    cy.intercept('GET', `${BASE_PATH}/api/observability/notebooks/`).as(
+      'notebook'
+    );
+
     cy.intercept(
       'GET',
       `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
+    ).as('savedNotebook');
 
     cy.get('#reportDefinitionDetailsLink').first().click();
 
@@ -175,6 +189,7 @@ describe('Cypress', () => {
     cy.wait('@visualization');
     cy.wait('@search');
     cy.wait('@notebook');
+    cy.wait('@savedNotebook');
 
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(1)').click({
       force: true,


### PR DESCRIPTION
### Description

Backport https://github.com/opensearch-project/opensearch-dashboards-functional-test/commit/b39db2d5f19580999c1b806e197029e05146673d from https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1908

added other url to notebook and savedbook
### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
