### PR TITLE
fix(sa): address security analytics cypress test failures in CI

### DIFF
--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/1_detectors.spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/1_detectors.spec.js
@@ -430,6 +430,10 @@ describe('Detectors', () => {
 
       // Visit Detectors page before any test
       cy.visit(`${OPENSEARCH_DASHBOARDS_URL}/detectors`);
+      // Short wait to ensure previous test operations are complete
+      cy.wait(2000);
+      // Force reload to ensure detectorsSearch request fires even if already on this page
+      cy.reload();
       cy.wait('@detectorsSearch').should('have.property', 'state', 'Complete');
     });
 
@@ -628,6 +632,7 @@ describe('Detectors', () => {
           });
           setupIntercept(cy, NODE_API.SEARCH_DETECTORS, 'detectorsSearch');
           cy.visit(`${OPENSEARCH_DASHBOARDS_URL}/detectors`);
+          cy.reload();
           cy.wait('@detectorsSearch').should(
             'have.property',
             'state',

--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/3_alerts.spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/3_alerts.spec.js
@@ -52,21 +52,26 @@ describe('Alerts', () => {
   beforeEach(() => {
     // Visit Alerts table page
     setupIntercept(cy, `${NODE_API.DETECTORS_BASE}/_search`, 'detectorsSearch');
-    // Visit Detectors page
+    // Visit Alerts page
     cy.visit(`${OPENSEARCH_DASHBOARDS_URL}/alerts`);
-    cy.wait('@detectorsSearch', { timeout: 600000 }).should(
-      'have.property',
-      'state',
-      'Complete'
-    );
+    // Force reload to dismiss any flyouts/overlays from previous test
+    cy.reload();
 
     // Wait for page to load
     cy.sa_waitForPageLoad('alerts', {
       contains: 'Security alerts',
     });
 
+    // Short wait to ensure data loads
+    cy.wait(5000);
+
     // Filter table to only show alerts for the test detector
-    cy.get(`input[type="search"]`).type(`${testDetectorCfg.name}{enter}`);
+    cy.get(`input[type="search"]`).type(`${testDetectorCfg.name}{enter}`, {
+      force: true,
+    });
+
+    // Wait for table to re-render after filter
+    cy.wait(2000);
 
     // Adjust the date range picker to display alerts from today
     cy.get(

--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/4_findings.spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/4_findings.spec.js
@@ -131,6 +131,11 @@ describe('Findings', () => {
     ruleTags.forEach((tag) => {
       cy.contains(tag);
     });
+
+    // Close the flyout to prevent overlay issues in subsequent tests
+    cy.get('.euiFlexItem--flexGrowZero > .euiButtonIcon').click({
+      force: true,
+    });
   });
 
   // TODO - upon reaching rules page, trigger appropriate rules detail flyout

--- a/cypress/utils/plugins/security-analytics-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/security-analytics-dashboards-plugin/commands.js
@@ -466,7 +466,11 @@ Cypress.Commands.add(
     prevSubject: true,
   },
   (subject, text) => {
-    return cy.get(subject).clear().sa_ospType(text).realPress('Enter');
+    return cy
+      .get(subject)
+      .clear({ force: true })
+      .sa_ospType(text)
+      .realPress('Enter');
   }
 );
 


### PR DESCRIPTION
- 1_detectors: Add `cy.reload()` to ensure detectorsSearch fires after page cache
- 3_alerts: Remove flaky cy.wait on detectorsSearch, use DOM-based page load check
- 4_findings: Close `flyout` to prevent overlay leaking into next test
- commands: Add `force:true` to `sa_ospSearch` clear as overlay safety net

### Description
Fixes security analytics cypress test failures in the 3.7.0 integ-test pipeline.

### Issues Resolved

Addresses securityAnalyticsDashboards failures in OpenSearch 3.7.0 RC1 integ-test (build 8534/8549).

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
