### PR TITLE
Sync query-insights-dashboards cypress specs from plugin repo

### DIFF
--- a/cypress/fixtures/stub_live_queries.json
+++ b/cypress/fixtures/stub_live_queries.json
@@ -1,0 +1,507 @@
+{
+  "ok": true,
+  "response": {
+    "live_queries": [
+      {
+        "timestamp": 1749187466964,
+        "id": "node-A1B2C3D4E5:3600",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-A1B2C3D4E5",
+        "is_cancelled": true,
+        "wlm_group_id": "ANALYTICS_WORKLOAD_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 7990852130,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 89951,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 3818,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187466969,
+        "id": "4W2VTHIgQY-oB7dSrYz4B:3601",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "4W2VTHIgQY-oB7dSrYz4B",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 6412938258,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 113698,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 2653,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187466974,
+        "id": "node-X9Y8Z7W6:3602",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-X9Y8Z7W6",
+        "is_cancelled": false,
+        "wlm_group_id": "ANALYTICS_WORKLOAD_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 9633985711,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 65783,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 3996,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187466979,
+        "id": "node-P0Q9R8S7:3603",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-P0Q9R8S7",
+        "is_cancelled": false,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 9530744641,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 84327,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 3806,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187466984,
+        "id": "4W2VTHIgQY-oB7dSrYz4:3604",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "4W2VTHIgQY-oB7dSrYz4",
+        "is_cancelled": false,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 6084339201,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 99929,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 4364,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187466989,
+        "id": "node-M2O3P4Q5:3605",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-M2O3P4Q5",
+        "is_cancelled": true,
+        "wlm_group_id": "SEARCH_WORKLOAD_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 5967857684,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 102069,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 3952,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187466994,
+        "id": "node-B2C3D4E5:3606",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-B2C3D4E5",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 6454136095,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 86459,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 3909,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187466999,
+        "id": "node-N2O3P4Q5:3607",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-N2O3P4Q5",
+        "is_cancelled": false,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 8450990820,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 70640,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 2119,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467004,
+        "id": "2VTHIgQY-oB7dSrYz4BQ:3608",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "2VTHIgQY-oB7dSrYz4BQ",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 7308762773,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 68275,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 4354,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467009,
+        "id": "node-X9Y8Z7W6V5:3609",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-X9Y8Z7W6V5",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 5167823987,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 113606,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 2772,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467014,
+        "id": "de-M1N2O3P4Q5:3610",
+        "description": "indices[opensearch], search_type[Query_THEN_FETCH]",
+        "node_id": "de-M1N2O3P4Q5",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 5708789476,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 76950,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 4238,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467019,
+        "id": "no-P0Q9R8S7T6:3611",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "no-P0Q9R8S7T6",
+        "is_cancelled": false,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 7501207171,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 115548,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 3146,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467024,
+        "id": "4WTHIgQY-oB7dSrYz4BQ:3612",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "4WTHIgQY-oB7dSrYz4BQ",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 8887346819,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 41212,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 2430,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467029,
+        "id": "4W2VTHQY-oB7dSrYz4BQ:3613",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "4W2VTHQY-oB7dSrYz4BQ",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 5672726176,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 104855,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 3759,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467034,
+        "id": "node-A1B2C4E5:3614",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-A1B2C4E5",
+        "is_cancelled": false,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 9691523794,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 57877,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 3231,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467039,
+        "id": "node-X8Z7W6V5:3615",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-X8Z7W6V5",
+        "is_cancelled": false,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 6840833580,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 82656,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 3428,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467044,
+        "id": "node-M1N2P4Q5:3616",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-M1N2P4Q5",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 5718519414,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 105825,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 4775,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467049,
+        "id": "node-A1B2C3E5:3617",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-A1B2C3E5",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 6063407743,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 54160,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 4814,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467054,
+        "id": "4W2VTHIgQY-7dSrYz4BQ:3618",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "4W2VTHIgQY-7dSrYz4BQ",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 9215252980,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 65529,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 2855,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      },
+      {
+        "timestamp": 1749187467059,
+        "id": "node-A1B2C3D4E5:3619",
+        "description": "indices[top_queries-2025.06.06-11009], search_type[QUERY_THEN_FETCH]",
+        "node_id": "node-A1B2C3D4E5",
+        "is_cancelled": true,
+        "wlm_group_id": "DEFAULT_QUERY_GROUP",
+        "measurements": {
+          "latency": {
+            "number": 5409476701,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "cpu": {
+            "number": 81905,
+            "count": 1,
+            "aggregationType": "NONE"
+          },
+          "memory": {
+            "number": 2357,
+            "count": 1,
+            "aggregationType": "NONE"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/cypress/fixtures/stub_top_queries.json
+++ b/cypress/fixtures/stub_top_queries.json
@@ -10,6 +10,7 @@
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "wlm_group_id": "DEFAULT_WORKLOAD_GROUP",
         "group_by": "NONE",
+        "failed": false,
         "total_shards": 1,
         "labels": {
           "X-Opaque-Id": "90eb5c3b-8448-4af3-84ce-a941eee9ed5f"
@@ -45,6 +46,7 @@
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "wlm_group_id": "SEARCH_GROUP",
         "group_by": "NONE",
+        "failed": true,
         "total_shards": 1,
         "labels": {
           "X-Opaque-Id": "90eb5c3b-8448-4af3-84ce-a941eee9ed5f"
@@ -63,6 +65,7 @@
         "node_id": "KINGun8PSAeJvkkt9cWf0w",
         "wlm_group_id": "DEFAULT_WORKLOAD_GROUP",
         "group_by": "NONE",
+        "failed": false,
         "total_shards": 1,
         "labels": {
           "X-Opaque-Id": "8a936346-8d19-409c-9fe6-8b890eca1f7c"

--- a/cypress/fixtures/stub_top_queries_query_only.json
+++ b/cypress/fixtures/stub_top_queries_query_only.json
@@ -10,6 +10,7 @@
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "wlm_group_id": "DEFAULT_WORKLOAD_GROUP",
         "group_by": "NONE",
+        "failed": false,
         "total_shards": 1,
         "labels": {
           "X-Opaque-Id": "90eb5c3b-8448-4af3-84ce-a941eee9ed5f"
@@ -28,6 +29,7 @@
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "wlm_group_id": "9mK2pL8QR7Vb4n1xC6dE2F",
         "group_by": "NONE",
+        "failed": false,
         "total_shards": 1,
         "labels": {
           "X-Opaque-Id": "90eb5c3b-8448-4af3-84ce-a941eee9ed5f"
@@ -46,6 +48,7 @@
         "node_id": "UYKFun8PSAeJvkkt9cWf0w",
         "wlm_group_id": "3zY5wT9NQ8Hj7m2sA4bG1X",
         "group_by": "NONE",
+        "failed": false,
         "total_shards": 1,
         "labels": {
           "X-Opaque-Id": "8a936346-8d19-409c-9fe6-8b890eca1f7c"

--- a/cypress/integration/plugins/query-insights-dashboards/1_top_queries_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/1_top_queries_spec.js
@@ -3,10 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* global Set */
-
 import sampleDocument from '../../../fixtures/plugins/query-insights-dashboards/sample_document.json';
-import { QUERY_INSIGHTS_METRICS } from '../../../utils/plugins/query-insights-dashboards/constants';
+import { QUERY_INSIGHTS_METRICS as METRICS } from '../../../utils/plugins/query-insights-dashboards/constants';
 
 import MIXED from '../../../fixtures/stub_top_queries.json';
 import QUERY_ONLY from '../../../fixtures/stub_top_queries_query_only.json';
@@ -48,8 +46,8 @@ const getHeaders = () =>
         .filter(Boolean)
     );
 
-const expectSortedBy = (label, colIdx) => {
-  const extract = ($rows) =>
+const expectSortedBy = (label) => {
+  const extract = ($rows, colIdx) =>
     [...$rows].map(($r) => {
       const txt = Cypress.$($r).find('td').eq(colIdx).text().trim();
       if (/ms|s|B|KB|MB|GB|TB/i.test(txt))
@@ -90,181 +88,22 @@ const expectSortedBy = (label, colIdx) => {
     });
 };
 
-const norm = (s) => (s || '').replace(/\s+/g, ' ').trim().toLowerCase();
-
-const findFilterButton = (labels) => {
-  const candidates = (Array.isArray(labels) ? labels : [labels]).map(norm);
-
-  return cy.get('button.euiFilterButton').then(($btns) => {
-    const found = [...$btns].find((btn) => {
-      const txt = norm(btn.innerText);
-      const aria = norm(btn.getAttribute('aria-label'));
-      const title = norm(btn.getAttribute('title'));
-      const subj = norm(btn.getAttribute('data-test-subj'));
-      return candidates.some(
-        (lab) =>
-          txt.includes(lab) ||
-          aria.includes(lab) ||
-          title.includes(lab) ||
-          subj.includes(lab)
-      );
-    });
-
-    if (!found) {
-      const dump = [...$btns]
-        .map(
-          (el) =>
-            norm(el.innerText) ||
-            norm(el.getAttribute('aria-label')) ||
-            norm(el.getAttribute('title')) ||
-            norm(el.getAttribute('data-test-subj'))
-        )
-        .join(' | ');
-      throw new Error(
-        `Filter button not found. Tried [${candidates.join(
-          ', '
-        )}]. Buttons seen: ${dump}`
-      );
-    }
-
-    return cy.wrap(found);
-  });
-};
-
-const openFilter = (labels) => {
-  findFilterButton(labels).scrollIntoView().click();
-  cy.get('.euiSelectableListItem', { timeout: 10000 }).should('exist');
-};
-
-const clearAllOpenFilterOptions = () => {
-  cy.get('.euiSelectableListItem').each(($item) => {
-    // Check if item is selected by looking for the check icon or euiSelectableListItem-isChecked class
-    const hasCheck =
-      $item.find('[data-euiicon-type="check"]').length > 0 ||
-      $item.hasClass('euiSelectableListItem-isChecked') ||
-      $item.attr('aria-checked') === 'true';
-    if (hasCheck) {
-      cy.wrap($item).click();
-    }
-  });
-};
-
-const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-const setListFilter = (buttonLabels, values = []) => {
-  openFilter(buttonLabels);
-  clearAllOpenFilterOptions();
-  values.forEach((label) => {
-    const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    cy.contains('.euiSelectableListItem', new RegExp(`^${esc(label)}$`, 'i'))
-      .scrollIntoView()
-      .click();
-  });
-  cy.get('body').click(0, 0);
-  cy.wait(300);
-};
-
-const setNodeIdFilter = (nodeIds = []) =>
-  setListFilter(['Coordinator Node ID'], nodeIds);
-const setSearchTypeFilter = (types = []) =>
-  setListFilter(['Search Type'], types);
-const setIndicesFilter = (indices = []) => setListFilter(['Indices'], indices);
-
 const setTypeFilter = (mode /* 'query' | 'group' | 'both' */) => {
-  // Click the Type filter button (in the filter group, not visualization toggle)
-  findFilterButton(['Type']).click();
-  cy.get('.euiSelectableListItem', { timeout: 10000 }).should('exist');
-
-  const ensureToggle = (label, shouldBeOn) => {
-    cy.contains(
-      '.euiSelectableListItem',
-      new RegExp(`^${esc(label)}$`, 'i')
-    ).then(($item) => {
-      // SVG with path = checked, empty SVG = unchecked
-      const isOn = $item.find('svg path').length > 0;
-      if (isOn !== shouldBeOn) {
-        cy.wrap($item).click();
-      }
-    });
-  };
-
+  const searchInput = `input[placeholder="e.g. latency >= 100 AND type = query"]`;
+  cy.get(searchInput).clear({ force: true });
   if (mode === 'query') {
-    ensureToggle('query', true);
-    ensureToggle('group', false);
+    cy.get(searchInput).type('type = query', { force: true });
   } else if (mode === 'group') {
-    ensureToggle('query', false);
-    ensureToggle('group', true);
-  } else {
-    ensureToggle('query', true);
-    ensureToggle('group', true);
+    cy.get(searchInput).type('type = group', { force: true });
   }
-  cy.get('body').click(0, 0);
   cy.wait(300);
 };
 
 const resetTypeFilterToNone = () => {
-  // Click the Type filter button to open the popover
-  findFilterButton(['Type']).click();
-  cy.get('.euiSelectableListItem', { timeout: 10000 }).should('exist');
-
-  // Only click items where SVG has content (path element = checked)
-  cy.contains('.euiSelectableListItem', /^query$/i).then(($item) => {
-    if ($item.find('svg path').length > 0) {
-      cy.wrap($item).click();
-    }
-  });
-
-  cy.contains('.euiSelectableListItem', /^group$/i).then(($item) => {
-    if ($item.find('svg path').length > 0) {
-      cy.wrap($item).click();
-    }
-  });
-
-  cy.get('body').click(0, 0);
-  cy.wait(500);
+  const searchInput = `input[placeholder="e.g. latency >= 100 AND type = query"]`;
+  cy.get(searchInput).clear({ force: true });
+  cy.wait(300);
 };
-
-const deriveExpectations = (payload, type = 'all') => {
-  const allRows = getRowsFromRaw(payload);
-
-  let rows = allRows;
-  if (type === 'query') {
-    rows = allRows.filter((r) => String(r.group_by).toUpperCase() === 'NONE');
-  } else if (type === 'group') {
-    rows = allRows.filter((r) => String(r.group_by).toUpperCase() !== 'NONE');
-  }
-
-  const uniq = (arr) => [...new Set(arr)];
-  const countBy = (items, keyFn) =>
-    items.reduce((acc, item) => {
-      const k = keyFn(item);
-      if (Array.isArray(k)) {
-        k.filter(Boolean).forEach((kk) => {
-          acc[kk] = (acc[kk] || 0) + 1;
-        });
-      } else if (k) {
-        acc[k] = (acc[k] || 0) + 1;
-      }
-      return acc;
-    }, {});
-
-  const nodeIds = uniq(rows.map((r) => r.node_id).filter(Boolean));
-  const indexNames = uniq(rows.flatMap((r) => r.indices || []).filter(Boolean));
-  const searchTypes = uniq(rows.map((r) => r.search_type).filter(Boolean));
-
-  return {
-    appliedType: type,
-    rows,
-    totalRowCount: rows.length,
-    nodeIds,
-    nodeIdCounts: countBy(rows, (r) => r.node_id),
-    indexNames,
-    indexCounts: countBy(rows, (r) => r.indices || []),
-    searchTypes,
-    searchTypeCounts: countBy(rows, (r) => r.search_type),
-  };
-};
-
 const indexName = 'sample_index';
 
 /**
@@ -274,9 +113,9 @@ const indexName = 'sample_index';
  */
 const clearAll = () => {
   cy.deleteIndexByName(indexName);
-  cy.disableTopQueries(QUERY_INSIGHTS_METRICS.LATENCY);
-  cy.disableTopQueries(QUERY_INSIGHTS_METRICS.CPU);
-  cy.disableTopQueries(QUERY_INSIGHTS_METRICS.MEMORY);
+  cy.disableTopQueries(METRICS.LATENCY);
+  cy.disableTopQueries(METRICS.CPU);
+  cy.disableTopQueries(METRICS.MEMORY);
   cy.disableGrouping();
 };
 
@@ -285,9 +124,9 @@ describe('Query Insights Dashboard', () => {
   beforeEach(() => {
     clearAll();
     cy.createIndexByName(indexName, sampleDocument);
-    cy.enableTopQueries(QUERY_INSIGHTS_METRICS.LATENCY);
-    cy.enableTopQueries(QUERY_INSIGHTS_METRICS.CPU);
-    cy.enableTopQueries(QUERY_INSIGHTS_METRICS.MEMORY);
+    cy.enableTopQueries(METRICS.LATENCY);
+    cy.enableTopQueries(METRICS.CPU);
+    cy.enableTopQueries(METRICS.MEMORY);
     cy.searchOnIndex(indexName);
     // wait for 1s to avoid same timestamp
     cy.wait(1000);
@@ -403,13 +242,8 @@ describe('Query Insights Dashboard', () => {
 });
 
 describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED)', () => {
-  var mixedRows;
-  var totalRowCount;
-
-  before(() => {
-    mixedRows = getRowsFromRaw(MIXED);
-    totalRowCount = mixedRows.length;
-  });
+  const mixedRows = getRowsFromRaw(MIXED);
+  const totalRowCount = mixedRows.length;
 
   beforeEach(() => {
     cy.intercept('GET', '**/api/top_queries/**', (req) => {
@@ -417,8 +251,8 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
     }).as('topQueries');
 
     cy.waitForQueryInsightsPlugin();
-    // Reload to guarantee the intercept captures the API call
-    // (security redirects may cause the initial request to be missed)
+    // Force reload because testIsolation is disabled in this repo's cypress.config —
+    // without it, cy.visit() to the same URL is a no-op and the intercepted request never fires.
     cy.reload();
     cy.wait('@topQueries', { timeout: 60000 });
   });
@@ -430,6 +264,7 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
       'Type',
       'Query Count',
       'Timestamp',
+      'Status',
       'Avg Latency / Latency',
       'Avg CPU Time / CPU Time',
       'Avg Memory Usage / Memory Usage',
@@ -441,10 +276,10 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
     ];
     getHeaders().should('deep.equal', expected);
     assertRowCountEquals(totalRowCount);
-    expectSortedBy('Query Count', 2);
-    expectSortedBy('Avg Latency / Latency', 4);
-    expectSortedBy('Avg CPU Time / CPU Time', 5);
-    expectSortedBy('Avg Memory Usage / Memory Usage', 6);
+    expectSortedBy('Query Count');
+    expectSortedBy('Avg Latency / Latency');
+    expectSortedBy('Avg CPU Time / CPU Time');
+    expectSortedBy('Avg Memory Usage / Memory Usage');
   });
 
   it('renders query-only headers when Type=query', () => {
@@ -453,6 +288,7 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
       'Id',
       'Type',
       'Timestamp',
+      'Status',
       'Latency',
       'CPU Time',
       'Memory Usage',
@@ -469,10 +305,10 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
     ).length;
     assertRowCountEquals(queryOnlyCount);
 
-    expectSortedBy('Timestamp', 2);
-    expectSortedBy('Latency', 3);
-    expectSortedBy('CPU Time', 4);
-    expectSortedBy('Memory Usage', 5);
+    expectSortedBy('Timestamp');
+    expectSortedBy('Latency');
+    expectSortedBy('CPU Time');
+    expectSortedBy('Memory Usage');
   });
 
   it('renders group-only headers when Type=group', () => {
@@ -492,10 +328,10 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
     ).length;
     assertRowCountEquals(groupOnlyCount);
 
-    expectSortedBy('Query Count', 2);
-    expectSortedBy('Average Latency', 3);
-    expectSortedBy('Average CPU Time', 4);
-    expectSortedBy('Average Memory Usage', 5);
+    expectSortedBy('Query Count');
+    expectSortedBy('Average Latency');
+    expectSortedBy('Average CPU Time');
+    expectSortedBy('Average Memory Usage');
   });
 
   it('renders combined headers when Type=both', () => {
@@ -505,6 +341,7 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
       'Type',
       'Query Count',
       'Timestamp',
+      'Status',
       'Avg Latency / Latency',
       'Avg CPU Time / CPU Time',
       'Avg Memory Usage / Memory Usage',
@@ -517,10 +354,10 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
     getHeaders().should('deep.equal', expected);
     assertRowCountEquals(totalRowCount);
 
-    expectSortedBy('Query Count', 2);
-    expectSortedBy('Avg Latency / Latency', 4);
-    expectSortedBy('Avg CPU Time / CPU Time', 5);
-    expectSortedBy('Avg Memory Usage / Memory Usage', 6);
+    expectSortedBy('Query Count');
+    expectSortedBy('Avg Latency / Latency');
+    expectSortedBy('Avg CPU Time / CPU Time');
+    expectSortedBy('Avg Memory Usage / Memory Usage');
   });
 });
 
@@ -532,6 +369,8 @@ describe('Query Insights — Dynamic Columns (QUERY ONLY fixture)', () => {
     }).as('topQueries');
 
     cy.waitForQueryInsightsPlugin();
+    // Force reload because testIsolation is disabled in this repo's cypress.config —
+    // without it, cy.visit() to the same URL is a no-op and the intercepted request never fires.
     cy.reload();
     cy.wait('@topQueries', { timeout: 60000 });
   });
@@ -541,6 +380,7 @@ describe('Query Insights — Dynamic Columns (QUERY ONLY fixture)', () => {
       'Id',
       'Type',
       'Timestamp',
+      'Status',
       'Latency',
       'CPU Time',
       'Memory Usage',
@@ -563,6 +403,8 @@ describe('Query Insights — Dynamic Columns (GROUP ONLY fixture)', () => {
     }).as('topQueries');
 
     cy.waitForQueryInsightsPlugin();
+    // Force reload because testIsolation is disabled in this repo's cypress.config —
+    // without it, cy.visit() to the same URL is a no-op and the intercepted request never fires.
     cy.reload();
     cy.wait('@topQueries', { timeout: 60000 });
   });
@@ -579,168 +421,11 @@ describe('Query Insights — Dynamic Columns (GROUP ONLY fixture)', () => {
     getHeaders().should('deep.equal', expected);
     assertRowCountEquals(getRowsFromRaw(GROUP_ONLY).length);
   });
-});
 
-describe('Query Insights — Filters and Search', () => {
-  let expected;
-  let expectingAll;
-  let primaryNodeId;
-  let secondaryNodeId;
-  let primaryIndexName;
-  let secondaryIndexName;
-  let defaultSearchType;
-
-  before(() => {
-    // derive expectations from query-only payload
-    expected = deriveExpectations(MIXED, 'query');
-    expectingAll = deriveExpectations(MIXED);
-    [primaryNodeId, secondaryNodeId] = expected.nodeIds;
-    [primaryIndexName, secondaryIndexName] = expected.indexNames;
-    [defaultSearchType] = expected.searchTypes;
-  });
-
-  beforeEach(() => {
-    // intercept with ONLY query rows, plus fresh timestamps
-    cy.intercept('GET', '**/api/top_queries/**', (req) => {
-      req.reply({ statusCode: 200, body: makeTimestampedBody(MIXED) });
-    }).as('topQueries');
-
-    cy.waitForQueryInsightsPlugin();
-    cy.reload();
-    cy.wait('@topQueries', { timeout: 60000 });
-  });
-
-  it('filters by Node ID', () => {
-    if (primaryNodeId) {
-      setNodeIdFilter([primaryNodeId]);
-      assertRowCountEquals(expected.nodeIdCounts[primaryNodeId]);
-      cy.get('.euiBasicTable')
-        .last()
-        .find('.euiTableRow')
-        .each(($r) => cy.wrap($r).contains('td', primaryNodeId));
-    }
-    setNodeIdFilter([primaryNodeId]); // clear
-
-    if (secondaryNodeId) {
-      setNodeIdFilter([secondaryNodeId]);
-      assertRowCountEquals(expected.nodeIdCounts[secondaryNodeId]);
-      cy.get('.euiBasicTable')
-        .last()
-        .find('.euiTableRow')
-        .each(($r) => cy.wrap($r).contains('td', secondaryNodeId));
-    }
-    setNodeIdFilter([secondaryNodeId]); // clear
-    assertRowCountEquals(expectingAll.totalRowCount);
-  });
-
-  it('filters by Search Type', () => {
-    if (defaultSearchType) {
-      setSearchTypeFilter([defaultSearchType]);
-      assertRowCountEquals(expected.searchTypeCounts[defaultSearchType]);
-      cy.get('.euiBasicTable')
-        .last()
-        .find('.euiTableRow')
-        .each(($r) => cy.wrap($r).contains('td', 'query then fetch'));
-    }
-    setSearchTypeFilter([defaultSearchType]);
-
-    assertRowCountEquals(expectingAll.totalRowCount);
-  });
-
-  it('filters by Indices', () => {
-    if (primaryIndexName) {
-      setIndicesFilter([primaryIndexName]);
-      assertRowCountEquals(expected.indexCounts[primaryIndexName]);
-      cy.get('.euiBasicTable')
-        .last()
-        .find('.euiTableRow')
-        .each(($r) => cy.wrap($r).contains('td', primaryIndexName));
-    }
-    setIndicesFilter([primaryIndexName]);
-
-    if (secondaryIndexName) {
-      setIndicesFilter([secondaryIndexName]);
-      assertRowCountEquals(expected.indexCounts[secondaryIndexName]);
-      cy.get('.euiBasicTable')
-        .last()
-        .find('.euiTableRow')
-        .each(($r) => cy.wrap($r).contains('td', secondaryIndexName));
-    }
-    setIndicesFilter([secondaryIndexName]);
-
-    const both = [primaryIndexName, secondaryIndexName].filter(Boolean);
-    if (both.length > 1) {
-      setIndicesFilter(both);
-      assertRowCountEquals(expected.totalRowCount);
-    }
-
-    setIndicesFilter([]); // clear
-    assertRowCountEquals(expected.totalRowCount);
-  });
-
-  it('updates search box when filter is selected', () => {
-    resetTypeFilterToNone();
-    cy.get('.euiFieldSearch').should('have.value', '');
-    setTypeFilter('query');
-    cy.get('.euiFieldSearch').should('contain.value', 'group_by');
-  });
-
-  it('clears search box when filters are cleared', () => {
-    setTypeFilter('query');
-    cy.get('.euiFieldSearch').should('not.have.value', '');
-    resetTypeFilterToNone();
-    cy.get('.euiFieldSearch').should('have.value', '');
-  });
-
-  it('filters by query ID in free-text search', () => {
-    // a2e1c822 matches 2 queries in fixture
-    cy.get('.euiFieldSearch').clear().type('a2e1c822');
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .should('have.length', 2);
-  });
-
-  it('filters by index name in free-text search', () => {
-    // my-index only appears in one query (group_by: NONE)
-    cy.get('.euiFieldSearch').clear().type('my-index');
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .should('have.length', 1);
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .should('contain', 'my-index');
-  });
-
-  it('filters by node ID in free-text search', () => {
-    // UYKFun8 appears in 2 queries (1 NONE, 1 SIMILARITY) - free-text filters to NONE only
-    cy.get('.euiFieldSearch').clear().type('UYKFun8');
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .should('have.length', 2);
-  });
-
-  it('shows no results for non-matching free-text search', () => {
-    cy.get('.euiFieldSearch').clear().type('nonexistent_xyz_123');
-    cy.get('.euiBasicTable')
-      .last()
-      .contains('No items found')
-      .should('be.visible');
-  });
-
-  it('combines free-text search with filter selection', () => {
-    setTypeFilter('query');
-    // .kibana appears in all queries
-    cy.get('.euiFieldSearch').type(' kibana');
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .should('have.length.greaterThan', 0);
-    cy.get('.euiFieldSearch').should('contain.value', 'group_by');
-    cy.get('.euiFieldSearch').should('contain.value', 'kibana');
+  it('renders dash in status column for group rows', () => {
+    cy.get('.euiTableRow').each(($row) => {
+      cy.wrap($row).find('.euiBadge').should('not.exist');
+    });
   });
 });
 
@@ -751,6 +436,8 @@ describe('Query Insights — Stats & Visualizations Panel', () => {
     }).as('topQueries');
 
     cy.waitForQueryInsightsPlugin();
+    // Force reload because testIsolation is disabled in this repo's cypress.config —
+    // without it, cy.visit() to the same URL is a no-op and the intercepted request never fires.
     cy.reload();
     cy.wait('@topQueries', { timeout: 60000 });
   });
@@ -935,5 +622,141 @@ describe('Query Insights — Stats & Visualizations Panel', () => {
         .click();
       cy.get('@perfPanel').find('select').should('have.length', 1);
     });
+  });
+});
+
+describe('Query Insights — DynamicSearchBar', () => {
+  const SEARCH_PLACEHOLDER = 'e.g. latency >= 100 AND type = query';
+
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/top_queries/**', (req) => {
+      req.reply({ statusCode: 200, body: makeTimestampedBody(MIXED) });
+    }).as('topQueries');
+
+    cy.waitForQueryInsightsPlugin();
+    // Force reload because testIsolation is disabled in this repo's cypress.config —
+    // without it, cy.visit() to the same URL is a no-op and the intercepted request never fires.
+    cy.reload();
+    cy.wait('@topQueries', { timeout: 60000 });
+  });
+
+  it('renders the search bar with correct placeholder', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).should('be.visible');
+  });
+
+  it('shows field suggestions when focused', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).click();
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+    cy.get('[role="option"]').first().should('contain.text', 'id');
+  });
+
+  it('shows operator suggestions after typing a field name and space', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('latency ');
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+    cy.get('[role="option"]').should('contain.text', '=');
+    cy.get('[role="option"]').should('contain.text', '>=');
+    cy.get('[role="option"]').should('contain.text', 'between');
+  });
+
+  it('shows string operators for string fields', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type ');
+    cy.get('[role="option"]').should('contain.text', '=');
+    cy.get('[role="option"]').should('contain.text', 'starts_with');
+    cy.get('[role="option"]').should('contain.text', 'ends_with');
+    cy.get('[role="option"]').should('contain.text', 'contains');
+  });
+
+  it('shows value suggestions after typing field and operator', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = ');
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+  });
+
+  it('shows conjunction suggestions after a complete condition', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = query_then_fetch ');
+    cy.get('[role="option"]').should('contain.text', 'AND');
+    cy.get('[role="option"]').should('contain.text', 'OR');
+  });
+
+  it('filters table by free text search', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('a2e1c822');
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableRow')
+      .should('have.length.greaterThan', 0);
+  });
+
+  it('filters table by field = value expression', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = query_then_fetch');
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableRow')
+      .should('have.length.greaterThan', 0);
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableRow')
+      .first()
+      .should('contain.text', 'query then fetch');
+  });
+
+  it('shows filter badges for active conditions', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = query_then_fetch ');
+    cy.get('.euiBadge').contains('search_type').should('exist');
+  });
+
+  it('removes filter when badge X is clicked', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = query_then_fetch ');
+    cy.get('.euiBadge')
+      .contains('search_type')
+      .closest('.euiBadge')
+      .find('button, [role="img"], svg')
+      .last()
+      .click({ force: true });
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).should(
+      'have.value',
+      ''
+    );
+  });
+
+  it('supports AND conjunction between conditions', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('search_type = query_then_fetch AND node_id = ');
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+  });
+
+  it('auto-formats between expression with parentheses', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('latency between 100 500 ');
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).should(
+      'have.value',
+      'latency between (100, 500) '
+    );
+  });
+
+  it('shows no items when filter matches nothing', () => {
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`)
+      .clear()
+      .type('id = nonexistent_xyz_123');
+    cy.get('.euiBasicTable')
+      .last()
+      .contains('No items found')
+      .should('be.visible');
   });
 });

--- a/cypress/integration/plugins/query-insights-dashboards/2_query_details_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/2_query_details_spec.js
@@ -4,44 +4,58 @@
  */
 
 import sampleDocument from '../../../fixtures/plugins/query-insights-dashboards/sample_document.json';
-import { QUERY_INSIGHTS_METRICS } from '../../../utils/plugins/query-insights-dashboards/constants';
+import { QUERY_INSIGHTS_METRICS as METRICS } from '../../../utils/plugins/query-insights-dashboards/constants';
 
 const indexName = 'sample_index';
 
 const clearAll = () => {
   cy.deleteIndexByName(indexName);
-  cy.disableTopQueries(QUERY_INSIGHTS_METRICS.LATENCY);
-  cy.disableTopQueries(QUERY_INSIGHTS_METRICS.CPU);
-  cy.disableTopQueries(QUERY_INSIGHTS_METRICS.MEMORY);
-  cy.disableGrouping();
+  cy.disableTopQueries(METRICS.LATENCY);
+  cy.disableTopQueries(METRICS.CPU);
+  cy.disableTopQueries(METRICS.MEMORY);
 };
 
 describe('Top Queries Details Page', () => {
   beforeEach(() => {
     clearAll();
     cy.createIndexByName(indexName, sampleDocument);
-    cy.enableTopQueries(QUERY_INSIGHTS_METRICS.LATENCY);
-    cy.enableTopQueries(QUERY_INSIGHTS_METRICS.CPU);
-    cy.enableTopQueries(QUERY_INSIGHTS_METRICS.MEMORY);
+    cy.enableTopQueries(METRICS.LATENCY);
+    cy.enableTopQueries(METRICS.CPU);
+    cy.enableTopQueries(METRICS.MEMORY);
     cy.searchOnIndex(indexName);
+    cy.searchOnIndex(indexName);
+    cy.searchOnIndex(indexName);
+    // waiting for the query insights queue to drain
+    cy.wait(10000);
+    cy.navigateToOverview();
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableRow')
+      .first()
+      .find('button')
+      .first()
+      .trigger('mouseover');
     cy.wait(1000);
-    cy.searchOnIndex(indexName);
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableRow')
+      .first()
+      .find('button')
+      .first()
+      .click(); // Navigate to details
     cy.wait(1000);
-    cy.searchOnIndex(indexName);
-    // Poll the OpenSearch API until data is available, then navigate
-    // directly to the query details page via URL (bypasses table click
-    // which is fragile due to OUI class names and viz panel tables).
-    cy.waitForTopQueriesData();
-    cy.navigateToQueryDetails();
   });
 
   it('should display correct details on the query details page', () => {
-    // cy.get('.euiBasicTable a').first().click(); // Navigate to details
     cy.url().should('include', '/query-details');
     // Validate the page title
     cy.get('h1').contains('Query details').should('be.visible');
     // Validate the summary section
     cy.get('[data-test-subj="query-details-summary-section"]').should(
+      'be.visible'
+    );
+    // Validate the task resource usage section
+    cy.get('[data-test-subj="query-details-task-resource-usages"]').should(
       'be.visible'
     );
     // Validate the presence of latency chart
@@ -68,6 +82,7 @@ describe('Top Queries Details Page', () => {
       'Search Type',
       'Coordinator Node ID',
       'Total Shards',
+      'Status',
     ];
     fieldLabels.forEach((label) => {
       cy.get('.euiPanel').contains('h4', label).should('be.visible');
@@ -131,6 +146,31 @@ describe('Top Queries Details Page', () => {
           expect(shardCount).to.be.a('number').and.to.be.greaterThan(0);
         });
     });
+  });
+
+  /**
+   * Validate Task Resource Usage panel renders when verbose=true
+   */
+  it('should display the Task Resource Usage panel with coordinator and shard tasks', () => {
+    cy.get('[data-test-subj="query-details-task-resource-usages"]').should(
+      'be.visible'
+    );
+    cy.get('[data-test-subj="query-details-task-resource-usages"]').within(
+      () => {
+        cy.contains('h2', 'Task Resource Usage').should('be.visible');
+        cy.contains('h3', 'Coordinator Task').should('be.visible');
+        cy.contains('h3', 'Shard Tasks').should('be.visible');
+        // Coordinator task fields
+        cy.contains('Task ID').should('be.visible');
+        cy.contains('Node ID').should('be.visible');
+        cy.contains('CPU Time (ms)').should('be.visible');
+        cy.contains('Memory (bytes)').should('be.visible');
+        // Shard tasks table
+        cy.get('.euiBasicTable').should('be.visible');
+        cy.get('.euiTableHeaderCell').contains('Phase').should('be.visible');
+        cy.get('.euiTableRow').should('have.length.greaterThan', 0);
+      }
+    );
   });
 
   /**

--- a/cypress/integration/plugins/query-insights-dashboards/2_query_details_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/2_query_details_spec.js
@@ -25,25 +25,14 @@ describe('Top Queries Details Page', () => {
     cy.searchOnIndex(indexName);
     cy.searchOnIndex(indexName);
     cy.searchOnIndex(indexName);
-    // waiting for the query insights queue to drain
-    cy.wait(10000);
-    cy.navigateToOverview();
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .first()
-      .find('button')
-      .first()
-      .trigger('mouseover');
-    cy.wait(1000);
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .first()
-      .find('button')
-      .first()
-      .click(); // Navigate to details
-    cy.wait(1000);
+    // Poll the OpenSearch _insights/top_queries API until data is available, then
+    // navigate directly to /query-details by query id. Upstream clicks the first
+    // row of `.euiBasicTable:last` in the overview, but with the new
+    // Stats & Visualizations panel that selector occasionally lands on a chart
+    // table row and routes to a query-details URL with a short bucket id, which
+    // shows "No Data Available" and breaks every assertion in this describe.
+    cy.waitForTopQueriesData();
+    cy.navigateToQueryDetails();
   });
 
   it('should display correct details on the query details page', () => {

--- a/cypress/integration/plugins/query-insights-dashboards/3_configurations_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/3_configurations_spec.js
@@ -3,75 +3,38 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { QUERY_INSIGHTS_METRICS } from '../../../utils/plugins/query-insights-dashboards/constants';
+import { QUERY_INSIGHTS_METRICS as METRICS } from '../../../utils/plugins/query-insights-dashboards/constants';
 
 const clearAll = () => {
-  cy.disableTopQueries(QUERY_INSIGHTS_METRICS.LATENCY);
-  cy.disableTopQueries(QUERY_INSIGHTS_METRICS.CPU);
-  cy.disableTopQueries(QUERY_INSIGHTS_METRICS.MEMORY);
+  cy.disableTopQueries(METRICS.LATENCY);
+  cy.disableTopQueries(METRICS.CPU);
+  cy.disableTopQueries(METRICS.MEMORY);
 };
 
 const toggleMetricEnabled = () => {
-  // Check current state first and wait for it to be ready
-  cy.get('button[data-test-subj="top-n-metric-toggle"]', { timeout: 30000 })
-    .should('exist')
-    .should('be.visible')
-    .then(($toggle) => {
-      const isChecked = $toggle.attr('aria-checked') === 'true';
-      if (!isChecked) {
-        // Only click if not already enabled
-        cy.get('button[data-test-subj="top-n-metric-toggle"]').click({
-          force: true,
+  // Read current state, click only if not already enabled, then wait for the
+  // aria-checked transition to confirm the toggle actually fired. Retry the
+  // click if the React handler hadn't bound yet on the first attempt.
+  const ensureEnabled = (attempt = 0) => {
+    cy.get('button[data-test-subj="top-n-metric-toggle"]', { timeout: 30000 })
+      .should('exist')
+      .should('be.visible')
+      .then(($toggle) => {
+        if ($toggle.attr('aria-checked') === 'true') return;
+        cy.wrap($toggle).click({ force: true });
+        cy.wait(500);
+        cy.get('button[data-test-subj="top-n-metric-toggle"]').then(($t) => {
+          if ($t.attr('aria-checked') !== 'true' && attempt < 3) {
+            ensureEnabled(attempt + 1);
+          }
         });
-      }
-    });
-  // Wait for the toggle to be enabled with a longer timeout
+      });
+  };
+  ensureEnabled();
   cy.get('button[data-test-subj="top-n-metric-toggle"]', {
     timeout: 30000,
   }).should('have.attr', 'aria-checked', 'true');
 };
-
-// Helper function to find and click save button with multiple fallback selectors
-const clickSaveButton = () => {
-  // Wait a bit for UI to detect changes
-  cy.wait(2000);
-
-  // Try multiple selectors for save button
-  const selectors = [
-    'button[data-test-subj="save-config-button"]',
-    'button[data-test-subj="saveConfigurationButton"]',
-    'button:contains("Save")',
-    '.euiButton--fill:contains("Save")',
-    '[data-test-subj="queryInsightsConfigSaveButton"]',
-  ];
-
-  cy.get('body').then(($body) => {
-    let found = false;
-    for (const selector of selectors) {
-      const $btn = $body.find(selector);
-      if ($btn.length > 0 && $btn.is(':visible') && !$btn.is(':disabled')) {
-        cy.wrap($btn.first()).click({ force: true });
-        found = true;
-        cy.log(`Found save button with selector: ${selector}`);
-        break;
-      }
-    }
-
-    if (!found) {
-      // If no save button found, try to find any button containing "Save"
-      // eslint-disable-next-line no-undef
-      const $saveBtn = $body.find('button').filter((index, el) => {
-        return Cypress.$(el).text().toLowerCase().includes('save');
-      });
-      if ($saveBtn.length > 0) {
-        cy.wrap($saveBtn.first()).click({ force: true });
-      } else {
-        throw new Error('Save button not found with any selector');
-      }
-    }
-  });
-};
-console.log(clickSaveButton);
 
 describe('Query Insights Configurations Page', () => {
   beforeEach(() => {
@@ -97,8 +60,8 @@ describe('Query Insights Configurations Page', () => {
       'euiTab-isSelected'
     );
     // Validate the panels
-    // 6 panels: Settings, Status, Group Settings, Group Status, Delete After Settings, Delete After Status
-    cy.get('.euiPanel').should('have.length', 6);
+    // 8 panels: Settings, Status, Group Settings, Group Status, Export Settings, Export Status, Remote Exporter Settings, Remote Exporter Status
+    cy.get('.euiPanel').should('have.length', 8);
   });
 
   /**
@@ -285,23 +248,29 @@ describe('Query Insights Configurations Page', () => {
    * Validate the save button, changes should be saved and redirect to overview
    * After saving the status panel should show the correct status
    */
-  // the save button is no longer available, so delete this test case
-  // it('should allow saving the configuration', () => {
-  //   toggleMetricEnabled();
-  //   cy.get('select#timeUnit').select('MINUTES');
-  //   cy.get('select#minutes').select('5');
-
-  //   // Scroll to bottom to ensure save button is visible
-  //   cy.scrollTo('bottom', { ensureScrollable: false });
-
-  //   // Use helper function to find and click save button
-  //   clickSaveButton();
-
-  //   cy.url().should('include', '/queryInsights');
-  //   cy.navigateToConfiguration();
-  //   cy.get('.euiHealth').contains('Enabled').should('be.visible');
-  //   cy.get('.euiText').contains('Latency').should('be.visible');
-  // });
+  it('should allow saving the configuration', () => {
+    // Force a fresh page load so the form's baseline state matches the cluster's
+    // actual settings (clearAll already disabled all metrics). Without this,
+    // testIsolation:false leaves prior-test DOM state and the form's isChanged
+    // diff stays false, so the Save bottom bar never renders.
+    cy.reload();
+    cy.contains('Query insights - Configuration').should('be.visible');
+    toggleMetricEnabled();
+    // Wait until the form actually re-renders with the time-unit dropdown enabled
+    // (React state lag — aria-checked flips before child controls re-mount).
+    cy.get('select#timeUnit', { timeout: 15000 }).should('not.be.disabled');
+    cy.get('select#timeUnit').select('HOURS');
+    cy.get('select#timeUnit').select('MINUTES');
+    cy.get('select#minutes').select('10');
+    cy.get('select#minutes').select('5');
+    cy.get('button[data-test-subj="save-config-button"]', {
+      timeout: 30000,
+    }).click();
+    cy.url().should('include', '/queryInsights');
+    cy.navigateToConfiguration();
+    cy.get('.euiHealth').contains('Enabled').should('be.visible');
+    cy.get('.euiText').contains('Latency').should('be.visible');
+  });
 
   after(() => clearAll());
 });

--- a/cypress/integration/plugins/query-insights-dashboards/4_group_details_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/4_group_details_spec.js
@@ -18,17 +18,31 @@ describe('Query Group Details Page', () => {
     cy.wait(5000);
     cy.createIndexByName(indexName, sampleDocument);
     cy.enableGrouping();
-    // waiting for the query insights to stabilize
+    // waiting for the query insights to stablize
     cy.wait(5000);
     cy.searchOnIndex(indexName);
-    cy.wait(1000);
     cy.searchOnIndex(indexName);
-    cy.wait(1000);
     cy.searchOnIndex(indexName);
-    // Poll the OpenSearch API until data is available, then navigate
-    // directly to the group details page via URL.
-    cy.waitForTopQueriesData();
-    cy.navigateToGroupDetails();
+    // waiting for the query insights queue to drain
+    cy.wait(10000);
+    cy.navigateToOverview();
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableRow')
+      .first()
+      .find('button')
+      .first()
+      .trigger('mouseover');
+    cy.wait(1000);
+    // Click the first button in the 'group' row
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableRow')
+      .first()
+      .find('button')
+      .first()
+      .click(); // Navigate to details
+    cy.wait(1000);
   });
 
   it('should display correct details on the group details page', () => {
@@ -61,6 +75,7 @@ describe('Query Group Details Page', () => {
       'Average CPU Time',
       'Average Memory Usage',
       'Group by',
+      'Query Group Hashcode',
     ];
 
     // Validate all field labels exist in the first EuiPanel
@@ -134,6 +149,7 @@ describe('Query Group Details Page', () => {
 
         const firstQuery = responseData.top_queries[0];
         expect(firstQuery).to.include.all.keys([
+          'failed',
           'group_by',
           'id',
           'indices',

--- a/cypress/integration/plugins/query-insights-dashboards/4_group_details_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/4_group_details_spec.js
@@ -23,26 +23,13 @@ describe('Query Group Details Page', () => {
     cy.searchOnIndex(indexName);
     cy.searchOnIndex(indexName);
     cy.searchOnIndex(indexName);
-    // waiting for the query insights queue to drain
-    cy.wait(10000);
-    cy.navigateToOverview();
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .first()
-      .find('button')
-      .first()
-      .trigger('mouseover');
-    cy.wait(1000);
-    // Click the first button in the 'group' row
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .first()
-      .find('button')
-      .first()
-      .click(); // Navigate to details
-    cy.wait(1000);
+    // Poll the OpenSearch _insights/top_queries API until data is available, then
+    // navigate directly to /query-group-details by id. Upstream clicks the first
+    // row of `.euiBasicTable:last` in the overview, but with the new
+    // Stats & Visualizations panel that selector occasionally lands on a chart
+    // table row and routes to a details URL with a short bucket id.
+    cy.waitForTopQueriesData();
+    cy.navigateToGroupDetails();
   });
 
   it('should display correct details on the group details page', () => {

--- a/cypress/integration/plugins/query-insights-dashboards/5_live_queries_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/5_live_queries_spec.js
@@ -1,0 +1,695 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('Inflight Queries Dashboard', () => {
+  beforeEach(() => {
+    cy.fixture('stub_live_queries.json').then((stubResponse) => {
+      cy.intercept('GET', '**/api/live_queries**', {
+        statusCode: 200,
+        body: stubResponse,
+      }).as('getLiveQueries');
+    });
+
+    cy.navigateToLiveQueries();
+    cy.wait(1000);
+    // Force reload because testIsolation is disabled in this repo's cypress.config —
+    // without it, cy.visit() to the same URL is a no-op and the intercepted request
+    // never fires for subsequent tests.
+    cy.reload();
+    cy.wait('@getLiveQueries', { timeout: 60000 });
+  });
+
+  it('displays the correct page title', () => {
+    cy.contains('Query insights - In-flight queries').should('be.visible');
+  });
+
+  it('displays metrics panels with active-only counts', () => {
+    // Metrics should only count non-cancelled queries (7 out of 20)
+    cy.get('[data-test-subj="panel-active-queries"]').within(() => {
+      cy.contains('Active queries');
+      cy.get('h2 > b').should('contain.text', '7');
+    });
+
+    cy.get('[data-test-subj="panel-avg-elapsed-time"]').within(() => {
+      cy.contains('Avg. elapsed time');
+      cy.contains('active queries');
+    });
+
+    cy.get('[data-test-subj="panel-longest-query"]').within(() => {
+      cy.contains('Longest running query');
+      cy.get('h2 > b').should('contain.text', '9.69 s');
+    });
+
+    cy.get('[data-test-subj="panel-total-cpu"]').within(() => {
+      cy.contains('Total CPU usage');
+      cy.contains('active queries');
+    });
+
+    cy.get('[data-test-subj="panel-total-memory"]').within(() => {
+      cy.contains('Total memory usage');
+      cy.contains('active queries');
+    });
+  });
+
+  it('displays Active Queries by Node and Active Queries by Index charts', () => {
+    cy.contains('Active Queries by Node').should('be.visible');
+    cy.contains('Active Queries by Index').should('be.visible');
+  });
+
+  it('shows finished query stats panels', () => {
+    cy.contains('Total completions').should('be.visible');
+    cy.contains('Total cancellations').should('be.visible');
+    cy.contains('Total failures').should('be.visible');
+  });
+
+  it('verifies table headers and row content in memory table', () => {
+    const expectedHeaders = [
+      '',
+      'Timestamp',
+      'Task ID',
+      'Index',
+      'Coordinator node',
+      'Time elapsed',
+      'CPU usage',
+      'Memory usage',
+      'Search type',
+      'Status',
+      'WLM Group',
+      'Actions',
+    ];
+
+    cy.get('.euiTable thead tr th').should(($headers) => {
+      const actualHeaders = [...$headers].map((el) => el.innerText.trim());
+      expect(actualHeaders.length).to.eq(expectedHeaders.length);
+      expectedHeaders.forEach((expected, index) => {
+        expect(actualHeaders[index]).to.eq(expected);
+      });
+    });
+  });
+
+  it('shows status as badges for running and cancelled queries', () => {
+    // Running queries should have a primary badge
+    cy.get('.euiBadge').contains('Running').should('be.visible');
+    // Cancelled queries should have a danger badge
+    cy.get('.euiBadge').contains('Cancelled').should('be.visible');
+  });
+
+  it('Task ID is a clickable link', () => {
+    cy.fixture('stub_live_queries.json').then((data) => {
+      const firstId = data.response.live_queries[0].id;
+      cy.get('.euiLink').contains(firstId).should('be.visible');
+    });
+  });
+
+  it('longest running query ID is a clickable link', () => {
+    cy.get('[data-test-subj="panel-longest-query"]').within(() => {
+      cy.get('.euiLink').should('be.visible');
+    });
+  });
+
+  it('navigates to next page in table pagination', () => {
+    cy.wait('@getLiveQueries');
+    cy.get('.euiPagination').should('be.visible');
+    cy.get('.euiPagination__item').contains('2').click();
+    cy.get('tbody tr').should('exist');
+  });
+
+  it('selects all checkboxes and shows bulk cancel text', () => {
+    // Hide finished queries first so the table only contains rows with checkboxes.
+    // Under testIsolation:false this repo's test ordering puts cancelled rows on
+    // page 1, breaking the assertion that some rows became `:checked`.
+    cy.get('[data-test-subj="live-queries-show-finished-toggle"]').then(
+      ($t) => {
+        if ($t.attr('aria-checked') === 'true') {
+          cy.wrap($t).click({ force: true });
+        }
+      }
+    );
+    cy.get('.euiTable thead tr th input[type="checkbox"]').check({
+      force: true,
+    });
+    cy.get('.euiTable tbody tr input[type="checkbox"]:checked').then(
+      ($rows) => {
+        const selectedCount = $rows.length;
+        const expectedText = `Cancel ${selectedCount} queries`;
+
+        cy.contains(expectedText).should('be.visible');
+      }
+    );
+  });
+
+  it('show finished queries toggle is enabled by default', () => {
+    cy.get('[data-test-subj="live-queries-show-finished-toggle"]').should(
+      'have.attr',
+      'aria-checked',
+      'true'
+    );
+  });
+
+  it('disables auto-refresh when toggled off', () => {
+    cy.get('[data-test-subj="live-queries-autorefresh-toggle"]').as('toggle');
+    cy.get('[data-test-subj="live-queries-refresh-interval"]').as('dropdown');
+
+    cy.get('@toggle').click();
+    cy.get('@toggle').should('have.attr', 'aria-checked', 'false');
+    cy.get('@dropdown').should('be.disabled');
+  });
+
+  it('has expected refresh interval options', () => {
+    cy.get('[data-test-subj="live-queries-refresh-interval"] option').should(
+      ($options) => {
+        const values = [...$options].map((opt) => opt.innerText.trim());
+        expect(values).to.include.members([
+          '5 seconds',
+          '10 seconds',
+          '30 seconds',
+          '1 minute',
+        ]);
+      }
+    );
+  });
+
+  it('manually refreshes data', () => {
+    cy.get('[data-test-subj="live-queries-refresh-button"]').click();
+    cy.wait('@getLiveQueries');
+  });
+
+  it('updates data periodically', () => {
+    cy.fixture('stub_live_queries.json').then((initialData) => {
+      let callCount = 0;
+      cy.intercept('GET', '**/api/live_queries**', (req) => {
+        callCount++;
+        const modifiedData = {
+          ...initialData,
+          response: {
+            ...initialData.response,
+            live_queries: initialData.response.live_queries.map((query) => ({
+              ...query,
+              id: `query${callCount}_${query.id}`,
+            })),
+          },
+        };
+        req.reply(modifiedData);
+      }).as('getPeriodicQueries');
+    });
+
+    cy.navigateToLiveQueries();
+
+    cy.wait('@getPeriodicQueries');
+    cy.wait('@getPeriodicQueries');
+    cy.wait('@getPeriodicQueries');
+
+    cy.get('@getPeriodicQueries.all').should('have.length.at.least', 3);
+  });
+
+  it('handles empty response state', () => {
+    cy.intercept('GET', '**/api/live_queries**', (req) => {
+      req.reply({
+        statusCode: 200,
+        body: {
+          ok: true,
+          response: {
+            live_queries: [],
+          },
+        },
+      });
+    }).as('getEmptyQueries');
+
+    cy.navigateToLiveQueries();
+    cy.wait('@getEmptyQueries');
+    cy.get('[data-test-subj="panel-active-queries"]').within(() => {
+      cy.contains('Active queries');
+      cy.get('h2 > b').should('contain.text', '0');
+    });
+
+    cy.contains('p', 'Active Queries by Node')
+      .closest('.euiPanel')
+      .within(() => {
+        cy.contains('No Visualization Available').should('be.visible');
+      });
+
+    cy.contains('p', 'Active Queries by Index')
+      .closest('.euiPanel')
+      .within(() => {
+        cy.contains('No Visualization Available').should('be.visible');
+      });
+  });
+
+  it('does not show cancel action for already cancelled queries', () => {
+    cy.fixture('stub_live_queries.json').then((data) => {
+      cy.intercept('GET', '**/api/live_queries**', {
+        statusCode: 200,
+        body: data,
+      }).as('getCancelledQuery');
+
+      cy.navigateToLiveQueries();
+      cy.wait('@getCancelledQuery');
+
+      cy.contains(data.response.live_queries[0].id)
+        .parents('tr')
+        .within(() => {
+          cy.get('[aria-label="Cancel this query"]').should('not.exist');
+        });
+
+      cy.contains(data.response.live_queries[0].id)
+        .parents('tr')
+        .find('input[type="checkbox"]')
+        .should('be.disabled');
+    });
+  });
+
+  it('filters table using the dynamic search bar', () => {
+    cy.get('[aria-label="Dynamic search bar"]').type('opensearch');
+    cy.get('tbody tr').should('have.length', 1);
+    cy.get('tbody tr')
+      .first()
+      .within(() => {
+        cy.contains('td', 'opensearch');
+      });
+  });
+
+  it('filters table by task ID using structured expression', () => {
+    cy.fixture('stub_live_queries.json').then((data) => {
+      const firstRunningQuery = data.response.live_queries.find(
+        (q) => !q.is_cancelled
+      );
+      cy.get('[aria-label="Dynamic search bar"]')
+        .clear()
+        .type(`id = ${firstRunningQuery.id}`);
+      cy.get('tbody tr').should('have.length', 1);
+      cy.get('tbody tr').first().contains(firstRunningQuery.id);
+    });
+  });
+
+  it('renders the search bar with correct placeholder', () => {
+    cy.get(
+      'input[placeholder="e.g. latency >= 1 AND status = Running"]'
+    ).should('be.visible');
+  });
+
+  it('shows field suggestions when search bar is focused', () => {
+    cy.get('[aria-label="Dynamic search bar"]').click();
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+    cy.get('[role="option"]').first().should('contain.text', 'id');
+  });
+
+  it('shows operator suggestions after typing a field name and space', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('latency ');
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+    cy.get('[role="option"]').should('contain.text', '=');
+    cy.get('[role="option"]').should('contain.text', '>=');
+    cy.get('[role="option"]').should('contain.text', 'between');
+  });
+
+  it('shows string operators for string fields', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('search_type ');
+    cy.get('[role="option"]').should('contain.text', '=');
+    cy.get('[role="option"]').should('contain.text', 'starts_with');
+    cy.get('[role="option"]').should('contain.text', 'contains');
+  });
+
+  it('shows value suggestions after typing field and operator', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('search_type = ');
+    cy.get('[role="option"]').should('have.length.greaterThan', 0);
+  });
+
+  it('shows conjunction suggestions after a complete condition', () => {
+    cy.get('[aria-label="Dynamic search bar"]').clear().type('id = somevalue ');
+    cy.get('[role="option"]').should('contain.text', 'AND');
+    cy.get('[role="option"]').should('contain.text', 'OR');
+  });
+
+  it('shows filter badges for active conditions', () => {
+    cy.get('[aria-label="Dynamic search bar"]')
+      .clear()
+      .type('status = Running ');
+    cy.get('.euiBadge').contains('status').should('exist');
+  });
+
+  it('removes filter when badge X is clicked', () => {
+    cy.get('[aria-label="Dynamic search bar"]')
+      .clear()
+      .type('status = Running ');
+    cy.get('.euiBadge')
+      .contains('status')
+      .closest('.euiBadge')
+      .find('button, [role="img"], svg')
+      .last()
+      .click({ force: true });
+    cy.get('[aria-label="Dynamic search bar"]').should('have.value', '');
+  });
+
+  it('auto-formats between expression with parentheses', () => {
+    cy.get('[aria-label="Dynamic search bar"]')
+      .clear()
+      .type('latency between 1 10 ');
+    cy.get('[aria-label="Dynamic search bar"]').should(
+      'have.value',
+      'latency between (1, 10) '
+    );
+  });
+
+  it('shows no items when filter matches nothing', () => {
+    cy.get('[aria-label="Dynamic search bar"]')
+      .clear()
+      .type('id = nonexistent_xyz_123');
+    cy.contains('No items found').should('be.visible');
+  });
+
+  it('displays WLM group as text when WLM is disabled', () => {
+    cy.get('tbody tr')
+      .first()
+      .within(() => {
+        cy.get('td')
+          .contains('ANALYTICS_WORKLOAD_GROUP')
+          .should('not.have.attr', 'href');
+      });
+  });
+});
+
+describe('Task Detail Flyout', () => {
+  it('opens flyout when clicking a running task ID', () => {
+    const mockData = {
+      ok: true,
+      response: {
+        live_queries: [
+          {
+            id: 'nodeA:1001',
+            timestamp: Date.now(),
+            node_id: 'nodeA',
+            description:
+              'indices[my-index] search_type[query_then_fetch] source[{"query":{"match_all":{}}}]',
+            measurements: {
+              latency: { number: 5e9 },
+              cpu: { number: 1e6 },
+              memory: { number: 4096 },
+            },
+            is_cancelled: false,
+            coordinator_task: {
+              task_id: 'nodeA:1001',
+              node_id: 'nodeA',
+              action: 'indices:data/read/search',
+              status: 'running',
+              description:
+                'indices[my-index] search_type[query_then_fetch] source[{"query":{"match_all":{}}}]',
+              start_time: Date.now(),
+              running_time_nanos: 5e9,
+              cpu_nanos: 1e6,
+              memory_bytes: 4096,
+            },
+            shard_tasks: [
+              {
+                task_id: 'nodeB:2001',
+                node_id: 'nodeB',
+                action: 'indices:data/read/search[phase/query]',
+                status: 'running',
+                description: 'shardId[[my-index][0]]',
+                start_time: Date.now(),
+                running_time_nanos: 4e9,
+                cpu_nanos: 800000,
+                memory_bytes: 2048,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    cy.intercept('GET', '**/api/live_queries**', {
+      statusCode: 200,
+      body: mockData,
+    }).as('getLiveQueries');
+
+    cy.navigateToLiveQueries();
+    // Force reload because testIsolation is disabled in this repo's cypress.config.
+    cy.reload();
+    cy.wait('@getLiveQueries', { timeout: 60000 });
+
+    // Click the task ID link
+    cy.get('.euiLink').contains('nodeA:1001').click();
+
+    // Flyout should open
+    cy.get('.euiFlyout').should('be.visible');
+    cy.contains('Task ID - nodeA:1001').should('be.visible');
+
+    // Task Summary panel
+    cy.get('.euiFlyout').within(() => {
+      cy.contains('Task Summary').should('exist');
+      cy.get('.euiBadge').contains('running').should('exist');
+
+      // Running task should show Refresh and Kill Query
+      cy.contains('Refresh').should('exist');
+      cy.contains('Kill Query').should('exist');
+
+      // Task Resource Usage
+      cy.contains('Task Resource Usage').should('exist');
+      cy.contains('Coordinator Task').should('exist');
+      cy.contains('Shard Tasks').should('exist');
+
+      // Shard ID should be parsed
+      cy.contains('my-index[0]').should('exist');
+
+      // Phase should be parsed
+      cy.contains('Query').should('exist');
+
+      // Query Source
+      cy.contains('Query Source').scrollIntoView().should('exist');
+      cy.contains('match_all').should('exist');
+    });
+  });
+
+  it('shows View Top N and hides Refresh/Kill for completed tasks', () => {
+    const mockData = {
+      ok: true,
+      response: {
+        live_queries: [],
+        finished_queries: [
+          {
+            id: 'nodeA:2001',
+            timestamp: Date.now() - 5000,
+            node_id: 'nodeA',
+            status: 'completed',
+            indices: ['test-idx'],
+            search_type: 'query_then_fetch',
+            measurements: {
+              latency: { number: 2e9 },
+              cpu: { number: 5e6 },
+              memory: { number: 8192 },
+            },
+            task_resource_usages: [
+              {
+                taskId: 100,
+                nodeId: 'nodeA',
+                parentTaskId: -1,
+                action: 'indices:data/read/search',
+                taskResourceUsage: {
+                  cpu_time_in_nanos: 5e6,
+                  memory_in_bytes: 4096,
+                },
+              },
+              {
+                taskId: 101,
+                nodeId: 'nodeA',
+                parentTaskId: 100,
+                action: 'indices:data/read/search[phase/query]',
+                taskResourceUsage: {
+                  cpu_time_in_nanos: 3e6,
+                  memory_in_bytes: 2048,
+                },
+              },
+            ],
+            top_n_id: 'topn-abc-123',
+            source: '{"query":{"match_all":{}}}',
+          },
+        ],
+      },
+    };
+
+    cy.intercept('GET', '**/api/live_queries**', {
+      statusCode: 200,
+      body: mockData,
+    }).as('getLiveQueries');
+
+    cy.navigateToLiveQueries();
+    // Force reload because testIsolation is disabled in this repo's cypress.config.
+    cy.reload();
+    cy.wait('@getLiveQueries', { timeout: 60000 });
+
+    // Click the finished task ID
+    cy.get('.euiLink').contains('nodeA:2001').click();
+
+    // Flyout should open
+    cy.get('.euiFlyout').should('be.visible');
+    cy.contains('Task ID - nodeA:2001').should('be.visible');
+
+    // Completed task should show View Top N
+    cy.get('.euiFlyout').within(() => {
+      cy.contains('View Top N').should('exist');
+
+      // Should NOT show Kill Query
+      cy.contains('Kill Query').should('not.exist');
+
+      // Status badge should be green (completed)
+      cy.get('.euiBadge').contains('completed').should('exist');
+
+      // Task Resource Usage with old format
+      cy.contains('Task Resource Usage').should('exist');
+      cy.contains('Coordinator Task').should('exist');
+
+      // Query Source
+      cy.contains('Query Source').scrollIntoView().should('exist');
+    });
+  });
+
+  it('shows View Top N for cancelled tasks', () => {
+    const mockData = {
+      ok: true,
+      response: {
+        live_queries: [
+          {
+            id: 'nodeA:3001',
+            timestamp: Date.now(),
+            node_id: 'nodeA',
+            description: 'indices[idx] search_type[query_then_fetch]',
+            measurements: {
+              latency: { number: 3e9 },
+              cpu: { number: 2e6 },
+              memory: { number: 2048 },
+            },
+            is_cancelled: true,
+            coordinator_task: {
+              task_id: 'nodeA:3001',
+              node_id: 'nodeA',
+              action: 'indices:data/read/search',
+              status: 'cancelled',
+              description: 'indices[idx] search_type[query_then_fetch]',
+              start_time: Date.now(),
+              running_time_nanos: 3e9,
+              cpu_nanos: 2e6,
+              memory_bytes: 2048,
+            },
+            shard_tasks: [],
+          },
+        ],
+      },
+    };
+
+    cy.intercept('GET', '**/api/live_queries**', {
+      statusCode: 200,
+      body: mockData,
+    }).as('getLiveQueries');
+
+    cy.navigateToLiveQueries();
+    // Force reload because testIsolation is disabled in this repo's cypress.config.
+    cy.reload();
+    cy.wait('@getLiveQueries', { timeout: 60000 });
+
+    cy.get('.euiLink').contains('nodeA:3001').click();
+
+    cy.get('.euiFlyout').should('be.visible');
+    cy.contains('Task ID - nodeA:3001').should('be.visible');
+
+    // Cancelled task should show View Top N
+    cy.contains('View Top N').should('be.visible');
+
+    // Should NOT show Kill Query
+    cy.get('.euiFlyout').within(() => {
+      cy.contains('Kill Query').should('not.exist');
+    });
+
+    // Status badge should be danger (cancelled)
+    cy.get('.euiBadge').contains('cancelled').should('be.visible');
+  });
+
+  it('closes flyout when close button is clicked', () => {
+    const mockData = {
+      ok: true,
+      response: {
+        live_queries: [
+          {
+            id: 'nodeA:4001',
+            timestamp: Date.now(),
+            node_id: 'nodeA',
+            description: 'indices[idx] search_type[query_then_fetch]',
+            measurements: {
+              latency: { number: 1e9 },
+              cpu: { number: 0 },
+              memory: { number: 0 },
+            },
+            is_cancelled: false,
+          },
+        ],
+      },
+    };
+
+    cy.intercept('GET', '**/api/live_queries**', {
+      statusCode: 200,
+      body: mockData,
+    }).as('getLiveQueries');
+
+    cy.navigateToLiveQueries();
+    // Force reload because testIsolation is disabled in this repo's cypress.config.
+    cy.reload();
+    cy.wait('@getLiveQueries', { timeout: 60000 });
+
+    cy.get('.euiLink').contains('nodeA:4001').click();
+    cy.get('.euiFlyout').should('be.visible');
+
+    // Close the flyout
+    cy.get('.euiFlyout [aria-label="Close this dialog"]').click();
+    cy.get('.euiFlyout').should('not.exist');
+  });
+
+  it('does not show cancel action for finished queries in table', () => {
+    const mockData = {
+      ok: true,
+      response: {
+        live_queries: [],
+        finished_queries: [
+          {
+            id: 'nodeA:5001',
+            timestamp: Date.now() - 1000,
+            node_id: 'nodeA',
+            status: 'completed',
+            indices: ['idx'],
+            search_type: 'query_then_fetch',
+            measurements: {
+              latency: { number: 1e9 },
+              cpu: { number: 0 },
+              memory: { number: 0 },
+            },
+            task_resource_usages: [],
+          },
+        ],
+      },
+    };
+
+    cy.intercept('GET', '**/api/live_queries**', {
+      statusCode: 200,
+      body: mockData,
+    }).as('getLiveQueries');
+
+    cy.navigateToLiveQueries();
+    // Force reload because testIsolation is disabled in this repo's cypress.config.
+    cy.reload();
+    cy.wait('@getLiveQueries', { timeout: 60000 });
+
+    // Finished query should show completed badge
+    cy.get('.euiBadge').contains('completed').should('exist');
+
+    // No cancel action for finished queries
+    cy.contains('nodeA:5001')
+      .parents('tr')
+      .within(() => {
+        cy.get('[aria-label="Cancel this query"]').should('not.exist');
+      });
+
+    // Checkbox should be disabled for finished queries
+    cy.contains('nodeA:5001')
+      .parents('tr')
+      .find('input[type="checkbox"]')
+      .should('be.disabled');
+  });
+});

--- a/cypress/integration/plugins/query-insights-dashboards/6_profiler_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/6_profiler_spec.js
@@ -1,0 +1,168 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BASE_PATH } from '../../../utils/base_constants';
+
+const PROFILER_PATH = `${BASE_PATH}/app/dev_tools#/queryProfiler`;
+
+describe('Query Profiler', () => {
+  beforeEach(() => {
+    cy.visit(PROFILER_PATH);
+    // Force reload because testIsolation is disabled in this repo's cypress.config —
+    // without it, the editor panel state (collapsed pane, leftover output) carries
+    // across tests and hides the action buttons.
+    cy.reload();
+    cy.contains('Import', { timeout: 30000 }).should('be.visible');
+  });
+
+  afterEach(() => {
+    cy.get('body').type('{esc}');
+  });
+
+  it('renders all tabs', () => {
+    cy.contains('.euiTab', 'Settings').should('be.visible');
+    cy.contains('.euiTab', 'Import').should('be.visible');
+    cy.contains('.euiTab', 'Export JSON').should('be.visible');
+    cy.contains('.euiTab', 'Help').should('be.visible');
+  });
+
+  it('renders editor panels', () => {
+    cy.get('.conApp__editorActionButton--success').should('have.length', 2);
+  });
+
+  it('opens settings modal', () => {
+    cy.contains('.euiTab', 'Settings').click();
+    cy.contains('Query Profiler Settings').should('be.visible');
+    cy.contains('Font Size').should('be.visible');
+    cy.contains('Wrap long lines').should('be.visible');
+    cy.contains('button', 'Cancel').click();
+    cy.contains('Query Profiler Settings').should('not.exist');
+  });
+
+  it('saves settings', () => {
+    cy.contains('.euiTab', 'Settings').click();
+    cy.get('input[type="number"]').clear().type('16');
+    cy.contains('button', 'Save').click();
+    cy.contains('Query Profiler Settings').should('not.exist');
+  });
+
+  it('opens import flyout', () => {
+    cy.contains('.euiTab', 'Import').click();
+    cy.contains('Search query').should('be.visible');
+    cy.contains('Profile JSON').should('be.visible');
+    cy.contains('button', 'Cancel').click();
+    cy.contains('Search query').should('not.exist');
+  });
+
+  it('opens help flyout', () => {
+    cy.contains('.euiTab', 'Help').click();
+    cy.contains('About Query Profiler').should('be.visible');
+    cy.contains('Reset All').scrollIntoView().should('be.visible');
+  });
+
+  it('executes a search query and returns 200', () => {
+    cy.intercept('POST', '**/api/profiler-proxy').as('profilerQuery');
+    cy.get('.conApp__editorActionButton--success').first().click();
+    cy.wait('@profilerQuery').its('response.statusCode').should('eq', 200);
+  });
+
+  it('shows meaningful error for invalid query', () => {
+    cy.intercept('POST', '**/api/profiler-proxy', {
+      statusCode: 400,
+      body: { message: '[illegal_argument_exception] bad parameter' },
+    }).as('profilerError');
+    cy.get('.conApp__editorActionButton--success').first().click();
+    cy.wait('@profilerError');
+    cy.get('.ace_content').last().invoke('text').should('include', 'Error');
+  });
+
+  it('resets editors when reset button clicked', () => {
+    cy.get('.conApp__editorActionButton--success').eq(1).click();
+    cy.contains('match_all').should('be.visible');
+  });
+
+  it('exports JSON file', () => {
+    cy.intercept('POST', '**/api/profiler-proxy').as('profilerQuery');
+    cy.get('.conApp__editorActionButton--success').first().click();
+    cy.wait('@profilerQuery').its('response.statusCode').should('eq', 200);
+    cy.contains('.euiTab', 'Export JSON').click();
+    cy.task('deleteFile', 'cypress/downloads/profile.json');
+  });
+
+  it('imports search query into editor', () => {
+    const query =
+      'GET _search\n{\n  "query": {\n    "term": { "status": "active" }\n  }\n}';
+    cy.contains('.euiTab', 'Import').click();
+    cy.contains('Search query').should('be.visible');
+    cy.get('input[type="file"]').selectFile(
+      {
+        contents: Cypress.Buffer.from(query),
+        fileName: 'test_query.txt',
+        mimeType: 'text/plain',
+      },
+      { force: true }
+    );
+    cy.get('[data-test-subj="importQueriesConfirmBtn"]')
+      .should('not.be.disabled')
+      .click();
+    cy.contains('Search query').should('not.exist');
+  });
+
+  it('imports profile JSON into output panel', () => {
+    const profile = JSON.stringify({
+      profile: { shards: [{ id: '[node1][index][0]', searches: [] }] },
+    });
+    cy.contains('.euiTab', 'Import').click();
+    cy.contains('Profile JSON').click();
+    cy.get('input[type="file"]').selectFile(
+      {
+        contents: Cypress.Buffer.from(profile),
+        fileName: 'test_profile.json',
+        mimeType: 'application/json',
+      },
+      { force: true }
+    );
+    cy.get('[data-test-subj="importQueriesConfirmBtn"]')
+      .should('not.be.disabled')
+      .click();
+    cy.contains('Profile JSON').should('not.exist');
+  });
+
+  it('Visualize button exists', () => {
+    cy.contains('Visualize profile').should('be.visible');
+  });
+
+  it('Visualize shows error when no output', () => {
+    cy.contains('Visualize profile').click();
+    cy.get('.ace_content').last().invoke('text').should('include', 'Error');
+  });
+
+  it('Visualize renders profile results after query', () => {
+    cy.intercept('POST', '**/api/profiler-proxy').as('profilerQuery');
+    cy.get('.conApp__editorActionButton--success').first().click();
+    cy.wait('@profilerQuery');
+    cy.contains('Visualize profile').click();
+    cy.contains('Profile Results').should('be.visible');
+  });
+
+  it('Shard table has search control after visualize', () => {
+    cy.intercept('POST', '**/api/profiler-proxy').as('profilerQuery');
+    cy.get('.conApp__editorActionButton--success').first().click();
+    cy.wait('@profilerQuery');
+    cy.contains('Visualize profile').click();
+    cy.contains('Profile Results').should('be.visible');
+    cy.get('input[placeholder="Search shard"]').should('exist');
+  });
+
+  it('Query tree renders with Search and Aggregation tabs', () => {
+    cy.intercept('POST', '**/api/profiler-proxy').as('profilerQuery');
+    cy.get('.conApp__editorActionButton--success').first().click();
+    cy.wait('@profilerQuery');
+    cy.contains('Visualize profile').click();
+    cy.contains('Profile Results').should('be.visible');
+    cy.contains('.euiTab', 'Search').should('be.visible');
+    cy.contains('.euiTab', 'Aggregation').should('be.visible');
+  });
+});

--- a/cypress/integration/plugins/query-insights-dashboards/COMPATIBILITY.md
+++ b/cypress/integration/plugins/query-insights-dashboards/COMPATIBILITY.md
@@ -163,11 +163,13 @@ one. Current cases:
 - `navigateToQueryDetails` and `navigateToGroupDetails` (in
   `commands.js`) fetch a query id directly from
   `/_insights/top_queries` and visit `#/query-details?id=...` /
-  `#/query-group-details?id=...`. Upstream's specs click into the table
-  to navigate, which is fragile here because of OUI/EUI class drift in
-  this repo's bundle and because there are multiple `.euiBasicTable`s
-  on the overview page. Keep these helpers and use them in
-  `2_query_details_spec.js` / `4_group_details_spec.js`.
+  `#/query-group-details?id=...`. Upstream's specs click into the
+  overview's last `.euiBasicTable` to navigate, which is fragile here:
+  the new Stats & Visualizations panel adds chart tables to the
+  overview, and "last" sometimes picks one of them, routing to
+  `query-details?id=<short-bucket-id>` and rendering "No Data
+  Available". Use these helpers in `2_query_details_spec.js` /
+  `4_group_details_spec.js` instead of the click-through navigation.
 - `waitForTopQueriesData` polls the API so the `before each` hook can
   proceed only once the QI backend has captured at least one query.
 

--- a/cypress/integration/plugins/query-insights-dashboards/COMPATIBILITY.md
+++ b/cypress/integration/plugins/query-insights-dashboards/COMPATIBILITY.md
@@ -1,0 +1,210 @@
+# Compatibility notes for Query Insights / WLM cypress specs
+
+The specs in this directory are kept in sync with the upstream cypress
+e2e tests in
+[`opensearch-project/query-insights-dashboards`](https://github.com/opensearch-project/query-insights-dashboards/tree/main/cypress/e2e).
+That repo's specs (under `cypress/e2e/qi`, `cypress/e2e/wlm`,
+`cypress/e2e/wlm-no-security`, `cypress/e2e/qi-wlm-interaction`) are the
+source of truth — they ship alongside the UI and are updated in the same
+PRs that change the UI.
+
+When you sync the specs into this repo, keep the test bodies identical
+to upstream and apply only the structural changes listed below. Anything
+larger than that should be raised as a question with the QI/WLM owners
+before landing here.
+
+## Mapping between repos
+
+| Upstream (query-insights-dashboards)                       | This repo                                                                 |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `cypress/e2e/qi/<n>_<name>.cy.js`                          | `cypress/integration/plugins/query-insights-dashboards/<n>_<name>_spec.js`|
+| `cypress/e2e/wlm/`                                         | **not synced** — see "Why WLM specs are not synced" below                 |
+| `cypress/e2e/wlm-no-security/`                             | **not synced** — same reason                                              |
+| `cypress/e2e/qi-wlm-interaction/`                          | **not synced** — same reason                                              |
+| `cypress/support/commands.js`                              | `cypress/utils/plugins/query-insights-dashboards/commands.js`             |
+| `cypress/support/constants.js`                             | `cypress/utils/plugins/query-insights-dashboards/constants.js`            |
+| `cypress/fixtures/*.json`                                  | `cypress/fixtures/*.json` (top-level, shared across all plugins)          |
+| `cypress/fixtures/sample_document.json`                    | `cypress/fixtures/plugins/query-insights-dashboards/sample_document.json` |
+
+## Why WLM specs are not synced
+
+The WLM specs upstream
+(`cypress/e2e/wlm/`, `cypress/e2e/wlm-no-security/`, and
+`cypress/e2e/qi-wlm-interaction/`) require:
+
+- HTTPS at `https://localhost:9200` with the security plugin installed
+  and demo creds (`admin / myStrongPassword123!`).
+- The WLM plugin (`workload-management`) installed on the OpenSearch
+  cluster.
+- The cluster setting `wlm.workload_group.mode=enabled` (default ships
+  as `monitor_only`).
+
+The QI release-signoff workflow in this repo
+(`.github/workflows/query-insights-dashboards-e2e-workflow.yml`) uses
+the standard `release-e2e-workflow-template.yml`, which spins up a
+bundled OpenSearch + OpenSearch Dashboards distribution but does not
+install the WLM plugin or flip the workload-group mode. Bringing the
+WLM specs over without that infra change would make every WLM spec
+fail in CI. If you want to enable them later, the workflow needs to:
+
+1. Install the `workload-management` plugin alongside the QI plugin on
+   the OpenSearch distribution.
+2. Issue a `PUT /_cluster/settings` with `{ persistent: {
+   "wlm.workload_group.mode": "enabled" } }` after cluster startup.
+3. Add WLM helper commands (`enableWlmMode`, `waitForWlmPlugin`) and
+   `WLM_AUTH` constants from upstream's `commands.js`/`constants.js`.
+
+Until that infra exists, the plugin repo's own
+`.github/workflows/cypress-tests.yml` is the only place WLM specs
+run.
+
+## Required adjustments per spec
+
+### Imports
+Upstream specs import from `../../support/constants` (constants.js) and
+`../../fixtures/...`. Rewrite both:
+
+```diff
+-import sampleDocument from '../../fixtures/sample_document.json';
+-import { METRICS } from '../../support/constants';
+-import { WLM_AUTH } from '../../support/constants';
+-import { BASE_PATH } from '../../support/constants';
++import sampleDocument from '../../../fixtures/plugins/query-insights-dashboards/sample_document.json';
++import { QUERY_INSIGHTS_METRICS as METRICS } from '../../../utils/plugins/query-insights-dashboards/constants';
++import { WLM_AUTH } from '../../../utils/plugins/query-insights-dashboards/constants';
++import { BASE_PATH } from '../../../utils/base_constants';
+```
+
+The stub fixtures (`stub_top_queries.json`, `stub_top_queries_query_only.json`,
+`stub_top_queries_group_only.json`, `stub_live_queries.json`,
+`stub_wlm_stats.json`) are at `cypress/fixtures/<name>.json` here, so:
+
+```diff
+-import MIXED from '../../fixtures/stub_top_queries.json';
++import MIXED from '../../../fixtures/stub_top_queries.json';
+```
+
+### Constant naming
+Upstream's `cypress/support/constants.js` exports `METRICS`, `BASE_PATH`,
+`OVERVIEW_PATH`, `CONFIGURATION_PATH`, `LIVEQUERIES_PATH`, `ADMIN_AUTH`,
+`PLUGIN_NAME`. This repo's
+`cypress/utils/plugins/query-insights-dashboards/constants.js` prefixes
+the QI-specific names with `QUERY_INSIGHTS_` to avoid collisions with
+other plugins' constants. When importing into a spec, alias on import
+(`QUERY_INSIGHTS_METRICS as METRICS`) so the body of the spec stays
+verbatim.
+
+### `cypress/support/commands.js` overrides
+Upstream's `commands.js` opens with `Cypress.Commands.overwrite('visit',
+...)` and `Cypress.Commands.overwrite('request', ...)` blocks that add
+basic-auth and a `security_tenant=private` query param when
+`SECURITY_ENABLED` is set. Drop these when porting — this repo handles
+auth globally in `cypress/utils/commands.js`, and adding a second layer
+of overrides causes the auth headers and the query string to be applied
+twice.
+
+The upstream `cy.login()` command uses these constants too and is also
+covered by the global commands; it is not added here.
+
+### `testIsolation: false`
+
+This repo runs Cypress with `testIsolation: false`
+(`cypress.config.js`). Upstream defaults to `true`. Two consequences:
+
+1. **Intercepted tests don't auto-refire on re-`cy.visit`** — when a test
+   navigates back to a URL it's already on, Cypress doesn't reload the
+   page, so the network request that the previous test set up an
+   intercept for never fires again. The upstream specs sometimes rely
+   on the auto-reload between tests. Where they do, add an explicit
+   `cy.reload()` immediately before the matching `cy.wait('@alias')`
+   call in the `beforeEach`.
+
+   Look for this pattern (intercepted topQueries):
+   ```js
+   beforeEach(() => {
+     cy.intercept('GET', '**/api/top_queries/**', ...).as('topQueries');
+     cy.waitForQueryInsightsPlugin();
+     cy.wait('@topQueries');
+   });
+   ```
+   In this repo it must be:
+   ```js
+   beforeEach(() => {
+     cy.intercept('GET', '**/api/top_queries/**', ...).as('topQueries');
+     cy.waitForQueryInsightsPlugin();
+     cy.reload();
+     cy.wait('@topQueries', { timeout: 60000 });
+   });
+   ```
+
+2. **`isChanged`-style form state carries over** — for example, the
+   "should allow saving the configuration" test in 3_configurations:
+   the upstream spec relies on a fresh page load to make the form's
+   `isChanged` flag reset, so toggling a metric is enough to make the
+   Save button render. Here the form's prior state persists and the
+   isChanged diff stays false. Add `cy.reload()` at the top of the
+   test body, and dirty the form with values that actually differ from
+   the cluster baseline (e.g. `select#timeUnit -> HOURS -> MINUTES`).
+
+### Spec-specific adjustments
+Some specs need extra reloads inside test bodies (not just the
+`beforeEach`) because state mutated by an earlier test breaks the next
+one. Current cases:
+
+- `5_live_queries_spec.js#selects all checkboxes...` — tests' default
+  table sort lands cancelled queries on the visible page first; we
+  toggle `live-queries-show-finished-toggle` off before checking
+  checkboxes so the table contains only cancellable rows.
+- `6_profiler_spec.js#beforeEach` — adds `cy.reload()` after `cy.visit`
+  so the editor state (collapsed pane / leftover output) is fresh.
+
+### Helpers we keep that upstream doesn't have
+
+- `navigateToQueryDetails` and `navigateToGroupDetails` (in
+  `commands.js`) fetch a query id directly from
+  `/_insights/top_queries` and visit `#/query-details?id=...` /
+  `#/query-group-details?id=...`. Upstream's specs click into the table
+  to navigate, which is fragile here because of OUI/EUI class drift in
+  this repo's bundle and because there are multiple `.euiBasicTable`s
+  on the overview page. Keep these helpers and use them in
+  `2_query_details_spec.js` / `4_group_details_spec.js`.
+- `waitForTopQueriesData` polls the API so the `before each` hook can
+  proceed only once the QI backend has captured at least one query.
+
+### Cypress tasks
+The 6_profiler spec uses `cy.task('deleteFile', ...)` to clean up
+downloaded JSON files. Upstream registers this task in
+`cypress/plugins/index.js`. This repo's `cypress/plugins/index.js`
+doesn't include it by default, so it's added under the existing
+`on('task', { ... })` block. If you ever rebuild plugins/index.js from
+scratch, re-add `deleteFile`.
+
+### Lint rules
+Upstream lints with `jest/valid-expect-in-promise`. This repo doesn't
+load that rule. Strip any `// eslint-disable-next-line
+jest/valid-expect-in-promise` comments — they cause `Definition for
+rule 'jest/...' was not found` errors here.
+
+### Window size (`enableTopQueries`, `enableGrouping`)
+Upstream uses `window_size: '1m'`; the previous functional-test version
+used `'5m'`. Keep `'1m'` so the Top N table populates inside a single
+test's beforeEach instead of staying empty.
+
+### Imports that aren't strictly needed
+The upstream `WLM_AUTH` import is referenced by WLM-only specs which we
+don't sync (see "Why WLM specs are not synced" above). If you do bring
+WLM specs over later, also add `WLM_AUTH` to `constants.js` and the
+`enableWlmMode` / `waitForWlmPlugin` helpers to `commands.js`.
+
+## Updating from upstream
+
+When upstream lands a UI change with matching cypress updates:
+
+1. Diff the upstream spec(s) against this repo's copy.
+2. Apply upstream's changes verbatim to the test bodies.
+3. Re-apply the import / constant alias / `cy.reload()` adjustments
+   listed above.
+4. Run `yarn lint --fix` and `yarn cypress:run-with-security --spec
+   'cypress/integration/plugins/query-insights-dashboards/<spec>'`
+   against a local OS+QI dev cluster to verify.
+5. Update this file if the set of required adjustments changed.

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -86,6 +86,19 @@ module.exports = (on, config) => {
     },
 
     /**
+     * Delete a file on disk. Used by the QI Profiler spec to clean up
+     * downloaded JSON files between tests.
+     */
+    deleteFile(filePath) {
+      try {
+        fs.unlinkSync(filePath);
+      } catch (e) {
+        console.error(e);
+      }
+      return null;
+    },
+
+    /**
      * Import JSON mapping file server-side (for large fixture files).
      * Reads the file, parses index definitions, and creates them via PUT.
      */

--- a/cypress/utils/plugins/query-insights-dashboards/commands.js
+++ b/cypress/utils/plugins/query-insights-dashboards/commands.js
@@ -3,9 +3,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Synced from opensearch-project/query-insights-dashboards' cypress/support/commands.js.
+// See COMPATIBILITY.md for the list of intentional divergences:
+//   - constants are aliased to QUERY_INSIGHTS_* names
+//   - the visit/request overrides from the plugin repo are dropped because this
+//     repo handles auth globally via cypress/utils/commands.js
+//   - navigateToQueryDetails/navigateToGroupDetails are kept (only here, used by
+//     2_query_details_spec.js / 4_group_details_spec.js for deterministic
+//     navigation by query id rather than clicking table rows)
+//   - the WLM commands (enableWlmMode, waitForWlmPlugin) and the WLM specs
+//     are NOT synced — they require an HTTPS cluster with the WLM plugin
+//     installed and `wlm.workload_group.mode=enabled`, which the QI release
+//     workflow's bundle-snapshot test cluster doesn't provide.
+
 const {
   QUERY_INSIGHTS_OVERVIEW_PATH,
   QUERY_INSIGHTS_CONFIGURATION_PATH,
+  QUERY_INSIGHTS_LIVEQUERIES_PATH,
 } = require('./constants');
 
 Cypress.Commands.add('getElementByText', (locator, text) => {
@@ -22,7 +36,7 @@ Cypress.Commands.add('enableTopQueries', (metric) => {
     body: {
       persistent: {
         [`search.insights.top_queries.${metric}.enabled`]: true,
-        [`search.insights.top_queries.${metric}.window_size`]: '5m',
+        [`search.insights.top_queries.${metric}.window_size`]: '1m',
         [`search.insights.top_queries.${metric}.top_n_size`]: 100,
       },
     },
@@ -59,9 +73,9 @@ Cypress.Commands.add('enableGrouping', () => {
         'search.insights.top_queries.latency.top_n_size': 5,
         'search.insights.top_queries.cpu.top_n_size': 5,
         'search.insights.top_queries.memory.top_n_size': 5,
-        'search.insights.top_queries.latency.window_size': '5m',
-        'search.insights.top_queries.cpu.window_size': '5m',
-        'search.insights.top_queries.memory.window_size': '5m',
+        'search.insights.top_queries.latency.window_size': '1m',
+        'search.insights.top_queries.cpu.window_size': '1m',
+        'search.insights.top_queries.memory.window_size': '1m',
         'search.insights.top_queries.exporter.type': 'none',
       },
     },
@@ -80,6 +94,21 @@ Cypress.Commands.add('disableGrouping', () => {
         'search.insights.top_queries.memory.enabled': false,
         'search.insights.top_queries.grouping.group_by': 'none',
         'search.insights.top_queries.exporter.type': 'none',
+      },
+    },
+    failOnStatusCode: true,
+  });
+});
+
+Cypress.Commands.add('setWindowSize', (size = '1m') => {
+  cy.request({
+    method: 'PUT',
+    url: `${Cypress.env('openSearchUrl')}/_cluster/settings`,
+    body: {
+      persistent: {
+        'search.insights.top_queries.latency.window_size': size,
+        'search.insights.top_queries.cpu.window_size': size,
+        'search.insights.top_queries.memory.window_size': size,
       },
     },
     failOnStatusCode: true,
@@ -155,15 +184,53 @@ Cypress.Commands.add('navigateToConfiguration', () => {
   });
 });
 
+Cypress.Commands.add('navigateToLiveQueries', () => {
+  cy.visit(QUERY_INSIGHTS_LIVEQUERIES_PATH);
+  cy.waitForPageLoad(QUERY_INSIGHTS_LIVEQUERIES_PATH, {
+    contains: 'Query insights - In-flight queries',
+  });
+});
+
+Cypress.Commands.add('waitForPluginToLoad', () => {
+  // CI environments need much longer waits for plugin initialization
+  const isCI = Cypress.env('CI') || !Cypress.config('isInteractive');
+  const waitTime = isCI ? 10000 : 3000;
+
+  cy.log(
+    `waitForPluginToLoad: ${
+      isCI ? 'CI' : 'Local'
+    } environment, waiting ${waitTime}ms`
+  );
+  cy.wait(waitTime);
+});
+
 Cypress.Commands.add('waitForQueryInsightsPlugin', () => {
   const isCI = Cypress.env('CI') || !Cypress.config('isInteractive');
   const timeout = isCI ? 360000 : 120000;
 
   cy.visit(QUERY_INSIGHTS_OVERVIEW_PATH, { timeout: 60000 });
 
+  // Wait for the plugin page to render. In CI, bundles may still be
+  // compiling on first visit — OSD serves a loading page that auto-refreshes
+  // when ready. Cypress's built-in retry on contains() handles this without
+  // explicit reloads (which can interfere with bundle compilation).
   cy.contains('Query insights - Top N queries', { timeout }).should(
     'be.visible'
   );
+});
+
+Cypress.Commands.add('setTypeFilter', (type) => {
+  cy.contains('button', 'Type').click();
+  cy.contains('[role="option"]', type).click();
+  cy.get('body').click(0, 0);
+});
+
+Cypress.Commands.add('resetTypeFilterToNone', () => {
+  cy.contains('button', 'Type').click();
+  cy.get('[role="option"][aria-selected="true"]').each(($el) => {
+    cy.wrap($el).click();
+  });
+  cy.get('body').click(0, 0);
 });
 
 /**

--- a/cypress/utils/plugins/query-insights-dashboards/constants.js
+++ b/cypress/utils/plugins/query-insights-dashboards/constants.js
@@ -9,6 +9,7 @@ export const QUERY_INSIGHTS_PLUGIN_NAME = 'query-insights-dashboards';
 
 export const QUERY_INSIGHTS_OVERVIEW_PATH = `${BASE_PATH}/app/${QUERY_INSIGHTS_PLUGIN_NAME}#/queryInsights`;
 export const QUERY_INSIGHTS_CONFIGURATION_PATH = `${BASE_PATH}/app/${QUERY_INSIGHTS_PLUGIN_NAME}#/configuration`;
+export const QUERY_INSIGHTS_LIVEQUERIES_PATH = `${BASE_PATH}/app/${QUERY_INSIGHTS_PLUGIN_NAME}#/LiveQueries`;
 export const QUERY_INSIGHTS_METRICS = {
   LATENCY: 'latency',
   CPU: 'cpu',


### PR DESCRIPTION
### Description

Sync the six Query Insights cypress specs (`1_top_queries`, `2_query_details`, `3_configurations`, `4_group_details`, `5_live_queries`, `6_profiler`) and their supporting fixtures/helpers from [`opensearch-project/query-insights-dashboards`'s `cypress/e2e/qi`](https://github.com/opensearch-project/query-insights-dashboards/tree/main/cypress/e2e/qi). This repo's copies had drifted from the plugin's UI, causing the integ-test failures in test-results/8534 (Filters & Search → DynamicSearchBar describe, new Status column, 8-panel Configuration page).

Test bodies match the plugin repo verbatim except for:
- Import paths and constant aliasing (`QUERY_INSIGHTS_METRICS as METRICS`)
- `cy.reload()` workarounds because this repo runs Cypress with `testIsolation: false` (the plugin repo defaults to true)
- A more robust `toggleMetricEnabled` helper in 3_configurations
- Stripped `jest/valid-expect-in-promise` eslint-disable comments

All adjustments and the rationale for not syncing the WLM specs are documented in `cypress/integration/plugins/query-insights-dashboards/COMPATIBILITY.md`.

Verified locally: all 4 specs (1, 3, 5, 6) pass 98/98 against an OS+QI dev cluster.

### Issues Resolved

Failing query-insights-dashboards integ tests in [test-results/8534](https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/3.7.0/8914/linux/x64/tar/test-results/8534/integ-test/queryInsightsDashboards/).

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.