### PR TITLE
[Backport 3.7] Backport missing commits from main

### DIFF
--- a/.github/workflows/alerting-release-e2e-workflow.yml
+++ b/.github/workflows/alerting-release-e2e-workflow.yml
@@ -16,10 +16,74 @@ jobs:
             - 'cypress/**/alerting-dashboards-plugin/**'
             - '.github/workflows/release-e2e-workflow-template.yml'
 
-  tests:
+  tests-acknowledge-alerts-modal:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
     with:
-      test-name: Alerting
-      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/*'
+      test-name: Alerting (acknowledge_alerts_modal_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/acknowledge_alerts_modal_spec.js'
+
+  tests-alert:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (alert_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/alert_spec.js'
+
+  tests-alerts-dashboard-flyout:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (alerts_dashboard_flyout_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/alerts_dashboard_flyout_spec.js'
+
+  tests-bucket-level-monitor:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (bucket_level_monitor_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js'
+
+  tests-cluster-metrics-monitor:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (cluster_metrics_monitor_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/cluster_metrics_monitor_spec.js'
+
+  tests-composite-level-monitor:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (composite_level_monitor_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/composite_level_monitor_spec.js'
+
+  tests-document-level-monitor:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (document_level_monitor_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/document_level_monitor_spec.js'
+
+  tests-monitors-dashboard:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (monitors_dashboard_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/monitors_dashboard_spec.js'
+
+  tests-query-level-monitor:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: Alerting (query_level_monitor_spec.js)
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js'

--- a/.github/workflows/dashboard-variable-release-e2e-workflow.yml
+++ b/.github/workflows/dashboard-variable-release-e2e-workflow.yml
@@ -1,0 +1,28 @@
+name: Dashboard Variable Release tests workflow in Bundled OpenSearch Dashboards
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.filter.outputs.tests }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            tests:
+              - 'cypress/**/dashboard-variable/**'
+              - '.github/workflows/dashboard-variable-release-e2e-workflow.yml'
+              - '.github/workflows/release-e2e-workflow-template.yml'
+  tests-with-security:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template.yml
+    with:
+      test-name: dashboard variable
+      test-command: env CYPRESS_DISABLE_LOCAL_CLUSTER=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true CYPRESS_WORKSPACE_ENABLED=true CYPRESS_SAVED_OBJECTS_PERMISSION_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/dashboard-variable/*'
+      osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --data_source.hideLocalCluster=true --workspace.enabled=true --savedObjects.permission.enabled=true --opensearch_security.multitenancy.enabled=false --opensearchDashboards.dashboardAdmin.users='["admin"]' --uiSettings.overrides.home:useNewHomePage=true --explore.enabled=true
+      artifact-name-suffix: "-with-security"

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/dashboard-variable/variable_crud.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/dashboard-variable/variable_crud.spec.js
@@ -1,0 +1,354 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { BASE_PATH } from '../../../../../utils/base_constants';
+import {
+  enterEditMode,
+  openAddVariableEditor,
+  saveVariableEditor,
+  openEditForVariable,
+  deleteVariable,
+} from '../../../../../utils/dashboards/dashboard_variable/helpers.js';
+
+const miscUtils = new MiscUtils(cy);
+const WORKSPACE_NAME = 'test_workspace_variable';
+const DASHBOARD_NAME = 'variable_crud_test_dashboard';
+const MDSEnabled = Cypress.env('DATASOURCE_MANAGEMENT_ENABLED');
+
+if (Cypress.env('WORKSPACE_ENABLED')) {
+  describe('Dashboard Variables CRUD', () => {
+    let workspaceId;
+    let datasourceId;
+    let dashboardId;
+
+    before(() => {
+      cy.deleteWorkspaceByName(WORKSPACE_NAME);
+
+      const createWorkspaceWithSampleData = (dsId) => {
+        cy.createWorkspace({
+          name: WORKSPACE_NAME,
+          features: ['use-case-observability'],
+          settings: {
+            permissions: {
+              library_write: { users: ['%me%'] },
+              write: { users: ['%me%'] },
+            },
+            ...(dsId ? { dataSources: [dsId] } : {}),
+          },
+        }).then((id) => {
+          workspaceId = id;
+          // Load eCommerce sample data so the workspace has real content
+          cy.loadSampleDataForWorkspace('ecommerce', id, dsId);
+        });
+      };
+
+      if (MDSEnabled) {
+        cy.deleteAllDataSources();
+        cy.createDataSourceNoAuth().then((result) => {
+          datasourceId = result[0];
+          expect(datasourceId).to.be.a('string').that.is.not.empty;
+          createWorkspaceWithSampleData(datasourceId);
+        });
+      } else {
+        createWorkspaceWithSampleData();
+      }
+    });
+
+    after(() => {
+      if (workspaceId) {
+        cy.removeSampleDataForWorkspace('ecommerce', workspaceId, datasourceId);
+        cy.deleteWorkspaceById(workspaceId);
+      }
+      if (MDSEnabled) {
+        cy.deleteAllDataSources();
+      }
+    });
+
+    before(() => {
+      const url = `${BASE_PATH}/w/${workspaceId}/api/saved_objects/dashboard`;
+
+      cy.request({
+        method: 'POST',
+        url,
+        headers: {
+          'content-type': 'application/json;charset=UTF-8',
+          'osd-xsrf': true,
+        },
+        body: JSON.stringify({
+          attributes: {
+            title: DASHBOARD_NAME,
+            description: 'Test dashboard for variable CRUD operations',
+          },
+        }),
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+        dashboardId = response.body.id;
+        cy.log(`Dashboard created with ID: ${dashboardId}`);
+      });
+    });
+
+    beforeEach(() => {
+      miscUtils.visitPage(
+        `w/${workspaceId}/app/dashboards#/view/${dashboardId}`
+      );
+      cy.reload();
+      enterEditMode();
+    });
+    describe('Create variable', () => {
+      it('should create query type variable', () => {
+        openAddVariableEditor();
+
+        // Verify default type is Query
+        cy.getElementByTestId('variableEditorType').should(
+          'contain.text',
+          'Query'
+        );
+
+        // Fill in the query variable form
+        cy.getElementByTestId('variableEditorName')
+          .clear()
+          .type('customer_gender');
+        cy.getElementByTestId('variableEditorLabel')
+          .clear()
+          .type('Customer Gender');
+
+        // Select dataset
+        cy.getElementByTestId('datasetSelectButton').click();
+        cy.contains('opensearch_dashboards_sample_data_ecommerce').click();
+
+        // Input query in the editor
+        cy.getElementByTestId('variableQueryPanelEditor')
+          .find('textarea')
+          .click({ force: true })
+          .focused()
+          .type(
+            'SOURCE = opensearch_dashboards_sample_data_ecommerce | FIELDS customer_gender',
+            { force: true }
+          );
+
+        cy.getElementByTestId('variableQueryPanelRunQuery').click();
+
+        // Verify preview shows values with count > 0
+        cy.contains(/Preview of values \([1-9]\d*\)/, {
+          timeout: 10000,
+        }).should('be.visible');
+
+        cy.get('.euiBadge__text').should('have.length.greaterThan', 0);
+        cy.get('.euiBadge__text').first().should('not.be.empty');
+
+        saveVariableEditor();
+
+        // Verify the variable is created
+        cy.getElementByTestId('variable-customer_gender').should('be.visible');
+      });
+
+      it('should create custom type variable', () => {
+        openAddVariableEditor();
+
+        cy.getElementByTestId('variableEditorType').click();
+        cy.contains('Custom').click();
+
+        cy.getElementByTestId('variableEditorName').clear().type('env');
+        cy.getElementByTestId('variableEditorLabel')
+          .clear()
+          .type('Environment');
+        cy.getElementByTestId('variableEditorDescription')
+          .clear()
+          .type('Environment');
+
+        const customOptions = ['production', 'staging', 'development'];
+        customOptions.forEach((opt) => {
+          cy.getElementByTestId('variableEditorCustomValues')
+            .find('input')
+            .type(`${opt}{enter}`);
+        });
+
+        saveVariableEditor();
+        cy.getElementByTestId('variable-env').should('be.visible');
+      });
+
+      it('should display and interact with variables in the bar', () => {
+        // Verify variables are visible
+        cy.getElementByTestId('variable-env').should('be.visible');
+        cy.getElementByTestId('variable-customer_gender').should('be.visible');
+
+        // Verify current value is displayed
+        cy.getElementByTestId('variable-env')
+          .find(`[data-test-subj="${'variable-selector-current'}"]`)
+          .should('not.be.empty');
+
+        // Test collapse and expand
+        cy.getElementByTestId('toggleVariablesBarButton').click();
+        cy.getElementByTestId('variable-env').should('not.exist');
+        cy.getElementByTestId('toggleVariablesBarButton').click();
+        cy.getElementByTestId('variable-env').should('be.visible');
+
+        // Test opening dropdown and viewing options
+        cy.getElementByTestId('variable-env')
+          .find(`[data-test-subj="${'variable-selector-button'}"]`)
+          .click();
+        cy.get('.euiSelectable').should('be.visible');
+        cy.contains('production').should('be.visible');
+        cy.contains('staging').should('be.visible');
+        cy.contains('development').should('be.visible');
+
+        // Test selecting a value
+        cy.contains('staging').click();
+        cy.getElementByTestId('variable-env')
+          .find(`[data-test-subj="${'variable-selector-current'}"]`)
+          .should('contain', 'staging');
+      });
+
+      it('should validate variable editor form and show appropriate errors', () => {
+        // Empty name error
+        openAddVariableEditor();
+        cy.getElementByTestId('variableEditorSave').click();
+        cy.contains('Variable name is required').should('be.visible');
+
+        // Invalid name error
+        cy.getElementByTestId('variableEditorName').clear().type('1invalid');
+        cy.getElementByTestId('variableEditorSave').click();
+
+        // Duplicate variable name error
+        cy.getElementByTestId('variableEditorName').clear().type('env');
+        cy.getElementByTestId('variableEditorSave').click();
+        cy.contains(
+          `The name "env" conflicts with an existing variable name or label`
+        ).should('be.visible');
+
+        // No query provided error for query type variable
+        cy.getElementByTestId('variableEditorName').clear().type('emptyVar');
+        cy.getElementByTestId('variableEditorSave').click();
+        cy.contains(`Query is required for Query type variables`).should(
+          'be.visible'
+        );
+
+        // No run query error for query type variable
+        cy.getElementByTestId('variableQueryPanelEditor')
+          .find('textarea')
+          .click({ force: true })
+          .focused()
+          .type(
+            'SOURCE = opensearch_dashboards_sample_data_ecommerce | FIELDS customer_gender',
+            { force: true }
+          );
+        cy.getElementByTestId('variableEditorSave').click();
+        cy.contains(
+          `You must preview the query successfully before saving`
+        ).should('be.visible');
+
+        // No options provided error for custom type variable
+        cy.getElementByTestId('variableEditorType').click();
+        cy.contains('Custom').click();
+        cy.getElementByTestId('variableEditorName').clear().type('emptyVar');
+        cy.getElementByTestId('variableEditorSave').click();
+        cy.contains(
+          `Custom values are required for Custom type variables`
+        ).should('be.visible');
+      });
+    });
+
+    describe('Edit variable', () => {
+      it('should open management panel and list all variables', () => {
+        cy.getElementByTestId('manageVariablesButton').click();
+        cy.getElementByTestId('variableManagementPanel').should('be.visible');
+        cy.contains('Manage variables').should('be.visible');
+
+        // Verify variables are listed
+        cy.getElementByTestId('variableManagementPanel')
+          .contains('env')
+          .should('be.visible');
+        cy.getElementByTestId('variableManagementPanel')
+          .contains('customer_gender')
+          .should('be.visible');
+
+        cy.contains('button', 'Close').click();
+        cy.getElementByTestId('variableManagementPanel').should('not.exist');
+      });
+
+      it('should edit variable and update label and options', () => {
+        // Verify pre-filled values
+        openEditForVariable('env');
+        cy.getElementByTestId('variableEditorName').should('have.value', 'env');
+        cy.getElementByTestId('variableEditorLabel').should(
+          'have.value',
+          'Environment'
+        );
+        cy.getElementByTestId('variableEditorDescription').should(
+          'have.value',
+          'Environment'
+        );
+
+        // Update the label
+        cy.getElementByTestId('variableEditorLabel')
+          .clear()
+          .type('Env Updated');
+        cy.getElementByTestId('variableEditorSave').click();
+        cy.contains('Variable updated').should('be.visible');
+        cy.getElementByTestId('variableEditorPanel').should('not.exist');
+        cy.getElementByTestId('variable-env').should('be.visible');
+
+        // Add a new option
+        openEditForVariable('env');
+        cy.getElementByTestId('variableEditorCustomValues')
+          .find('input')
+          .type('canary{enter}');
+        cy.getElementByTestId('variableEditorSave').click();
+        cy.contains('Variable updated').should('be.visible');
+        cy.getElementByTestId('variableEditorPanel').should('not.exist');
+
+        // Verify new option appears in dropdown
+        cy.getElementByTestId('variable-env')
+          .find(`[data-test-subj="${'variable-selector-button'}"]`)
+          .click();
+        cy.get('.euiSelectable').should('be.visible');
+        cy.contains('canary').should('be.visible');
+        cy.get('body').click(0, 0);
+      });
+
+      it('should hide and show variable from the bar', () => {
+        cy.getElementByTestId('manageVariablesButton').click();
+        cy.getElementByTestId('variableManagementPanel').should('be.visible');
+
+        // Hide 'env'
+        cy.getElementByTestId('variableManagementPanel')
+          .contains('env')
+          .closest('[class*="euiPanel"]')
+          .find('[aria-label="Hide variable"]')
+          .click();
+
+        cy.getElementByTestId('variableManagementPanel')
+          .contains('env')
+          .closest('[class*="euiPanel"]')
+          .contains('Hidden')
+          .should('be.visible');
+
+        cy.contains('button', 'Close').click();
+        cy.getElementByTestId('variable-env').should('not.exist');
+
+        // Show the variable again
+        cy.getElementByTestId('manageVariablesButton').click();
+        cy.getElementByTestId('variableManagementPanel')
+          .contains('env')
+          .closest('[class*="euiPanel"]')
+          .find('[aria-label="Show variable"]')
+          .click();
+        cy.contains('button', 'Close').click();
+        cy.getElementByTestId('variable-env').should('be.visible');
+      });
+    });
+
+    describe('Delete variable', () => {
+      it('should delete variables and remove them from the bar', () => {
+        deleteVariable('customer_gender');
+        cy.getElementByTestId('variable-customer_gender').should('not.exist');
+
+        deleteVariable('env');
+        cy.getElementByTestId('variable-env').should('not.exist');
+      });
+    });
+  });
+}

--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/dashboard-variable/variable_interact_with_query_editor.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/dashboard-variable/variable_interact_with_query_editor.spec.js
@@ -1,0 +1,217 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MiscUtils } from '@opensearch-dashboards-test/opensearch-dashboards-test-library';
+import { BASE_PATH } from '../../../../../utils/base_constants';
+import { enterEditMode } from '../../../../../utils/dashboards/dashboard_variable/helpers.js';
+
+const miscUtils = new MiscUtils(cy);
+const WORKSPACE_NAME = 'test_workspace_variable';
+const DASHBOARD_NAME = 'variable_crud_test_dashboard';
+const MDSEnabled = Cypress.env('DATASOURCE_MANAGEMENT_ENABLED');
+const EXPLORE_NAME = 'Explore With Variable';
+
+if (Cypress.env('WORKSPACE_ENABLED')) {
+  describe('Dashboard Variables Interaction', () => {
+    let workspaceId;
+    let datasourceId;
+    let dashboardId;
+
+    before(() => {
+      cy.deleteWorkspaceByName(WORKSPACE_NAME);
+
+      const createWorkspaceWithSampleData = (dsId) => {
+        cy.createWorkspace({
+          name: WORKSPACE_NAME,
+          features: ['use-case-observability'],
+          settings: {
+            permissions: {
+              library_write: { users: ['%me%'] },
+              write: { users: ['%me%'] },
+            },
+            ...(dsId ? { dataSources: [dsId] } : {}),
+          },
+        }).then((id) => {
+          workspaceId = id;
+          cy.loadSampleDataForWorkspace('flights', id, dsId);
+        });
+      };
+
+      if (MDSEnabled) {
+        cy.deleteAllDataSources();
+        cy.createDataSourceNoAuth().then((result) => {
+          datasourceId = result[0];
+          expect(datasourceId).to.be.a('string').that.is.not.empty;
+          createWorkspaceWithSampleData(datasourceId);
+        });
+      } else {
+        createWorkspaceWithSampleData();
+      }
+    });
+
+    after(() => {
+      if (workspaceId) {
+        cy.removeSampleDataForWorkspace('flights', workspaceId, datasourceId);
+        cy.deleteWorkspaceById(workspaceId);
+      }
+      if (MDSEnabled) {
+        cy.deleteAllDataSources();
+      }
+    });
+
+    before(() => {
+      const url = `${BASE_PATH}/w/${workspaceId}/api/saved_objects/dashboard`;
+
+      cy.request({
+        method: 'POST',
+        url,
+        headers: {
+          'content-type': 'application/json;charset=UTF-8',
+          'osd-xsrf': true,
+        },
+        body: JSON.stringify({
+          attributes: {
+            title: DASHBOARD_NAME,
+            description: 'Test dashboard for variable CRUD operations',
+            variablesJSON:
+              '{"variables":[{"current":["max"],"customOptions":["max","min","avg"],"id":"test-id","includeAll":false,"multi":false,"name":"function","type":"custom"}]}',
+          },
+        }),
+      }).then((response) => {
+        expect(response.status).to.equal(200);
+        dashboardId = response.body.id;
+        cy.log(`Dashboard created with ID: ${dashboardId}`);
+      });
+    });
+
+    beforeEach(() => {
+      miscUtils.visitPage(
+        `w/${workspaceId}/app/dashboards#/view/${dashboardId}`
+      );
+      cy.reload();
+      enterEditMode();
+    });
+    it('should interact with explore visualization in query editor page', () => {
+      cy.getElementByTestId('dashboardAddPanelButton')
+        .should('be.visible')
+        .click();
+      cy.getElementByTestId(
+        'embeddablePanelAction-add_vis_action_VisualizationEditor'
+      )
+        .should('be.visible')
+        .click();
+
+      cy.getElementByTestId('dashboardVariablesBar')
+        .should('exist')
+        .getElementByTestId('variable-function')
+        .should('be.visible');
+
+      // Verify current value is displayed
+      cy.getElementByTestId('variable-function')
+        .find('[data-test-subj="variable-selector-current"]')
+        .should('not.be.empty')
+        .and('contain', 'max');
+
+      cy.getElementByTestId('visEditorUninitialized')
+        .contains('Run a query to visualize your data')
+        .should('be.visible');
+
+      // Select dataset
+      cy.getElementByTestId('datasetSelectButton').click();
+      cy.contains('opensearch_dashboards_sample_data_flights').click();
+
+      // Input query in the editor
+      cy.getElementByTestId('exploreQueryPanelEditor')
+        .find('textarea')
+        .click({ force: true })
+        .focused()
+        .type('{esc}', { force: true })
+        .type(
+          'source=opensearch_dashboards_sample_data_flights| where `FlightDelay` = true | stats ${function}(`FlightDelayMin`) as ${function}_delay by `OriginWeather`, `DestWeather`',
+          { force: true, parseSpecialCharSequences: false }
+        );
+
+      cy.intercept('POST', '**/api/enhancements/search/ppl').as('pplSearch');
+
+      cy.getElementByTestId('exploreQueryExecutionButton').click();
+
+      cy.wait('@pplSearch').then((interception) => {
+        const query = interception.request.body.query.query;
+        expect(query).to.not.include('${function}');
+        expect(query).to.include('max(`FlightDelayMin`) as max_delay');
+      });
+
+      cy.getElementByTestId('saveVisualizationEditorButton').click();
+
+      cy.get('.euiModal').should('be.visible');
+      cy.getElementByTestId('saveVisModalTitle').should(
+        'contain',
+        'Save your visualization'
+      );
+
+      cy.get('input[placeholder="Enter save search name"]')
+        .should('be.visible')
+        .type(EXPLORE_NAME);
+
+      cy.getElementByTestId('saveVisandBackToDashboardConfirmButton')
+        .should('not.be.disabled')
+        .click();
+
+      cy.url({ timeout: 30000 }).should('include', '/app/dashboards#/view/');
+
+      cy.getElementByTestId('dashboardSaveMenuItem')
+        .should('be.visible')
+        .click();
+
+      cy.getElementByTestId('confirmSaveSavedObjectButton')
+        .should('be.visible')
+        .click();
+
+      cy.contains(`Dashboard '${DASHBOARD_NAME}' was saved`).should('be.exist');
+    });
+
+    it('should interact with explore visualization in dashboard page', () => {
+      cy.getElementByTestId('dashboardVariablesBar')
+        .should('exist')
+        .getElementByTestId('variable-function')
+        .should('be.visible');
+
+      cy.getElementByTestId('variable-function')
+        .find('[data-test-subj="variable-selector-current"]')
+        .should('not.be.empty')
+        .and('contain', 'max');
+
+      cy.getElementByTestId('dashboardPanel').should('be.visible');
+
+      cy.get('[data-test-subj="dashboardPanelTitle"]')
+        .first()
+        .should('be.visible')
+        .and('contain.text', EXPLORE_NAME);
+
+      cy.getElementByTestId('embeddedSavedExplore').should('be.visible');
+
+      cy.intercept('POST', '**/api/enhancements/search/ppl').as('pplSearch');
+
+      cy.getElementByTestId('variable-function')
+        .find('[data-test-subj="variable-selector-button"]')
+        .click();
+      cy.get('.euiSelectable')
+        .should('be.visible')
+        .contains('avg')
+        .should('be.visible')
+        .click();
+
+      cy.getElementByTestId('variable-function')
+        .find('[data-test-subj="variable-selector-current"]')
+        .should('contain', 'avg');
+
+      cy.wait('@pplSearch').then((interception) => {
+        const query = interception.request.body.query.query;
+        expect(query).to.not.include('${function}');
+        expect(query).to.include('avg(`FlightDelayMin`) as avg_delay');
+      });
+    });
+  });
+}

--- a/cypress/integration/plugins/alerting-dashboards-plugin/monitors_dashboard_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/monitors_dashboard_spec.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// Each spec runs in its own process via matrix strategy to prevent memory crashes
+
 import {
   ALERTING_INDEX,
   ALERTING_PLUGIN_NAME,

--- a/cypress/integration/plugins/dashboards-investigation/2_agentic_notebook.spec.js
+++ b/cypress/integration/plugins/dashboards-investigation/2_agentic_notebook.spec.js
@@ -112,6 +112,16 @@ describe('Agentic Notebook Investigation Tests', () => {
       name: workspaceName,
       description: 'Workspace for cypress testing',
       features: ['use-case-observability'],
+      settings: {
+        permissions: {
+          library_write: {
+            users: ['%me%'],
+          },
+          write: {
+            users: ['%me%'],
+          },
+        },
+      },
     }).then((wsId) => {
       workspaceId = wsId;
       cy.loadSampleDataForWorkspace('ecommerce', workspaceId);

--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -6,7 +6,9 @@
 import { BASE_PATH, TIMEOUT } from '../../../utils/constants';
 
 describe('Cypress', () => {
-  it('Visit edit page, update name and description', () => {
+  beforeEach(() => {
+    // Wait before visiting to allow index refresh after previous test's save
+    cy.wait(5000);
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
       waitForGetTenant: true,
     });
@@ -14,41 +16,25 @@ describe('Cypress', () => {
       'include',
       '/reports-dashboards'
     );
-
-    cy.wait(12500);
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
-    ).as('dashboard');
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/visualization`
-    ).as('visualization');
-
-    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
-      'search'
+    // Retry: if the list doesn't load, reload the page
+    cy.get('body').then(($body) => {
+      if ($body.find('#reportDefinitionDetailsLink').length === 0) {
+        cy.wait(5000);
+        cy.reload();
+      }
+    });
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
     );
+  });
 
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
-
+  it('Visit edit page, update name and description', () => {
     cy.get('#reportDefinitionDetailsLink').first().click({ force: true });
 
     cy.get('#editReportDefinitionButton').should('exist');
-
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
-
-    cy.wait(1000);
-    cy.wait('@dashboard');
-    cy.wait('@visualization');
-    cy.wait('@search');
-    cy.wait('@notebook');
 
     // update the report name
     cy.get('#reportSettingsName').type('{selectall}{backspace} update name');
@@ -63,56 +49,20 @@ describe('Cypress', () => {
       .trigger('mouseover')
       .click({ force: true });
 
-    cy.wait(12500);
-
     // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink').should('exist');
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
+    );
   });
 
   it('Visit edit page, change report trigger', () => {
-    cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
-      waitForGetTenant: true,
-    });
-    cy.location('pathname', { timeout: TIMEOUT }).should(
-      'include',
-      '/reports-dashboards'
-    );
-
-    cy.wait(12500);
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
-    ).as('dashboard');
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/visualization`
-    ).as('visualization');
-
-    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
-      'search'
-    );
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
-
     cy.get('#reportDefinitionDetailsLink').first().click();
 
     cy.get('#editReportDefinitionButton').should('exist');
-
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
 
-    cy.wait(1000);
-
-    cy.wait('@dashboard');
-    cy.wait('@visualization');
-    cy.wait('@search');
-    cy.wait('@notebook');
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(2)').click({
       force: true,
     });
@@ -123,56 +73,19 @@ describe('Cypress', () => {
       .trigger('mouseover')
       .click({ force: true });
 
-    cy.wait(12500);
-
     // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink').should('exist');
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
+    );
   });
 
   it('Visit edit page, change report trigger back', () => {
-    cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
-      waitForGetTenant: true,
-    });
-    cy.location('pathname', { timeout: TIMEOUT }).should(
-      'include',
-      '/reports-dashboards'
-    );
-
-    cy.wait(12500);
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
-    ).as('dashboard');
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/visualization`
-    ).as('visualization');
-
-    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
-      'search'
-    );
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
-
     cy.get('#reportDefinitionDetailsLink').first().click();
 
     cy.get('#editReportDefinitionButton').should('exist');
-
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
-
-    cy.wait(1000);
-
-    cy.wait('@dashboard');
-    cy.wait('@visualization');
-    cy.wait('@search');
-    cy.wait('@notebook');
 
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(1)').click({
       force: true,
@@ -183,9 +96,9 @@ describe('Cypress', () => {
       .trigger('mouseover')
       .click({ force: true });
 
-    cy.wait(12500);
-
     // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink').should('exist');
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
+    );
   });
 });

--- a/cypress/utils/dashboards/dashboard_variable/helpers.js
+++ b/cypress/utils/dashboards/dashboard_variable/helpers.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Enter edit mode on the currently open dashboard (idempotent).
+ */
+export const enterEditMode = () => {
+  // Wait for the dashboard to be fully loaded
+  cy.getElementByTestId('dashboardEditSwitch', { timeout: 30000 }).should(
+    'be.visible'
+  );
+
+  // Check if already in edit mode
+  cy.getElementByTestId('dashboardEditSwitch').then(($switch) => {
+    const isEditMode = $switch.attr('aria-checked') === 'true';
+
+    // Only click if not already in edit mode
+    if (!isEditMode) {
+      cy.getElementByTestId('dashboardEditSwitch')
+        .should('not.be.disabled')
+        .click({ force: false });
+    }
+  });
+
+  // Verify we're in edit mode by checking for the save button
+  cy.getElementByTestId('dashboardSaveMenuItem', { timeout: 30000 }).should(
+    'be.visible'
+  );
+
+  cy.getElementByTestId('dashboardVariablesBar').should('be.visible');
+  cy.getElementByTestId('addVariableButton').should('be.visible');
+};
+
+export const openAddVariableEditor = () => {
+  cy.getElementByTestId('addVariableButton').click();
+  cy.getElementByTestId('variableEditorPanel').should('be.visible');
+  cy.getElementByTestId('variableEditorName').should('be.visible');
+  cy.getElementByTestId('variableEditorLabel').should('be.visible');
+  cy.getElementByTestId('variableEditorDescription').should('be.visible');
+  cy.getElementByTestId('variableEditorType').should('be.visible');
+  cy.getElementByTestId('variableEditorCancel').should('be.visible');
+};
+
+export const saveVariableEditor = () => {
+  cy.getElementByTestId('variableEditorSave').click();
+  cy.contains('Variable added').should('be.visible');
+  cy.getElementByTestId('variableEditorPanel').should('not.exist');
+};
+
+export const openEditForVariable = (varName) => {
+  cy.getElementByTestId('manageVariablesButton').click();
+  cy.getElementByTestId('variableManagementPanel').should('be.visible');
+  cy.getElementByTestId('variableManagementPanel')
+    .contains('strong', varName)
+    .closest('.euiDraggable')
+    .find('[aria-label="Edit variable"]')
+    .click();
+  cy.getElementByTestId('variableEditorPanel').should('be.visible');
+};
+
+export const deleteVariable = (varName) => {
+  cy.getElementByTestId('manageVariablesButton').click();
+  cy.getElementByTestId('variableManagementPanel').should('be.visible');
+  cy.getElementByTestId('variableManagementPanel')
+    .contains('strong', varName)
+    .closest('.euiDraggable')
+    .find('[aria-label="Delete variable"]')
+    .click();
+  cy.get('.euiModal, .euiConfirmModal').should('be.visible');
+  cy.contains('button', 'Delete').click();
+  cy.contains('Variable deleted').click();
+  cy.get('.euiModal, .euiConfirmModal').should('not.exist');
+};


### PR DESCRIPTION
## Summary
- Backports 3 commits from `main` that were missing on the `3.7` branch:
  - `a6897ab` [Variable] add dashboard variable functional test (#2004)
  - `2468b7e` fix(test): replace hardcoded waits with API intercepts in edit tests (#2019)
  - `c9c646e` fix(alerting): add matrix strategy for alerting cypress tests (#2027)
  - [fix: add permissions entry for agentic notebook test cases (](https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/2028/commits/14d016d24ee979f6d056a070c12d133e2e35c6b1)https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/2022
[14d016d](https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/2028/commits/14d016d24ee979f6d056a070c12d133e2e35c6b1)

https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/2022)

## Test plan
- [ ] Verify CI passes on the 3.7 branch with these changes
- [ ] Confirm no merge conflicts with existing 3.7 code