### PR TITLE
[3.7] Upgrade cypress 13.17.0 zip binary pack on Windows

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -112,7 +112,7 @@ fi
 # And is not baked in images due to slow startup time
 # We are forcing the installation from opensearch ci bucket
 if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "win32" ]; then
-    CYPRESS_INSTALL_BINARY=https://ci.opensearch.org/ci/dbc/tools/Cypress-9.5.4-x64-windows.zip npm install cypress
+    CYPRESS_INSTALL_BINARY=https://ci.opensearch.org/ci/dbc/tools/Cypress-13.17.0-x64-windows.zip npm install cypress
 fi
 
 npm install


### PR DESCRIPTION
### Description

[3.7] Upgrade cypress 13.17.0 zip binary pack on Windows

### Issues Resolved

https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/3.7.0/8924/windows/x64/zip/test-results/8605/integ-test/assistantDashboards/with-security/stdout.txt

```
Found binary version 9.5.4 installed in: C:\Users\ContainerAdministrator\AppData\Local\Cypress\Cache\13.17.0\Cypress
```

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
