### PR TITLE
Fix security aggregation view Cypress stability

### DIFF
--- a/cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js
+++ b/cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js
@@ -14,6 +14,7 @@ import roleWithoutTestSetUp from '../../../fixtures/plugins/security-dashboards-
 import kibanaRoleMappingSetUp from '../../../fixtures/plugins/security-dashboards-plugin/rolesmapping/kibanauserRoleMapping';
 import roleWithTestMappingSetUp from '../../../fixtures/plugins/security-dashboards-plugin/rolesmapping/roleWithTestMapping';
 import roleWithoutTestMappingSetUp from '../../../fixtures/plugins/security-dashboards-plugin/rolesmapping/roleWithoutTestMapping';
+import indexPatternPrivateTenantHeaderSetUp from '../../../fixtures/plugins/security-dashboards-plugin/indexpatterns/indexPatternPrivateTenantHeader';
 import indexPatternTenantHeaderSetUp from '../../../fixtures/plugins/security-dashboards-plugin/indexpatterns/indexPatternTenantHeader';
 
 const tenantName = 'test';
@@ -26,16 +27,91 @@ const kibanaRoleName = 'kibana_user';
 
 if (Cypress.env('SECURITY_ENABLED') && Cypress.env('AGGREGATION_VIEW')) {
   describe('Saved objects table test', () => {
+    const deleteIndexPatternFromTenant = (id, tenantHeader) =>
+      cy.deleteIndexPattern(id, {
+        failOnStatusCode: false,
+        headers: {
+          'osd-xsrf': true,
+          ...tenantHeader,
+        },
+      });
+
+    const deleteIndexPatternFromTestTenants = (id) => {
+      cy.deleteIndexPattern(id, { failOnStatusCode: false });
+      deleteIndexPatternFromTenant(id, indexPatternPrivateTenantHeaderSetUp);
+      deleteIndexPatternFromTenant(id, indexPatternTenantHeaderSetUp);
+    };
+
+    const visitSavedObjects = () => {
+      cy.intercept(
+        'GET',
+        '/api/opensearch-dashboards/management/saved_objects/_find*'
+      ).as('findSavedObjects');
+      cy.visit(SAVED_OBJECTS_PATH);
+      cy.wait('@findSavedObjects');
+      cy.contains('a', 'Saved objects');
+    };
+
+    const savedObjectRow = (title) => cy.contains('tbody tr', title);
+
+    const clearSavedObjectsSearch = () => {
+      cy.intercept(
+        'POST',
+        '/api/opensearch-dashboards/management/saved_objects/scroll/counts'
+      ).as('getSavedObjectCounts');
+      cy.intercept(
+        'GET',
+        '/api/opensearch-dashboards/management/saved_objects/_find*'
+      ).as('findSavedObjects');
+
+      cy.get('input[type="search"]').clear();
+
+      cy.wait('@getSavedObjectCounts');
+      cy.wait('@findSavedObjects');
+    };
+
+    const selectTenantFilter = (tenant) => {
+      cy.intercept(
+        'POST',
+        '/api/opensearch-dashboards/management/saved_objects/scroll/counts'
+      ).as('getSavedObjectCounts');
+      cy.intercept(
+        'GET',
+        '/api/opensearch-dashboards/management/saved_objects/_find*'
+      ).as('findSavedObjects');
+
+      cy.contains('button.euiFilterButton', 'Tenant')
+        .should('be.enabled')
+        .click({ force: true });
+      cy.get('.euiPopover__panel')
+        .should('be.visible')
+        .within(() => {
+          cy.contains(
+            '[role="option"], button, .euiSelectableListItem, .euiFilterSelectItem',
+            tenant
+          )
+            .should('be.visible')
+            .click();
+        });
+
+      cy.wait('@getSavedObjectCounts');
+      cy.wait('@findSavedObjects');
+    };
+
     before(() => {
-      cy.deleteIndexPattern('index-pattern1', { failOnStatusCode: false });
-      cy.deleteIndexPattern('index-pattern2', { failOnStatusCode: false });
+      deleteIndexPatternFromTestTenants('index-pattern1');
+      deleteIndexPatternFromTestTenants('index-pattern2');
 
       cy.createTenant(tenantName, tenantDescription);
 
-      cy.createIndexPattern('index-pattern1', {
-        title: 's*',
-        timeFieldName: 'timestamp',
-      });
+      cy.createIndexPattern(
+        'index-pattern1',
+        {
+          title: 's*',
+          timeFieldName: 'timestamp',
+        },
+        indexPatternPrivateTenantHeaderSetUp
+      );
       cy.createIndexPattern(
         'index-pattern2',
         {
@@ -54,33 +130,27 @@ if (Cypress.env('SECURITY_ENABLED') && Cypress.env('AGGREGATION_VIEW')) {
       cy.createRoleMapping(kibanaRoleName, kibanaRoleMappingSetUp);
       cy.createRoleMapping(roleName1, roleWithTestMappingSetUp);
       cy.createRoleMapping(roleName2, roleWithoutTestMappingSetUp);
-
-      cy.wait(10000);
     });
 
     it('should check the saved objects as global tenant', () => {
       CURRENT_TENANT.newTenant = 'global';
-      cy.visit(SAVED_OBJECTS_PATH);
-      cy.contains('s*');
-      cy.contains('se*');
+      visitSavedObjects();
+      savedObjectRow('s*').should('contain', 'Private');
+      savedObjectRow('se*').should('contain', 'test');
     });
 
     it('should check the saved objects by applying filter', () => {
       CURRENT_TENANT.newTenant = 'global';
-      cy.visit(SAVED_OBJECTS_PATH);
-      cy.contains('a', 'Saved objects');
+      visitSavedObjects();
 
-      cy.contains('button', 'Tenant').click({ force: true });
-      cy.contains('.euiFilterSelectItem', 'Private').click();
-      cy.contains('button', 'Tenant').click({ force: true });
-      cy.contains('se*').should('not.exist');
-      cy.contains('s*');
+      selectTenantFilter('Private');
+      savedObjectRow('se*').should('not.exist');
+      savedObjectRow('s*').should('contain', 'Private');
 
-      cy.contains('button', 'Tenant').click({ force: true });
-      cy.contains('.euiFilterSelectItem', 'test').click();
-      cy.contains('button', 'Tenant').click({ force: true });
-      cy.contains('s*');
-      cy.contains('se*');
+      clearSavedObjectsSearch();
+      selectTenantFilter('test');
+      savedObjectRow('s*').should('contain', 'Private');
+      savedObjectRow('se*').should('contain', 'test');
     });
 
     it('should login as test1 and check saved object', () => {
@@ -88,14 +158,13 @@ if (Cypress.env('SECURITY_ENABLED') && Cypress.env('AGGREGATION_VIEW')) {
       ADMIN_AUTH.newUser = userName1;
       ADMIN_AUTH.newPassword = password;
 
-      cy.visit(SAVED_OBJECTS_PATH);
+      visitSavedObjects();
       cy.url().should((url) => {
         expect(url).to.contain('/management');
       });
 
-      cy.wait(5000);
-      cy.contains('se*');
-      cy.contains('s*').should('not.exist');
+      savedObjectRow('se*').should('contain', 'test');
+      savedObjectRow('s*').should('not.exist');
     });
 
     it('should login as test2 and check saved object', () => {
@@ -103,22 +172,21 @@ if (Cypress.env('SECURITY_ENABLED') && Cypress.env('AGGREGATION_VIEW')) {
       ADMIN_AUTH.newUser = userName2;
       ADMIN_AUTH.newPassword = password;
 
-      cy.visit(SAVED_OBJECTS_PATH);
+      visitSavedObjects();
       cy.url().should((url) => {
         expect(url).to.contain('/management');
       });
 
-      cy.wait(5000);
-      cy.contains('se*').should('not.exist');
-      cy.contains('s*').should('not.exist');
+      savedObjectRow('se*').should('not.exist');
+      savedObjectRow('s*').should('not.exist');
     });
 
     after(() => {
       ADMIN_AUTH.newUser = Cypress.env('username');
       ADMIN_AUTH.newPassword = Cypress.env('password');
       CURRENT_TENANT.newTenant = 'private';
-      cy.deleteIndexPattern('index-pattern1', { failOnStatusCode: false });
-      cy.deleteIndexPattern('index-pattern2', { failOnStatusCode: false });
+      deleteIndexPatternFromTestTenants('index-pattern1');
+      deleteIndexPatternFromTestTenants('index-pattern2');
     });
   });
 }

--- a/cypress/utils/plugins/security-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/security-dashboards-plugin/commands.js
@@ -12,61 +12,54 @@ import { SEC_API } from '../../constants';
  */
 
 Cypress.Commands.add('createTenant', (tenantID, tenantJson) => {
-  cy.request(
+  return cy.request(
     'PUT',
     `${Cypress.env('openSearchUrl')}${SEC_API.TENANTS_BASE}/${tenantID}`,
     tenantJson
   );
-  cy.wait(10000);
 });
 
 Cypress.Commands.add('createInternalUser', (userID, userJson) => {
-  cy.request(
+  return cy.request(
     'PUT',
     `${Cypress.env('openSearchUrl')}${SEC_API.INTERNALUSERS_BASE}/${userID}`,
     userJson
   );
-  cy.wait(10000);
 });
 
 Cypress.Commands.add('deleteInternalUser', (userID) => {
-  cy.request(
+  return cy.request(
     'DELETE',
     `${Cypress.env('openSearchUrl')}${SEC_API.INTERNALUSERS_BASE}/${userID}`
   );
-  cy.wait(10000);
 });
 
 Cypress.Commands.add('createRole', (roleID, roleJson) => {
-  cy.request(
+  return cy.request(
     'PUT',
     `${Cypress.env('openSearchUrl')}${SEC_API.ROLE_BASE}/${roleID}`,
     roleJson
   );
-  cy.wait(10000);
 });
 
 Cypress.Commands.add('deleteRole', (roleID) => {
-  cy.request(
+  return cy.request(
     'DELETE',
     `${Cypress.env('openSearchUrl')}${SEC_API.ROLE_BASE}/${roleID}`
   );
-  cy.wait(10000);
 });
 
 Cypress.Commands.add('createRoleMapping', (roleID, rolemappingJson) => {
-  cy.request(
+  return cy.request(
     'PUT',
     `${Cypress.env('openSearchUrl')}${SEC_API.ROLE_MAPPING_BASE}/${roleID}`,
     rolemappingJson
   );
-  cy.wait(10000);
 });
 
 Cypress.Commands.add('deleteRoleMapping', (roleID) => {
-  cy.request(
+  return cy.request(
     'DELETE',
     `${Cypress.env('openSearchUrl')}${SEC_API.ROLE_MAPPING_BASE}/${roleID}`
   );
-  cy.wait(10000);
 });


### PR DESCRIPTION
## Summary
- remove fixed 10s waits from security-dashboards-plugin setup helper commands
- make aggregation_view saved object tenant setup explicit for Private and test tenants
- wait for saved object API calls instead of fixed sleeps when visiting/filtering saved objects
- clean up test index patterns from the tenants where they are created

## Verification
- mise exec node@22.22.0 -- ./node_modules/.bin/eslint cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js cypress/utils/plugins/security-dashboards-plugin/commands.js
- mise exec node@22.22.0 -- yarn cypress run --browser chrome --headed --spec cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js --env SECURITY_ENABLED=true,openSearchUrl=https://localhost:9200,AGGREGATION_VIEW=true,WAIT_FOR_LOADER_BUFFER_MS=500

Local Cypress result: 4 passing in 24s.