### PR TITLE
Fix security-dashboards-plugin test stability

### DIFF
--- a/cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js
@@ -27,6 +27,9 @@ const kibanaRoleName = 'kibana_user';
 if (Cypress.env('SECURITY_ENABLED') && Cypress.env('AGGREGATION_VIEW')) {
   describe('Saved objects table test', () => {
     before(() => {
+      cy.deleteIndexPattern('index-pattern1', { failOnStatusCode: false });
+      cy.deleteIndexPattern('index-pattern2', { failOnStatusCode: false });
+
       cy.createTenant(tenantName, tenantDescription);
 
       cy.createIndexPattern('index-pattern1', {
@@ -68,13 +71,14 @@ if (Cypress.env('SECURITY_ENABLED') && Cypress.env('AGGREGATION_VIEW')) {
       cy.contains('a', 'Saved objects');
 
       cy.contains('button', 'Tenant').click({ force: true });
-      cy.contains('Private').click();
-      cy.contains('s*');
+      cy.contains('.euiFilterSelectItem', 'Private').click();
+      cy.contains('button', 'Tenant').click({ force: true });
       cy.contains('se*').should('not.exist');
+      cy.contains('s*');
 
-      cy.wait(3000);
-
-      cy.contains('test').click();
+      cy.contains('button', 'Tenant').click({ force: true });
+      cy.contains('.euiFilterSelectItem', 'test').click();
+      cy.contains('button', 'Tenant').click({ force: true });
       cy.contains('s*');
       cy.contains('se*');
     });

--- a/cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js
@@ -19,7 +19,9 @@ const tenantName = 'test';
 const setTenancyConfig = (config) => {
   cy.request({
     method: 'PUT',
-    url: `${Cypress.env('openSearchUrl')}/_plugins/_security/api/tenancy/config`,
+    url: `${Cypress.env(
+      'openSearchUrl'
+    )}/_plugins/_security/api/tenancy/config`,
     body: config,
   });
 };

--- a/cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js
@@ -16,9 +16,20 @@ import tenantDescription from '../../../fixtures/plugins/security-dashboards-plu
 
 const tenantName = 'test';
 
+const setTenancyConfig = (config) => {
+  cy.request({
+    method: 'PUT',
+    url: `${Cypress.env('openSearchUrl')}/_plugins/_security/api/tenancy/config`,
+    body: config,
+  });
+};
+
 if (Cypress.env('SECURITY_ENABLED')) {
   describe('Multi Tenancy Tests: ', () => {
     before(() => {
+      cy.deleteIndexPattern('index-pattern1', { failOnStatusCode: false });
+      cy.deleteIndexPattern('index-pattern2', { failOnStatusCode: false });
+
       cy.createTenant(tenantName, tenantDescription);
       cy.createIndexPattern(
         'index-pattern1',
@@ -55,26 +66,21 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.get('#user-icon-btn').click();
       cy.contains('button', 'Switch tenants').should('exist');
 
-      // Disable multi-tenancy.
+      // Disable multi-tenancy via API.
+      setTenancyConfig({
+        multitenancy_enabled: false,
+        private_tenant_enabled: true,
+        default_tenant: 'Private',
+      });
+
       cy.visit(TENANTS_MANAGE_PATH);
-      cy.waitForLoader();
-
-      cy.contains('button', 'Configure').click();
-      cy.waitForLoader();
-      cy.get('#EnableMultitenancyCheckBox').uncheck({ force: true });
-      cy.contains('button', 'Save Changes').click();
-
-      cy.get('#tenancyChangeCheckbox').check({ force: true });
-      cy.contains('button', 'Apply changes').click();
-
-      cy.reload();
       cy.waitForLoader();
 
       // Switch tenants button should not exist when multi-tenancy is disabled.
       cy.get('#user-icon-btn').click();
       cy.contains('button', 'Switch tenants').should('not.exist');
 
-      //Tenancy disbaled warning should show on manage page.
+      //Tenancy disabled warning should show on manage page.
       cy.contains('Tenancy is disabled').should('exist');
 
       // Saved index pattern should only have the ones saved in Global tenant.
@@ -84,14 +90,12 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.contains('s*');
 
       // Enable Multi-tenancy before closing test.
-      cy.visit(TENANTS_MANAGE_PATH);
-      cy.waitForLoader();
-      cy.contains('button', 'Configure').click();
-      cy.waitForLoader();
-      cy.get('#EnableMultitenancyCheckBox').check({ force: true });
-      cy.contains('button', 'Save Changes').click();
-      cy.get('#tenancyChangeCheckbox').check({ force: true });
-      cy.contains('button', 'Apply changes').click();
+      setTenancyConfig({
+        multitenancy_enabled: true,
+        private_tenant_enabled: true,
+        default_tenant: 'Private',
+      });
+
       cy.reload();
       cy.waitForLoader();
     });
@@ -110,22 +114,17 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.get('#private').should('be.enabled');
       cy.contains('button', 'Cancel').click();
 
-      // Disable private tenant.
+      // Disable private tenant via API.
+      setTenancyConfig({
+        multitenancy_enabled: true,
+        private_tenant_enabled: false,
+        default_tenant: 'Global',
+      });
+
       cy.visit(TENANTS_MANAGE_PATH);
       cy.waitForLoader();
 
-      cy.contains('button', 'Configure').click();
-      cy.waitForLoader();
-      cy.get('#EnablePrivateTenantCheckBox').uncheck({ force: true });
-      cy.contains('button', 'Save Changes').click();
-
-      cy.get('#privateTenancyChangeCheckbox').check({ force: true });
-      cy.contains('button', 'Apply changes').click();
-
-      cy.reload();
-      cy.waitForLoader();
-
-      // Check if switching to private tenant is enabled.
+      // Check if switching to private tenant is disabled.
       cy.get('#user-icon-btn').click();
       cy.contains('button', 'Switch tenants').click();
       cy.get('#private').should('be.disabled');
@@ -138,14 +137,12 @@ if (Cypress.env('SECURITY_ENABLED')) {
       cy.contains('s*');
 
       // Enable private tenant before exiting test.
-      cy.visit(TENANTS_MANAGE_PATH);
-      cy.waitForLoader();
-      cy.contains('button', 'Configure').click();
-      cy.waitForLoader();
-      cy.get('#EnablePrivateTenantCheckBox').check({ force: true });
-      cy.contains('button', 'Save Changes').click();
-      cy.get('#privateTenancyChangeCheckbox').check({ force: true });
-      cy.contains('button', 'Apply changes').click();
+      setTenancyConfig({
+        multitenancy_enabled: true,
+        private_tenant_enabled: true,
+        default_tenant: 'Private',
+      });
+
       cy.reload();
       cy.waitForLoader();
     });


### PR DESCRIPTION
### Description

Fixes `multi_tenancy.js` and `aggregation_view.js` test failures that occur with Cypress 13.

**multi_tenancy.js:**
- Replace UI checkbox interactions with direct API calls to the tenancy config endpoint (`_plugins/_security/api/tenancy/config`). The `EuiCompressedCheckbox` with a `disabled` prop doesn't respond to Cypress `.uncheck({force:true})` due to React 18 event handling changes — the native DOM events fire but React's synthetic event system doesn't pick them up.
- Add idempotent cleanup in `before` hook to prevent 409 conflicts on re-runs.

**aggregation_view.js:**
- Fix filter selector: use `.euiFilterSelectItem` instead of the removed `.euiFilterSelect__items` class.
- Add idempotent cleanup in `before` hook to prevent 409 conflicts.
- Close the filter dropdown after selection to ensure the filter is applied before assertions.

### Testing

Both tests pass locally with Cypress 13.17.0 and Chrome 147 (headless):

```
  Multi Tenancy Tests:
    ✓ Test 1 Disable Multi Tenancy  (25424ms)
    ✓ Test 2 Disable Private Tenancy  (5164ms)

  2 passing (33s)
```

```
  Saved objects table test
    ✓ should check the saved objects as global tenant (107495ms)
    ✓ should check the saved objects by applying filter
    ✓ should login as test1 and check saved object (5053ms)
    ✓ should login as test2 and check saved object (5044ms)

  4 passing (2m)
```

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.