### PR TITLE
[3.7] Wait for profiler output before clicking Visualize in 6_profiler_spec

### DIFF
--- a/cypress/integration/plugins/query-insights-dashboards/6_profiler_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/6_profiler_spec.js
@@ -139,10 +139,18 @@ describe('Query Profiler', () => {
     cy.get('.ace_content').last().invoke('text').should('include', 'Error');
   });
 
+  // The output editor mirrors `output` state via a useEffect, and `handleVisualize` is a
+  // useCallback memoized on `output`. cy.wait('@profilerQuery') resolves on response receipt
+  // — before React commits setOutput and rebinds the Visualize click handler. Waiting until
+  // the response body is visible in the output editor ensures the click sees the fresh closure.
+  const waitForProfilerOutput = () =>
+    cy.get('.ace_content').last().invoke('text').should('include', '"took"');
+
   it('Visualize renders profile results after query', () => {
     cy.intercept('POST', '**/api/profiler-proxy').as('profilerQuery');
     cy.get('.conApp__editorActionButton--success').first().click();
     cy.wait('@profilerQuery');
+    waitForProfilerOutput();
     cy.contains('Visualize profile').click();
     cy.contains('Profile Results').should('be.visible');
   });
@@ -151,6 +159,7 @@ describe('Query Profiler', () => {
     cy.intercept('POST', '**/api/profiler-proxy').as('profilerQuery');
     cy.get('.conApp__editorActionButton--success').first().click();
     cy.wait('@profilerQuery');
+    waitForProfilerOutput();
     cy.contains('Visualize profile').click();
     cy.contains('Profile Results').should('be.visible');
     cy.get('input[placeholder="Search shard"]').should('exist');
@@ -160,6 +169,7 @@ describe('Query Profiler', () => {
     cy.intercept('POST', '**/api/profiler-proxy').as('profilerQuery');
     cy.get('.conApp__editorActionButton--success').first().click();
     cy.wait('@profilerQuery');
+    waitForProfilerOutput();
     cy.contains('Visualize profile').click();
     cy.contains('Profile Results').should('be.visible');
     cy.contains('.euiTab', 'Search').should('be.visible');


### PR DESCRIPTION
### Description

Fixes intermittent failures in `6_profiler_spec.js` for the three tests that click "Visualize profile" after running a query:

- `Query Profiler > Visualize renders profile results after query`
- `Query Profiler > Shard table has search control after visualize`
- `Query Profiler > Query tree renders with Search and Aggregation tabs`

All three time out 60s on `cy.contains('Profile Results').should('be.visible')` after the Visualize click.

### Root cause

Race between Cypress's network-level resume and React's commit cycle:

- `Profiler.tsx` `executeQuery` does `await http.post(...)` then `setOutput(JSON.stringify(response, null, 2))`.
- `handleVisualize = useCallback(() => { if (!output.trim()) { setOutput('Error: No profile output…'); return; } …; setProfileData(parsed); }, [output])` — the click handler captures `output` at render time.
- `cy.wait('@profilerQuery')` resolves the moment the proxy sees the response, **before** React has committed `setOutput` and re-bound the memoized `useCallback`.
- The Visualize click fires against the stale closure, hits the early-return `if (!output.trim())`, sets the error message `'Error: No profile output to visualize. Run a query first.'`, and `setProfileData` is never called. `<h3>Profile Results</h3>` is gated on `profileData?.profile?.shards?.length > 0`, so it never renders.

This is confirmed by the failure-time Cypress screenshots from runs #8578 and #8581 — the output editor at the moment of timeout literally displays the string `Error: No profile output to visualize. Run a query first.`, the exact text written by the early-return branch in `handleVisualize`.

The race is bimodal — fast runners' event loops drain the gap between response receipt and React commit in well under a tick, so the click always lands on the fresh closure. Slow containerized Jenkins integ-test runners widen the gap past a tick and the click can land mid-race. Failing runs:
- https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test-opensearch-dashboards/detail/integ-test-opensearch-dashboards/8581/pipeline (linux/arm64/deb)
- https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test-opensearch-dashboards/detail/integ-test-opensearch-dashboards/8578/pipeline (linux/x64/deb)

### Fix

Between `cy.wait('@profilerQuery')` and the Visualize click, assert that the response body has actually flushed into the Ace output editor (`.ace_content` text contains `"took"`). This guarantees the `useEffect` mirroring `output` → editor has run, which in turn proves `setOutput` has committed and `handleVisualize` is bound to the fresh closure. Mirrors the existing wait pattern at line 78 of the same file.

### Issues Resolved

- https://github.com/opensearch-project/query-insights-dashboards/issues/506

### Check List

- [x] All tests pass
- [ ] New functionality includes testing
  - n/a (test-only fix)
- [ ] New functionality has been documented in the README if applicable
  - n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.