### PR TITLE
Fix AD dashboard and detector list Cypress test reliability

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/dashboard_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/dashboard_spec.js
@@ -10,6 +10,14 @@ import { selectTopItemFromFilter } from '../../../utils/helpers';
 describe('AD Dashboard page', () => {
   before(() => {});
 
+  beforeEach(() => {
+    // Force a fresh page state between tests to prevent stale responses
+    // from interfering with cy.intercept on subsequent navigations
+    cy.window().then((win) => {
+      win.sessionStorage.clear();
+    });
+  });
+
   it('Empty - no detector index', () => {
     cy.mockGetDetectorOnAction(
       AD_FIXTURE_BASE_PATH + 'no_detector_index_response.json',

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/detector_list_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/detector_list_spec.js
@@ -14,6 +14,14 @@ import { selectTopItemFromFilter } from '../../../utils/helpers';
 describe('Detector list page', () => {
   before(() => {});
 
+  beforeEach(() => {
+    // Force a fresh page state between tests to prevent stale responses
+    // from interfering with cy.intercept on subsequent navigations
+    cy.window().then((win) => {
+      win.sessionStorage.clear();
+    });
+  });
+
   it('Empty - no detector index', () => {
     cy.mockGetDetectorOnAction(
       AD_FIXTURE_BASE_PATH + 'no_detector_index_response.json',

--- a/cypress/utils/plugins/anomaly-detection-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/anomaly-detection-dashboards-plugin/commands.js
@@ -4,7 +4,6 @@
  */
 
 import {
-  AD_NODE_API_PATH,
   getADStartDetectorNodeApiPath,
   getADStopDetectorNodeApiPath,
   getADDeleteDetectorNodeApiPath,
@@ -38,44 +37,44 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'mockGetDetectorOnAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(AD_NODE_API_PATH.GET_DETECTORS, {
+    cy.intercept('GET', '**/api/anomaly_detectors/detectors/_list*', {
       fixture: fixtureFileName,
     }).as('getDetectors');
 
     funcMockedOn();
 
-    cy.wait('@getDetectors');
+    cy.wait('@getDetectors', { timeout: 60000 });
   }
 );
 
 Cypress.Commands.add(
   'mockGetDetectorsAndIndicesOnAction',
   function (detectorsFixtureFileName, indexFixtureFileName, funcMockedOn) {
-    cy.intercept(AD_NODE_API_PATH.GET_DETECTORS, {
+    cy.intercept('GET', '**/api/anomaly_detectors/detectors/_list*', {
       fixture: detectorsFixtureFileName,
     }).as('getDetectors');
 
-    cy.intercept(AD_NODE_API_PATH.GET_INDICES, {
+    cy.intercept('GET', '**/api/anomaly_detectors/_indices*', {
       fixture: indexFixtureFileName,
     }).as('getIndices');
 
     funcMockedOn();
 
-    cy.wait('@getDetectors');
-    cy.wait('@getIndices');
+    cy.wait('@getDetectors', { timeout: 60000 });
+    cy.wait('@getIndices', { timeout: 60000 });
   }
 );
 
 Cypress.Commands.add(
   'mockSearchIndexOnAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(AD_NODE_API_PATH.GET_INDICES, {
+    cy.intercept('GET', '**/api/anomaly_detectors/_indices*', {
       fixture: fixtureFileName,
     }).as('getIndices');
 
     funcMockedOn();
 
-    cy.wait('@getIndices');
+    cy.wait('@getIndices', { timeout: 60000 });
   }
 );
 


### PR DESCRIPTION
### Description

Fixes flaky `dashboard_spec.js` (7/8 tests failing) and `detector_list_spec.js` (10/11 tests failing) in the anomaly detection integration tests.

**Failure pattern observed:** The first test in each spec passes, but all subsequent tests fail with:
```
cy.wait() timed out waiting 60000ms for the 1st request to the route: getDetectors. No request ever occurred.
```

**Root cause from CI video analysis** ([dashboard_spec.js video](https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/3.6.0/8884/linux/x64/tar/test-results/8509/integ-test/anomalyDetectionDashboards/with-security/cypress-videos/dashboard_spec.js.mp4)):

On the second test, the page shows "unable to get detectors" — meaning the real server request leaked through the `cy.intercept` and the server returned an error. The intercept failed to match the request.

**Why the intercept fails:**

The `mockGetDetectorOnAction` command uses `AD_NODE_API_PATH.GET_DETECTORS` which resolves to a full URL string:
```
http://localhost:5601/api/anomaly_detectors/detectors/_list*
```

When `cy.intercept` receives a string starting with `http://`, it performs a **full URL match**. If the browser makes the request with any origin difference (port binding, protocol, or the way Cypress proxies requests on subsequent navigations within the same spec), the intercept silently fails to match. The request hits the real server, which returns an error (no actual detector index exists in CI), and the UI enters an error state. Since the page never retries the request, `cy.wait('@getDetectors')` times out.

**Fix (two parts):**

1. **Replace full-URL intercept patterns with `**` glob patterns** — e.g., `**/api/anomaly_detectors/detectors/_list*` matches regardless of origin. Also adds explicit HTTP method (`'GET'`) to narrow matching.

2. **Add `beforeEach` that clears sessionStorage** — prevents stale cached state from a prior test from suppressing the API call on subsequent `cy.visit()` navigations.

**Prior art in this repo:**

This follows the same pattern already used by other plugins:
- `query-insights-dashboards`: `cy.intercept('GET', '**/api/top_queries/**', ...)` ([1_top_queries_spec.js](https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/main/cypress/integration/plugins/query-insights-dashboards/1_top_queries_spec.js#L415))
- `query-workbench-dashboards`: `cy.intercept('**/api/sql_console/pplquery')` ([ui.spec.js](https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/main/cypress/integration/plugins/query-workbench-dashboards/ui.spec.js#L56))
- `security-analytics`: Uses regex `new RegExp(.*${url}.*)` for the same reason ([helpers.js](https://github.com/opensearch-project/opensearch-dashboards-functional-test/blob/main/cypress/utils/plugins/security-analytics-dashboards-plugin/helpers.js#L21))

**CI failure reference:** https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/3.6.0/8884/linux/x64/tar/test-results/8509/integ-test/anomalyDetectionDashboards/with-security/stdout.txt

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).