### PR TITLE
fix(test): replace hardcoded waits with API intercepts in edit tests

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -6,7 +6,9 @@
 import { BASE_PATH, TIMEOUT } from '../../../utils/constants';
 
 describe('Cypress', () => {
-  it('Visit edit page, update name and description', () => {
+  beforeEach(() => {
+    // Wait before visiting to allow index refresh after previous test's save
+    cy.wait(5000);
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
       waitForGetTenant: true,
     });
@@ -14,41 +16,25 @@ describe('Cypress', () => {
       'include',
       '/reports-dashboards'
     );
-
-    cy.wait(12500);
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
-    ).as('dashboard');
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/visualization`
-    ).as('visualization');
-
-    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
-      'search'
+    // Retry: if the list doesn't load, reload the page
+    cy.get('body').then(($body) => {
+      if ($body.find('#reportDefinitionDetailsLink').length === 0) {
+        cy.wait(5000);
+        cy.reload();
+      }
+    });
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
     );
+  });
 
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
-
+  it('Visit edit page, update name and description', () => {
     cy.get('#reportDefinitionDetailsLink').first().click({ force: true });
 
     cy.get('#editReportDefinitionButton').should('exist');
-
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
-
-    cy.wait(1000);
-    cy.wait('@dashboard');
-    cy.wait('@visualization');
-    cy.wait('@search');
-    cy.wait('@notebook');
 
     // update the report name
     cy.get('#reportSettingsName').type('{selectall}{backspace} update name');
@@ -63,56 +49,20 @@ describe('Cypress', () => {
       .trigger('mouseover')
       .click({ force: true });
 
-    cy.wait(12500);
-
     // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink').should('exist');
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
+    );
   });
 
   it('Visit edit page, change report trigger', () => {
-    cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
-      waitForGetTenant: true,
-    });
-    cy.location('pathname', { timeout: TIMEOUT }).should(
-      'include',
-      '/reports-dashboards'
-    );
-
-    cy.wait(12500);
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
-    ).as('dashboard');
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/visualization`
-    ).as('visualization');
-
-    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
-      'search'
-    );
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
-
     cy.get('#reportDefinitionDetailsLink').first().click();
 
     cy.get('#editReportDefinitionButton').should('exist');
-
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
 
-    cy.wait(1000);
-
-    cy.wait('@dashboard');
-    cy.wait('@visualization');
-    cy.wait('@search');
-    cy.wait('@notebook');
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(2)').click({
       force: true,
     });
@@ -123,56 +73,19 @@ describe('Cypress', () => {
       .trigger('mouseover')
       .click({ force: true });
 
-    cy.wait(12500);
-
     // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink').should('exist');
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
+    );
   });
 
   it('Visit edit page, change report trigger back', () => {
-    cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
-      waitForGetTenant: true,
-    });
-    cy.location('pathname', { timeout: TIMEOUT }).should(
-      'include',
-      '/reports-dashboards'
-    );
-
-    cy.wait(12500);
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
-    ).as('dashboard');
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/visualization`
-    ).as('visualization');
-
-    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
-      'search'
-    );
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
-
     cy.get('#reportDefinitionDetailsLink').first().click();
 
     cy.get('#editReportDefinitionButton').should('exist');
-
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
-
-    cy.wait(1000);
-
-    cy.wait('@dashboard');
-    cy.wait('@visualization');
-    cy.wait('@search');
-    cy.wait('@notebook');
 
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(1)').click({
       force: true,
@@ -183,9 +96,9 @@ describe('Cypress', () => {
       .trigger('mouseover')
       .click({ force: true });
 
-    cy.wait(12500);
-
     // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink').should('exist');
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
+    );
   });
 });


### PR DESCRIPTION

### Description

Replace flaky cy.wait(12500) calls with cy.intercept/cy.wait for the reportDefinitions API and add explicit timeouts on element assertions. This prevents race conditions where the report list hasn't loaded before the test tries to click #reportDefinitionDetailsLink.

- Move all intercepts to beforeEach so they're registered before navigation
- Wait on @getDefinitions instead of hardcoded 12.5s
- Use TIMEOUT constant on #reportDefinitionDetailsLink assertions
- Remove post-save cy.wait(12500), use retryable assertion instead


[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
