### PR TITLE
fix(test): select file format radio in reporting edit tests

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -44,6 +44,9 @@ describe('Cypress', () => {
       '{selectall}{backspace} update description'
     );
 
+    // ensure file format is selected (radio may not be pre-populated on edit)
+    cy.get('#csv').check({ force: true });
+
     cy.get('#editReportDefinitionButton')
       .contains('Save Changes')
       .trigger('mouseover')
@@ -62,6 +65,9 @@ describe('Cypress', () => {
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
+
+    // ensure file format is selected
+    cy.get('#csv').check({ force: true });
 
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(2)').click({
       force: true,
@@ -86,6 +92,9 @@ describe('Cypress', () => {
     cy.get('#editReportDefinitionButton').click();
 
     cy.url().should('include', 'edit');
+
+    // ensure file format is selected
+    cy.get('#csv').check({ force: true });
 
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(1)').click({
       force: true,


### PR DESCRIPTION


### Description

The edit form does not pre-populate the file format radio for saved search reports, causing the save to fail with 400. Explicitly select the CSV radio before saving in all three edit test cases.


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
