### PR TITLE
Fix reload in ISM cypress tests

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -31,6 +31,7 @@ describe('Aliases', () => {
   beforeEach(() => {
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/aliases`);
+    cy.reload(true);
 
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Rows per page', { timeout: 60000 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/data_streams.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/data_streams.js
@@ -37,6 +37,7 @@ describe('Data stream', () => {
   beforeEach(() => {
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/data-streams`);
+    cy.reload(true);
 
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Data streams', { timeout: 60000 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/indices_spec.js
@@ -20,6 +20,7 @@ describe('Indices', () => {
 
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/indices`);
+    cy.reload(true);
 
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Rows per page', { timeout: 60000 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/managed_indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/managed_indices_spec.js
@@ -25,6 +25,7 @@ describe('Managed indices', () => {
 
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/managed-indices`);
+    cy.reload(true);
 
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Edit rollover alias', { timeout: 60000 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/policies_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/policies_spec.js
@@ -15,6 +15,7 @@ describe('Policies', () => {
 
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}`);
+    cy.reload(true);
 
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Create policy', { timeout: 60000 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/reindex_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/reindex_spec.js
@@ -15,6 +15,7 @@ describe('Reindex', () => {
 
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/indices`);
+    cy.reload(true);
 
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Rows per page', { timeout: 60000 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/split_index.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/split_index.js
@@ -18,6 +18,7 @@ describe('Split Index', () => {
     beforeEach(() => {
       // Visit ISM OSD
       cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/indices`);
+      cy.reload(true);
       cy.contains('Rows per page', { timeout: 60000 });
     });
 

--- a/cypress/integration/plugins/index-management-dashboards-plugin/template_components.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/template_components.js
@@ -41,6 +41,7 @@ describe('Component templates', () => {
   beforeEach(() => {
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/composable-templates`);
+    cy.reload(true);
 
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Rows per page', { timeout: 60000 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/templates.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/templates.js
@@ -31,6 +31,7 @@ describe('Templates', () => {
   beforeEach(() => {
     // Visit ISM OSD
     cy.visit(`${BASE_PATH}/app/${IM_PLUGIN_NAME}#/templates`);
+    cy.reload(true);
 
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Rows per page', { timeout: 60000 });


### PR DESCRIPTION
### Description

ISM tests were failing due to improper reload before each test. This fix forces reload which allows tests to proceed as usual.

### Issues Resolved

https://github.com/opensearch-project/index-management-dashboards-plugin/issues/1426

### Check List

- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
