### PR TITLE
[Backport main] Upgrade cypress 13.17.0 zip binary pack on Windows (#2059)

### DIFF
--- a/integtest.sh
+++ b/integtest.sh
@@ -112,7 +112,7 @@ fi
 # And is not baked in images due to slow startup time
 # We are forcing the installation from opensearch ci bucket
 if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "win32" ]; then
-    CYPRESS_INSTALL_BINARY=https://ci.opensearch.org/ci/dbc/tools/Cypress-9.5.4-x64-windows.zip npm install cypress
+    CYPRESS_INSTALL_BINARY=https://ci.opensearch.org/ci/dbc/tools/Cypress-13.17.0-x64-windows.zip npm install cypress
 fi
 
 npm install


### PR DESCRIPTION
### Description

[Backport main] Upgrade cypress 13.17.0 zip binary pack on Windows (#2059)

### Issues Resolved

Backport https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/2059

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
