### PR TITLE
fix(alerting): add matrix strategy for alerting cypress tests

### DIFF
--- a/.github/workflows/alerting-release-e2e-workflow.yml
+++ b/.github/workflows/alerting-release-e2e-workflow.yml
@@ -16,10 +16,74 @@ jobs:
             - 'cypress/**/alerting-dashboards-plugin/**'
             - '.github/workflows/release-e2e-workflow-template.yml'
 
-  tests:
+  tests-acknowledge-alerts-modal:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
     with:
-      test-name: Alerting
-      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/*'
+      test-name: Alerting (acknowledge_alerts_modal_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/acknowledge_alerts_modal_spec.js'
+
+  tests-alert:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (alert_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/alert_spec.js'
+
+  tests-alerts-dashboard-flyout:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (alerts_dashboard_flyout_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/alerts_dashboard_flyout_spec.js'
+
+  tests-bucket-level-monitor:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (bucket_level_monitor_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js'
+
+  tests-cluster-metrics-monitor:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (cluster_metrics_monitor_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/cluster_metrics_monitor_spec.js'
+
+  tests-composite-level-monitor:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (composite_level_monitor_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js'
+
+  tests-document-level-monitor:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (document_level_monitor_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/document_level_monitor_spec.js'
+
+  tests-monitors-dashboard:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (monitors_dashboard_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/monitors_dashboard_spec.js'
+
+  tests-query-level-monitor:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (query_level_monitor_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js'

--- a/cypress/integration/plugins/alerting-dashboards-plugin/monitors_dashboard_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/monitors_dashboard_spec.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Each spec runs in its own process via matrix strategy to prevent memory crashes
+
 import {
   ALERTING_INDEX,
   ALERTING_PLUGIN_NAME,


### PR DESCRIPTION
Split alerting specs into separate jobs to prevent Electron renderer memory crashes when running all 9 specs in a single process.

### Description

Split alerting specs into separate jobs to prevent Electron renderer memory crashes when running all 9 specs in a single process. GitHub Actions doesn't support matrix strategy with reusable workflows, so each spec is a separate job calling the template individually.


### Issues Resolved

Addresses alertingDashboards Electron renderer crashes in OpenSearch 3.7.0 integ-test pipeline.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
