### PR TITLE
Fix AD Cypress mock response caching

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/dashboard_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/dashboard_spec.js
@@ -7,9 +7,7 @@ import { AD_FIXTURE_BASE_PATH, AD_URL } from '../../../utils/constants';
 import { selectTopItemFromFilter } from '../../../utils/helpers';
 
 // Contains basic sanity tests on AD Dashboards page
-describe('AD Dashboard page', () => {
-  before(() => {});
-
+describe('AD Dashboard page', { testIsolation: true }, () => {
   it('Empty - no detector index', () => {
     cy.mockGetDetectorOnAction(
       AD_FIXTURE_BASE_PATH + 'no_detector_index_response.json',

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/detector_list_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/detector_list_spec.js
@@ -11,9 +11,7 @@ import {
 } from '../../../utils/constants';
 import { selectTopItemFromFilter } from '../../../utils/helpers';
 
-describe('Detector list page', () => {
-  before(() => {});
-
+describe('Detector list page', { testIsolation: true }, () => {
   it('Empty - no detector index', () => {
     cy.mockGetDetectorOnAction(
       AD_FIXTURE_BASE_PATH + 'no_detector_index_response.json',

--- a/cypress/utils/plugins/anomaly-detection-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/anomaly-detection-dashboards-plugin/commands.js
@@ -15,6 +15,15 @@ import {
 } from '../../constants';
 import { selectTopItemFromFilter } from './helpers';
 
+const noStoreFixtureResponse = (fixtureFileName) => ({
+  fixture: fixtureFileName,
+  headers: {
+    'cache-control': 'no-store, no-cache, must-revalidate',
+    pragma: 'no-cache',
+    expires: '0',
+  },
+});
+
 Cypress.Commands.add(
   'handleTenantDialog',
   {
@@ -38,9 +47,10 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'mockGetDetectorOnAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(AD_NODE_API_PATH.GET_DETECTORS, {
-      fixture: fixtureFileName,
-    }).as('getDetectors');
+    cy.intercept(
+      AD_NODE_API_PATH.GET_DETECTORS,
+      noStoreFixtureResponse(fixtureFileName)
+    ).as('getDetectors');
 
     funcMockedOn();
 
@@ -51,13 +61,15 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'mockGetDetectorsAndIndicesOnAction',
   function (detectorsFixtureFileName, indexFixtureFileName, funcMockedOn) {
-    cy.intercept(AD_NODE_API_PATH.GET_DETECTORS, {
-      fixture: detectorsFixtureFileName,
-    }).as('getDetectors');
+    cy.intercept(
+      AD_NODE_API_PATH.GET_DETECTORS,
+      noStoreFixtureResponse(detectorsFixtureFileName)
+    ).as('getDetectors');
 
-    cy.intercept(AD_NODE_API_PATH.GET_INDICES, {
-      fixture: indexFixtureFileName,
-    }).as('getIndices');
+    cy.intercept(
+      AD_NODE_API_PATH.GET_INDICES,
+      noStoreFixtureResponse(indexFixtureFileName)
+    ).as('getIndices');
 
     funcMockedOn();
 
@@ -69,9 +81,10 @@ Cypress.Commands.add(
 Cypress.Commands.add(
   'mockSearchIndexOnAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(AD_NODE_API_PATH.GET_INDICES, {
-      fixture: fixtureFileName,
-    }).as('getIndices');
+    cy.intercept(
+      AD_NODE_API_PATH.GET_INDICES,
+      noStoreFixtureResponse(fixtureFileName)
+    ).as('getIndices');
 
     funcMockedOn();
 
@@ -277,9 +290,10 @@ Cypress.Commands.add('deleteAllRemoteIndices', () => {
 Cypress.Commands.add(
   'mockGetForecastersOnAction',
   function (fixtureFileName, funcMockedOn) {
-    cy.intercept(FORECAST_NODE_API_PATH.GET_FORECASTERS, {
-      fixture: fixtureFileName,
-    }).as('getForecasters');
+    cy.intercept(
+      FORECAST_NODE_API_PATH.GET_FORECASTERS,
+      noStoreFixtureResponse(fixtureFileName)
+    ).as('getForecasters');
 
     funcMockedOn();
 


### PR DESCRIPTION
## Summary
- Add no-store headers to AD Cypress fixture-backed GET intercept responses.
- Reuse the same helper for detector list, index list, and forecaster list mock helpers.
- Enable Cypress test isolation for the detector list and dashboard specs so each case starts from a clean page and emits a fresh list request.

## Root cause
AD dashboard and detector list specs reuse the same browser context with `testIsolation: false`. Fixture-backed GET intercepts can be satisfied from browser cache after the first test, so later tests may not issue a network request for Cypress to observe and `cy.wait(@getDetectors)` can time out while the page keeps previous state.

The detector list and dashboard specs also repeatedly visit the same hash-routed SPA URLs. After the first test rewrites the route with query params, later visits can remain in the mounted app without re-triggering the detector list fetch effect. Per-suite `testIsolation: true` gives each case a clean page before it registers intercepts and visits the AD route under test.

## Validation
- all AD cypress tests pass.

Full Cypress validation is intended to run in PR CI.
