### PR TITLE
fix: add permissions entry for agentic notebook test cases

### DIFF
--- a/cypress/integration/plugins/dashboards-investigation/2_agentic_notebook.spec.js
+++ b/cypress/integration/plugins/dashboards-investigation/2_agentic_notebook.spec.js
@@ -112,6 +112,16 @@ describe('Agentic Notebook Investigation Tests', () => {
       name: workspaceName,
       description: 'Workspace for cypress testing',
       features: ['use-case-observability'],
+      settings: {
+        permissions: {
+          library_write: {
+            users: ['%me%'],
+          },
+          write: {
+            users: ['%me%'],
+          },
+        },
+      },
     }).then((wsId) => {
       workspaceId = wsId;
       cy.loadSampleDataForWorkspace('ecommerce', workspaceId);


### PR DESCRIPTION
### Description

OSD introduced a change: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12080 to refresh workspace metadata, but it has an issue with workspaces without any permission entries. This PR is to fix that by adding permission entry when creating workspaces.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
