### PR TITLE
Fix security Cypress 13 test stability

### DIFF
--- a/cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js
@@ -26,10 +26,7 @@ const kibanaRoleName = 'kibana_user';
 
 if (Cypress.env('SECURITY_ENABLED') && Cypress.env('AGGREGATION_VIEW')) {
   describe('Saved objects table test', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
     before(() => {
-      cy.intercept();
       cy.createTenant(tenantName, tenantDescription);
 
       cy.createIndexPattern('index-pattern1', {

--- a/cypress/integration/plugins/security-dashboards-plugin/change_tenant_successfully.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/change_tenant_successfully.js
@@ -11,7 +11,6 @@ if (Cypress.env('SECURITY_ENABLED')) {
     const tenantName = 'private';
 
     before(() => {
-      cy.intercept();
       localStorage.setItem('home:welcome:show', false);
       localStorage.setItem('home:newThemeModal:show', false);
     });

--- a/cypress/integration/plugins/security-dashboards-plugin/change_tenant_successfully.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/change_tenant_successfully.js
@@ -13,6 +13,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
     before(() => {
       localStorage.setItem('home:welcome:show', false);
       localStorage.setItem('home:newThemeModal:show', false);
+      localStorage.setItem('home:enhancedDiscover:dismissed', 'true');
     });
     it('Checks that the tenant switcher can switch tenants despite a different tenant being present in the tenant query parameter.', function () {
       CURRENT_TENANT.newTenant = tenantName;
@@ -21,7 +22,7 @@ if (Cypress.env('SECURITY_ENABLED')) {
         cy.waitForLoader();
         switchTenantTo('global');
         cy.waitForLoader();
-        cy.getElementByTestId('account-popover').click();
+        cy.getElementByTestId('account-popover').click({ force: true });
         cy.get('#tenantName').should('contain.text', 'Global');
       });
     });

--- a/cypress/integration/plugins/security-dashboards-plugin/default_tenant.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/default_tenant.js
@@ -13,7 +13,6 @@ const tenantName = 'test';
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Multi Tenancy Default Tenant Tests: ', () => {
     before(() => {
-      cy.intercept();
       cy.createTenant(tenantName, tenantDescription);
       cy.changeDefaultTenant({
         multitenancy_enabled: true,

--- a/cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js
@@ -19,7 +19,6 @@ const tenantName = 'test';
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Multi Tenancy Tests: ', () => {
     before(() => {
-      cy.intercept();
       cy.createTenant(tenantName, tenantDescription);
       cy.createIndexPattern(
         'index-pattern1',

--- a/cypress/integration/plugins/security-dashboards-plugin/readonly.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/readonly.js
@@ -33,8 +33,6 @@ const TEST_CONFIG = {
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Read Only mode', () => {
     before(() => {
-      cy.intercept();
-
       cy.createTenant(TEST_CONFIG.tenant.name, {
         description: TEST_CONFIG.tenant.description,
       });

--- a/cypress/integration/plugins/security-dashboards-plugin/readonly.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/readonly.js
@@ -61,6 +61,10 @@ if (Cypress.env('SECURITY_ENABLED')) {
           );
           window.localStorage.setItem('home:newThemeModal:show', false);
           window.localStorage.setItem('home:welcome:show', false);
+          window.localStorage.setItem(
+            'home:enhancedDiscover:dismissed',
+            'true'
+          );
         },
       });
       cy.waitForLoader();

--- a/cypress/integration/plugins/security-dashboards-plugin/switch_tenant.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/switch_tenant.js
@@ -4,7 +4,7 @@
  */
 
 export function switchTenantTo(newTenant) {
-  cy.getElementByTestId('account-popover').click();
+  cy.getElementByTestId('account-popover').click({ force: true });
   cy.intercept({
     method: 'GET',
     url: '/api/v1/auth/dashboardsinfo*',
@@ -15,24 +15,26 @@ export function switchTenantTo(newTenant) {
     url: '/api/v1/configuration/account*',
   }).as('waitForAccountInfo');
 
-  cy.getElementByTestId('switch-tenants').click();
+  cy.getElementByTestId('switch-tenants').click({ force: true });
 
   if (['global', 'private'].includes(newTenant)) {
     cy.get('[id="' + newTenant + '"][name="tenantSwitchRadios"]').should(
       'be.enabled'
     );
-    cy.get('.euiRadio__label[for="' + newTenant + '"]').click();
+    cy.get('.euiRadio__label[for="' + newTenant + '"]').click({
+      force: true,
+    });
   } else {
     cy.get('[id="custom"][name="tenantSwitchRadios"]').should('be.enabled');
 
     cy.getElementByTestId('tenant-switch-modal')
       .find('[data-test-subj="comboBoxInput"]')
-      .click();
+      .click({ force: true });
 
     // typo in data-test-subj
     cy.getElementByTestId('comboBoxOptionsList ')
       .find(`[title="${newTenant}"]`)
-      .click();
+      .click({ force: true });
   }
 
   cy.intercept({
@@ -41,7 +43,7 @@ export function switchTenantTo(newTenant) {
   }).as('waitForUpdatingTenants');
   cy.getElementByTestId('tenant-switch-modal')
     .find('[data-test-subj="confirm"]')
-    .click();
+    .click({ force: true });
 
   cy.wait('@waitForUpdatingTenants');
 

--- a/cypress/integration/plugins/security-dashboards-plugin/tenancy_change_on_shortlink.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/tenancy_change_on_shortlink.js
@@ -8,10 +8,6 @@ import { switchTenantTo } from './switch_tenant';
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Multi Tenancy Tests: ', () => {
-    before(() => {
-      cy.intercept();
-    });
-
     it('Tests that when the short URL is copied and pasted, it will route correctly with the right tenant', function () {
       const randomNumber = Cypress._.random(0, 1e6);
       const dashboardName = 'Cypress dashboard - ' + randomNumber;

--- a/cypress/integration/plugins/security/audit_log_spec.js
+++ b/cypress/integration/plugins/security/audit_log_spec.js
@@ -15,7 +15,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
         SEC_AUDIT_FIXTURES_PATH + '/audit_info_response.json',
         () => {
           cy.visit(SEC_UI_AUDIT_LOGGING_PATH);
-        }
+        },
+        { reloadAfterAction: true }
       );
 
       cy.contains('h1', 'Audit logging');
@@ -24,7 +25,13 @@ if (Cypress.env('SECURITY_ENABLED')) {
     });
 
     it('should toggle enable-disable switch for audit logging', () => {
-      cy.visit(SEC_UI_AUDIT_LOGGING_PATH);
+      cy.mockAuditLogsAction(
+        SEC_AUDIT_FIXTURES_PATH + '/audit_info_response.json',
+        () => {
+          cy.visit(SEC_UI_AUDIT_LOGGING_PATH);
+        },
+        { reloadAfterAction: true }
+      );
 
       // enabled by default
       cy.contains('.euiSwitch', 'Enabled');
@@ -55,7 +62,13 @@ if (Cypress.env('SECURITY_ENABLED')) {
     });
 
     it('should configure general settings successfully', () => {
-      cy.visit(SEC_UI_AUDIT_LOGGING_PATH);
+      cy.mockAuditLogsAction(
+        SEC_AUDIT_FIXTURES_PATH + '/audit_info_response.json',
+        () => {
+          cy.visit(SEC_UI_AUDIT_LOGGING_PATH);
+        },
+        { reloadAfterAction: true }
+      );
 
       cy.get('button[data-test-subj="general-settings-configure"]')
         .first()
@@ -90,7 +103,13 @@ if (Cypress.env('SECURITY_ENABLED')) {
     });
 
     it('should configure compliance settings successfully', () => {
-      cy.visit(SEC_UI_AUDIT_LOGGING_PATH);
+      cy.mockAuditLogsAction(
+        SEC_AUDIT_FIXTURES_PATH + '/audit_info_response.json',
+        () => {
+          cy.visit(SEC_UI_AUDIT_LOGGING_PATH);
+        },
+        { reloadAfterAction: true }
+      );
 
       cy.get('button[data-test-subj="compliance-settings-configure"]')
         .first()

--- a/cypress/integration/plugins/security/audit_log_spec.js
+++ b/cypress/integration/plugins/security/audit_log_spec.js
@@ -10,12 +10,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Audit logs page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.intercept();
-    });
-
     it('should load Audit logs page properly', () => {
       cy.mockAuditLogsAction(
         SEC_AUDIT_FIXTURES_PATH + '/audit_info_response.json',

--- a/cypress/integration/plugins/security/auth_spec.js
+++ b/cypress/integration/plugins/security/auth_spec.js
@@ -11,9 +11,13 @@ import {
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Authc and Authz page', () => {
     it('authentication and authorization section should exist', () => {
-      cy.mockAuthAction(SEC_FIXTURES_BASE_PATH + '/auth_response.json', () => {
-        cy.visit(SEC_UI_AUTH_PATH);
-      });
+      cy.mockAuthAction(
+        SEC_FIXTURES_BASE_PATH + '/auth_response.json',
+        () => {
+          cy.visit(SEC_UI_AUTH_PATH);
+        },
+        { reloadAfterAction: true }
+      );
 
       cy.contains('h3', 'Authentication sequences');
       cy.contains('span', 'kerberos_auth_domain');
@@ -23,9 +27,13 @@ if (Cypress.env('SECURITY_ENABLED')) {
     });
 
     it('View Expression Modal should display and close correctly', () => {
-      cy.mockAuthAction(SEC_FIXTURES_BASE_PATH + '/auth_response.json', () => {
-        cy.visit(SEC_UI_AUTH_PATH);
-      });
+      cy.mockAuthAction(
+        SEC_FIXTURES_BASE_PATH + '/auth_response.json',
+        () => {
+          cy.visit(SEC_UI_AUTH_PATH);
+        },
+        { reloadAfterAction: true }
+      );
 
       cy.get('.euiModal').should('not.exist');
 

--- a/cypress/integration/plugins/security/auth_spec.js
+++ b/cypress/integration/plugins/security/auth_spec.js
@@ -10,12 +10,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Authc and Authz page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.intercept();
-    });
-
     it('authentication and authorization section should exist', () => {
       cy.mockAuthAction(SEC_FIXTURES_BASE_PATH + '/auth_response.json', () => {
         cy.visit(SEC_UI_AUTH_PATH);

--- a/cypress/integration/plugins/security/get_started_spec.js
+++ b/cypress/integration/plugins/security/get_started_spec.js
@@ -10,12 +10,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Home(Get Started) page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.intercept();
-    });
-
     it('should load Home page properly', () => {
       cy.visit(BASE_SEC_UI_PATH);
 

--- a/cypress/integration/plugins/security/inaccessible_tenancy_features.js
+++ b/cypress/integration/plugins/security/inaccessible_tenancy_features.js
@@ -7,9 +7,6 @@ import { SECURITY_PLUGIN_PATH } from '../../../utils/dashboards/constants';
 
 if (Cypress.env('SECURITY_ENABLED') && !Cypress.env('MULTITENANCY_ENABLED')) {
   describe('Multi Tenancy Tests: ', () => {
-    before(() => {
-      cy.intercept();
-    });
     it('Test Dashboards tenancy features should not be accessible ', () => {
       // This test is to ensure tenancy related features are not accessible when opensearch_security.multitenancy.enabled is disabled in the opensearchdashboard.yaml
       cy.visit(SECURITY_PLUGIN_PATH);

--- a/cypress/integration/plugins/security/internalusers_spec.js
+++ b/cypress/integration/plugins/security/internalusers_spec.js
@@ -16,7 +16,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
         SEC_INTERNALUSERS_FIXTURES_PATH + '/internalusers_info_response.json',
         () => {
           cy.visit(SEC_UI_INTERNAL_USERS_PATH);
-        }
+        },
+        { reloadAfterAction: true }
       );
 
       cy.contains('h3', 'Internal users');
@@ -30,7 +31,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
         SEC_INTERNALUSERS_FIXTURES_PATH + '/internalusers_info_response.json',
         () => {
           cy.visit(SEC_UI_INTERNAL_USERS_PATH);
-        }
+        },
+        { reloadAfterAction: true }
       );
 
       cy.get('a[href*="#/users/edit/logstash"]').click({ force: true });
@@ -48,7 +50,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
         SEC_INTERNALUSERS_FIXTURES_PATH + '/internalusers_info_response.json',
         () => {
           cy.visit(SEC_UI_INTERNAL_USERS_PATH);
-        }
+        },
+        { reloadAfterAction: true }
       );
 
       cy.contains('span', 'Create internal user');

--- a/cypress/integration/plugins/security/internalusers_spec.js
+++ b/cypress/integration/plugins/security/internalusers_spec.js
@@ -11,12 +11,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Internal users page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.intercept();
-    });
-
     it('should load internal users page properly', () => {
       cy.mockInternalUsersAction(
         SEC_INTERNALUSERS_FIXTURES_PATH + '/internalusers_info_response.json',

--- a/cypress/integration/plugins/security/permissions_spec.js
+++ b/cypress/integration/plugins/security/permissions_spec.js
@@ -10,12 +10,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Permissions page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.intercept();
-    });
-
     it('should load Permissions page properly', () => {
       cy.mockPermissionsAction(
         SEC_PERMISSIONS_FIXTURES_PATH + '/actiongroups_response.json',

--- a/cypress/integration/plugins/security/permissions_spec.js
+++ b/cypress/integration/plugins/security/permissions_spec.js
@@ -15,7 +15,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
         SEC_PERMISSIONS_FIXTURES_PATH + '/actiongroups_response.json',
         () => {
           cy.visit(SEC_UI_PERMISSIONS_PATH);
-        }
+        },
+        { reloadAfterAction: true }
       );
 
       cy.contains('h3', 'Permissions');
@@ -29,7 +30,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
         SEC_PERMISSIONS_FIXTURES_PATH + '/actiongroups_response.json',
         () => {
           cy.visit(SEC_UI_PERMISSIONS_PATH);
-        }
+        },
+        { reloadAfterAction: true }
       );
 
       cy.get('tr[class="euiTableRow euiTableRow-isExpandedRow"]').should(
@@ -52,7 +54,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
         SEC_PERMISSIONS_FIXTURES_PATH + '/actiongroups_response.json',
         () => {
           cy.visit(SEC_UI_PERMISSIONS_PATH);
-        }
+        },
+        { reloadAfterAction: true }
       );
 
       cy.contains('button', 'Create from blank').should('not.exist');

--- a/cypress/integration/plugins/security/roles_spec.js
+++ b/cypress/integration/plugins/security/roles_spec.js
@@ -16,7 +16,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
         SEC_ROLES_FIXTURES_PATH + '/roles_response.json',
         () => {
           cy.visit(SEC_UI_ROLES_PATH);
-        }
+        },
+        { reloadAfterAction: true }
       );
 
       cy.contains('h3', 'Roles');
@@ -31,7 +32,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
         SEC_ROLES_FIXTURES_PATH + '/roles_response.json',
         () => {
           cy.visit(SEC_UI_ROLES_PATH);
-        }
+        },
+        { reloadAfterAction: true }
       );
 
       // one of the cluster permissions
@@ -53,7 +55,8 @@ if (Cypress.env('SECURITY_ENABLED')) {
         SEC_ROLES_FIXTURES_PATH + '/roles_response.json',
         () => {
           cy.visit(SEC_UI_ROLES_PATH);
-        }
+        },
+        { reloadAfterAction: true }
       );
 
       cy.contains('span', 'Create role');

--- a/cypress/integration/plugins/security/roles_spec.js
+++ b/cypress/integration/plugins/security/roles_spec.js
@@ -11,12 +11,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Roles page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.intercept();
-    });
-
     it('should load Roles page properly', () => {
       cy.mockRolesAction(
         SEC_ROLES_FIXTURES_PATH + '/roles_response.json',

--- a/cypress/integration/plugins/security/tenants_spec.js
+++ b/cypress/integration/plugins/security/tenants_spec.js
@@ -10,12 +10,6 @@ import {
 
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Tenants page', () => {
-    // start a server so that server responses can be mocked via fixtures
-    // in all of the below test cases
-    before(() => {
-      cy.intercept();
-    });
-
     it('should load Tenants page properly', () => {
       cy.mockTenantsAction(
         SEC_TENANTS_FIXTURES_PATH + '/tenants_info_response.json',

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -63,7 +63,7 @@ module.exports = (on, config) => {
   const options = {
     webpackOptions: {
       resolve: {
-        extensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
+        extensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx', '.json'],
       },
       module: {
         rules: [

--- a/cypress/utils/plugins/security/commands.js
+++ b/cypress/utils/plugins/security/commands.js
@@ -14,6 +14,12 @@ import {
   SEC_API_INTERNAL_USERS_PATH,
 } from '../../constants';
 
+function reloadAfterActionIfNeeded(options = {}) {
+  if (options.reloadAfterAction) {
+    cy.reload();
+  }
+}
+
 /**
  *****************************
  SECURITY PLUGIN COMMANDS
@@ -21,12 +27,13 @@ import {
  */
 Cypress.Commands.add(
   'mockAuthAction',
-  function (fixtureFileName, funcMockedOn) {
+  function (fixtureFileName, funcMockedOn, options) {
     cy.intercept(`${SEC_API_CONFIG_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getAuthDetails');
 
     funcMockedOn();
+    reloadAfterActionIfNeeded(options);
 
     cy.wait('@getAuthDetails');
   }
@@ -34,12 +41,13 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'mockRolesAction',
-  function (fixtureFileName, funcMockedOn) {
+  function (fixtureFileName, funcMockedOn, options) {
     cy.intercept(`${SEC_API_ROLES_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getRoleDetails');
 
     funcMockedOn();
+    reloadAfterActionIfNeeded(options);
 
     cy.wait('@getRoleDetails');
   }
@@ -47,12 +55,13 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'mockInternalUsersAction',
-  function (fixtureFileName, funcMockedOn) {
+  function (fixtureFileName, funcMockedOn, options) {
     cy.intercept(`${SEC_API_INTERNAL_USERS_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getInternalUsersDetails');
 
     funcMockedOn();
+    reloadAfterActionIfNeeded(options);
 
     cy.wait('@getInternalUsersDetails');
   }
@@ -60,12 +69,13 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'mockPermissionsAction',
-  function (fixtureFileName, funcMockedOn) {
+  function (fixtureFileName, funcMockedOn, options) {
     cy.intercept(`${SEC_API_ACTIONGROUPS_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getPermissions');
 
     funcMockedOn();
+    reloadAfterActionIfNeeded(options);
 
     cy.wait('@getPermissions');
   }
@@ -73,12 +83,13 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'mockTenantsAction',
-  function (fixtureFileName, funcMockedOn) {
+  function (fixtureFileName, funcMockedOn, options) {
     cy.intercept(`${SEC_API_TENANTS_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getTenants');
 
     funcMockedOn();
+    reloadAfterActionIfNeeded(options);
 
     cy.wait('@getTenants');
   }
@@ -86,12 +97,13 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   'mockAuditLogsAction',
-  function (fixtureFileName, funcMockedOn) {
+  function (fixtureFileName, funcMockedOn, options) {
     cy.intercept(`${SEC_API_AUDIT_PATH}*`, {
       fixture: fixtureFileName,
     }).as('getAuditInfo');
 
     funcMockedOn();
+    reloadAfterActionIfNeeded(options);
 
     cy.wait('@getAuditInfo');
   }


### PR DESCRIPTION
### Description

The Cypress 13 upgrade exposed a few security test issues:

- Bare `cy.intercept()` calls are invalid in Cypress 13 and are not needed after migrating away from `cy.server()` / `cy.route()`.
- Some security page tests revisit the same app route with `testIsolation: false`, so the expected API request is not always reissued before `cy.wait('@alias')`.
- EUI tenant-switch controls can be reported as covered by overlays or modal layout elements under Cypress 13 actionability checks.
- Audit log tests depended on page state from a prior test instead of reloading the mocked audit info response for each test that needs enabled audit UI.

This PR removes the invalid bare intercept calls, makes page-load API mocks explicitly reload when needed, stabilizes tenant switching interactions, and re-mocks audit info where tests depend on it.

Fixes the CI failure in: https://github.com/opensearch-project/security-dashboards-plugin/actions/runs/25518993743/job/74897688623?pr=2422

### Testing

Local Cypress 13.17.0 runs against Dashboards at `http://localhost:5601`:

- `cypress/integration/plugins/security-dashboards-plugin/readonly.js` - 2 passing
- `cypress/integration/plugins/security-dashboards-plugin/change_tenant_successfully.js` - 1 passing
- Grouped security specs passed locally: `auth_spec.js`, `roles_spec.js`, `internalusers_spec.js`, `permissions_spec.js`, `audit_log_spec.js`
- ESLint passed on touched files

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
