### PR TITLE
fix(test): replace hardcoded waits with visitReportingLandingPage in …

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -3,43 +3,39 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BASE_PATH, TIMEOUT } from '../../../utils/constants';
+import {
+  BASE_PATH,
+  TIMEOUT,
+  WAIT_TIME,
+  visitReportingLandingPage,
+} from '../../../utils/constants';
 
 describe('Cypress', () => {
-  it('Visit edit page, update name and description', () => {
-    cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
-      waitForGetTenant: true,
-    });
-    cy.location('pathname', { timeout: TIMEOUT }).should(
-      'include',
-      '/reports-dashboards'
-    );
-
-    cy.wait(12500);
-
+  beforeEach(() => {
     cy.intercept(
       'GET',
       `${BASE_PATH}/api/reporting/getReportSource/dashboard`
     ).as('dashboard');
-
     cy.intercept(
       'GET',
       `${BASE_PATH}/api/reporting/getReportSource/visualization`
     ).as('visualization');
-
     cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
       'search'
     );
-
     cy.intercept(
       'GET',
       `${BASE_PATH}/api/observability/notebooks/savedNotebook`
     ).as('notebook');
+  });
+
+  it('Visit edit page, update name and description', () => {
+    visitReportingLandingPage();
+    cy.wait(WAIT_TIME);
 
     cy.get('#reportDefinitionDetailsLink').first().click({ force: true });
 
     cy.get('#editReportDefinitionButton').should('exist');
-
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
@@ -63,56 +59,28 @@ describe('Cypress', () => {
       .trigger('mouseover')
       .click({ force: true });
 
-    cy.wait(12500);
-
-    // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink').should('exist');
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
+    );
   });
 
   it('Visit edit page, change report trigger', () => {
-    cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
-      waitForGetTenant: true,
-    });
-    cy.location('pathname', { timeout: TIMEOUT }).should(
-      'include',
-      '/reports-dashboards'
-    );
-
-    cy.wait(12500);
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
-    ).as('dashboard');
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/visualization`
-    ).as('visualization');
-
-    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
-      'search'
-    );
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
+    visitReportingLandingPage();
+    cy.wait(WAIT_TIME);
 
     cy.get('#reportDefinitionDetailsLink').first().click();
 
     cy.get('#editReportDefinitionButton').should('exist');
-
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
 
     cy.wait(1000);
-
     cy.wait('@dashboard');
     cy.wait('@visualization');
     cy.wait('@search');
     cy.wait('@notebook');
+
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(2)').click({
       force: true,
     });
@@ -123,52 +91,23 @@ describe('Cypress', () => {
       .trigger('mouseover')
       .click({ force: true });
 
-    cy.wait(12500);
-
-    // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink').should('exist');
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
+    );
   });
 
   it('Visit edit page, change report trigger back', () => {
-    cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
-      waitForGetTenant: true,
-    });
-    cy.location('pathname', { timeout: TIMEOUT }).should(
-      'include',
-      '/reports-dashboards'
-    );
-
-    cy.wait(12500);
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/dashboard`
-    ).as('dashboard');
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/reporting/getReportSource/visualization`
-    ).as('visualization');
-
-    cy.intercept('GET', `${BASE_PATH}/api/reporting/getReportSource/search`).as(
-      'search'
-    );
-
-    cy.intercept(
-      'GET',
-      `${BASE_PATH}/api/observability/notebooks/savedNotebook`
-    ).as('notebook');
+    visitReportingLandingPage();
+    cy.wait(WAIT_TIME);
 
     cy.get('#reportDefinitionDetailsLink').first().click();
 
     cy.get('#editReportDefinitionButton').should('exist');
-
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
 
     cy.wait(1000);
-
     cy.wait('@dashboard');
     cy.wait('@visualization');
     cy.wait('@search');
@@ -183,9 +122,8 @@ describe('Cypress', () => {
       .trigger('mouseover')
       .click({ force: true });
 
-    cy.wait(12500);
-
-    // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink').should('exist');
+    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
+      'exist'
+    );
   });
 });


### PR DESCRIPTION
…edit tests

Use the same proven pattern as 03-details.spec.js: visitReportingLandingPage()
+ cy.wait(WAIT_TIME) to ensure the reporting list page is fully loaded before interacting with report definitions. This fixes flaky failures where #reportDefinitionDetailsLink was not found due to index refresh delays.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
