### PR TITLE
Fix Cypress detached menu item queries

### DIFF
--- a/cypress/utils/dashboards/vis-augmenter/commands.js
+++ b/cypress/utils/dashboards/vis-augmenter/commands.js
@@ -9,26 +9,22 @@ Cypress.Commands.add('getVisPanelByTitle', (title) =>
   cy.get(`[data-title="${title}"]`).parents('.embPanel').should('be.visible')
 );
 
-Cypress.Commands.add('openVisContextMenu', { prevSubject: true }, (panel) =>
-  cy
-    .wrap(panel)
+Cypress.Commands.add('openVisContextMenu', { prevSubject: true }, (panel) => {
+  cy.wrap(panel)
     .find(`[data-test-subj="embeddablePanelContextMenuClosed"]`)
-    .click()
-    .then(() => cy.get('.euiContextMenu'))
-);
+    .click();
+
+  return cy.get('.euiContextMenu');
+});
 
 Cypress.Commands.add(
   'clickVisPanelMenuItem',
   { prevSubject: 'optional' },
-  (menu, text) =>
-    (menu ? cy.wrap(menu) : cy.get('.euiContextMenu'))
-      .find('button')
-      .contains(text)
-      .click()
+  (_menu, text) => cy.get('.euiContextMenu button').contains(text).click()
 );
 
-Cypress.Commands.add('getMenuItems', { prevSubject: 'optional' }, (menu) =>
-  (menu ? cy.wrap(menu) : cy.get('.euiContextMenu')).find('button')
+Cypress.Commands.add('getMenuItems', { prevSubject: 'optional' }, () =>
+  cy.get('.euiContextMenu button')
 );
 
 Cypress.Commands.add('visitDashboard', (dashboardName) => {


### PR DESCRIPTION
### Description

fixed failing test:
  1) View anomaly events in flyout
       Action does not exist if there are no VisLayers for a visualization:
     CypressError: Timed out retrying after 60050ms: `cy.find()` failed because the page updated as a result of this command, but you tried to continue the command chain. The subject is no longer attached to the DOM, and Cypress cannot requery the page after commands such as `cy.find()`.


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
