### PR TITLE
[Backport main] Update chromium flag when running on cpuonly servers

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -80,7 +80,9 @@ module.exports = defineConfig({
           launchOptions.args.push('--js-flags=--max-old-space-size=4096');
           launchOptions.args.push('--disable-gpu');
           launchOptions.args.push('--use-gl=swiftshader');
-          launchOptions.args.push('--disable-features=IsolateOrigins,site-per-process,Vulkan,VulkanFromANGLE,UseSkiaRenderer');
+          launchOptions.args.push(
+            '--disable-features=IsolateOrigins,site-per-process,Vulkan,VulkanFromANGLE,UseSkiaRenderer'
+          );
 
           launchOptions.args.push('--no-sandbox');
           launchOptions.args.push('--disable-dev-shm-usage');

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -75,24 +75,15 @@ module.exports = defineConfig({
     experimentalMemoryManagement: true,
     numTestsKeptInMemory: 0,
     setupNodeEvents(on, config) {
-      // Configure Chromium browser launch options for memory optimization
       on('before:browser:launch', (browser = {}, launchOptions) => {
         if (browser.family === 'chromium') {
           launchOptions.args.push('--js-flags=--max-old-space-size=4096');
-          launchOptions.args.push('--use-gl=disabled');
-          launchOptions.args.push('--use-angle=disabled');
           launchOptions.args.push('--disable-gpu');
-          launchOptions.args.push('--disable-software-rasterizer');
-          launchOptions.args.push('--disable-vulkan');
-          launchOptions.args.push('--disable-features=Vulkan,VulkanFromANGLE');
-          launchOptions.args.push('--disable-gpu-compositing');
-          launchOptions.args.push(
-            '--disable-features=IsolateOrigins,site-per-process,Vulkan,VulkanFromANGLE,UseSkiaRenderer'
-          );
+          launchOptions.args.push('--use-gl=swiftshader');
+          launchOptions.args.push('--disable-features=IsolateOrigins,site-per-process,Vulkan,VulkanFromANGLE,UseSkiaRenderer');
 
           launchOptions.args.push('--no-sandbox');
           launchOptions.args.push('--disable-dev-shm-usage');
-          launchOptions.args.push('--disable-setuid-sandbox');
 
           launchOptions.args.push('--disable-renderer-backgrounding');
           launchOptions.args.push('--disable-background-timer-throttling');


### PR DESCRIPTION
### Description

[Backport main] Update chromium flag when running on cpuonly servers

### Issues Resolved

Backport https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/2055

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
