### PR TITLE
Fix Cypress 15 compatibility for custom-import-map-dashboards tests

### DIFF
--- a/.github/workflows/custom-import-map-dashboards-release-e2e-workflow.yml
+++ b/.github/workflows/custom-import-map-dashboards-release-e2e-workflow.yml
@@ -23,3 +23,4 @@ jobs:
     with:
       test-name: Observability
       test-command: yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/custom-import-map-dashboards/*'
+      osd-serve-args: --home.disableExperienceModal=true --home.disableWelcomeScreen=true

--- a/cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js
@@ -38,9 +38,7 @@ describe('Default OpenSearch base map layer', () => {
       force: true,
     });
     for (let i = 0; i < 21; i++) {
-      cy.wait(1000)
-        .get('canvas.maplibregl-canvas')
-        .trigger('dblclick', { force: true });
+      cy.wait(1000).get('canvas.maplibregl-canvas').dblclick({ force: true });
     }
     cy.get('[data-test-subj="mapStatusBar"]').should('contain', 'zoom: 22');
   });

--- a/cypress/integration/plugins/custom-import-map-dashboards/6_geojson_file_upload.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/6_geojson_file_upload.spec.js
@@ -6,7 +6,6 @@
 import { BASE_PATH } from '../../../utils/constants';
 import { CURRENT_TENANT } from '../../../utils/commands';
 import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
-import 'cypress-file-upload';
 
 const miscUtils = new MiscUtils(cy);
 
@@ -33,8 +32,8 @@ describe('Verify successful custom geojson file upload', () => {
     // Click on "Import Vector Map" tab, which is part of customImportMap plugin
     cy.contains('Import Vector Map').click({ force: true });
 
-    cy.get('[data-testId="filePicker"]').attachFile(
-      'plugins/custom-import-map-dashboards/sample_geo.json'
+    cy.get('[data-testId="filePicker"]').selectFile(
+      'cypress/fixtures/plugins/custom-import-map-dashboards/sample_geo.json'
     );
     cy.get('[data-testId="customIndex"]').type('sample');
     cy.contains('Import file').click({ force: true });


### PR DESCRIPTION
### Description

- Fix map zoom test to use .dblclick() instead of .trigger('dblclick') which no longer triggers MapLibre's zoom handler in Cypress 15 / Electron 138
- Fix file upload test to use Cypress built-in .selectFile() instead of cypress-file-upload plugin's .attachFile() which doesn't properly read file content in Cypress 15

### Issues Resolved
N/A

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
