### PR TITLE
Fix observability services spec formatting

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js
@@ -44,4 +44,3 @@ describe('Testing services table', { testIsolation: true }, () => {
     cy.get('body').should('contain', 'Overview');
   });
 });
-


### PR DESCRIPTION
### Description

Fixes the lint failure in `cypress/integration/plugins/observability-dashboards/2_trace_analytics_services.spec.js` by removing the extra trailing blank line at EOF.

### Testing

- `yarn lint`

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
