### PR TITLE
Fix flaky query-insights cypress tests on Windows

### DIFF
--- a/cypress/integration/plugins/query-insights-dashboards/1_top_queries_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/1_top_queries_spec.js
@@ -390,8 +390,11 @@ describe('Query Insights — Dynamic Columns (QUERY ONLY fixture)', () => {
       'WLM Group',
       'Total Shards',
     ];
-    getHeaders().should('deep.equal', expected);
+    // assertRowCountEquals uses .should('have.length', N) which retries until items
+    // has populated; once row count matches, columnsToShow has evaluated against the
+    // populated data and headers are stable for the deep-equal assertion.
     assertRowCountEquals(getRowsFromRaw(QUERY_ONLY).length);
+    getHeaders().should('deep.equal', expected);
   });
 });
 
@@ -418,8 +421,11 @@ describe('Query Insights — Dynamic Columns (GROUP ONLY fixture)', () => {
       'Average CPU Time',
       'Average Memory Usage',
     ];
-    getHeaders().should('deep.equal', expected);
+    // assertRowCountEquals uses .should('have.length', N) which retries until items
+    // has populated; once row count matches, columnsToShow has evaluated against the
+    // populated data and headers are stable for the deep-equal assertion.
     assertRowCountEquals(getRowsFromRaw(GROUP_ONLY).length);
+    getHeaders().should('deep.equal', expected);
   });
 
   it('renders dash in status column for group rows', () => {
@@ -439,7 +445,16 @@ describe('Query Insights — Stats & Visualizations Panel', () => {
     // Force reload because testIsolation is disabled in this repo's cypress.config —
     // without it, cy.visit() to the same URL is a no-op and the intercepted request never fires.
     cy.reload();
+    // The page fires three GETs (latency, cpu, memory) and only flips loading=false
+    // after all three resolve. Wait for all three plus the table to render so the
+    // visualizations panel is stable and React state has settled.
     cy.wait('@topQueries', { timeout: 60000 });
+    cy.wait('@topQueries', { timeout: 60000 });
+    cy.wait('@topQueries', { timeout: 60000 });
+    cy.get('.euiBasicTable', { timeout: 30000 })
+      .last()
+      .find('.euiTableRow')
+      .should('have.length.greaterThan', 0);
   });
 
   it('displays visualizations panel with Query/Group toggle', () => {
@@ -637,7 +652,19 @@ describe('Query Insights — DynamicSearchBar', () => {
     // Force reload because testIsolation is disabled in this repo's cypress.config —
     // without it, cy.visit() to the same URL is a no-op and the intercepted request never fires.
     cy.reload();
+    // The page fires three GETs (latency, cpu, memory) and only flips loading=false
+    // after all three resolve. The DynamicSearchBar is conditionally rendered on
+    // `!loading`, so wait for all three plus the table to render before any test
+    // interacts with the search input — otherwise the input may be detached/re-mounted
+    // between Cypress commands, surfacing as a misleading 'disabled element' error.
     cy.wait('@topQueries', { timeout: 60000 });
+    cy.wait('@topQueries', { timeout: 60000 });
+    cy.wait('@topQueries', { timeout: 60000 });
+    cy.get('.euiBasicTable', { timeout: 30000 })
+      .last()
+      .find('.euiTableRow')
+      .should('have.length.greaterThan', 0);
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).should('be.visible');
   });
 
   it('renders the search bar with correct placeholder', () => {

--- a/cypress/integration/plugins/query-insights-dashboards/5_live_queries_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/5_live_queries_spec.js
@@ -19,6 +19,21 @@ describe('Inflight Queries Dashboard', () => {
     // never fires for subsequent tests.
     cy.reload();
     cy.wait('@getLiveQueries', { timeout: 60000 });
+
+    // Disable auto-refresh to keep the DOM stable across assertions. Without this,
+    // every refreshInterval (default 5s) the table re-renders, detaching row and
+    // pagination handles mid-test (root cause of the pagination 'detached from DOM'
+    // and WLM-disabled content-match failures).
+    cy.get('[data-test-subj="live-queries-autorefresh-toggle"]').then(($t) => {
+      if ($t.attr('aria-checked') === 'true') {
+        cy.wrap($t).click();
+      }
+    });
+    cy.get('[data-test-subj="live-queries-autorefresh-toggle"]').should(
+      'have.attr',
+      'aria-checked',
+      'false'
+    );
   });
 
   it('displays the correct page title', () => {
@@ -110,9 +125,15 @@ describe('Inflight Queries Dashboard', () => {
   });
 
   it('navigates to next page in table pagination', () => {
-    cy.wait('@getLiveQueries');
     cy.get('.euiPagination').should('be.visible');
-    cy.get('.euiPagination__item').contains('2').click();
+    cy.get('[data-test-subj="pagination-button-1"]')
+      .should('be.visible')
+      .click();
+    cy.get('[data-test-subj="pagination-button-1"]').should(
+      'have.attr',
+      'aria-current',
+      'true'
+    );
     cy.get('tbody tr').should('exist');
   });
 
@@ -152,6 +173,10 @@ describe('Inflight Queries Dashboard', () => {
     cy.get('[data-test-subj="live-queries-autorefresh-toggle"]').as('toggle');
     cy.get('[data-test-subj="live-queries-refresh-interval"]').as('dropdown');
 
+    // beforeEach already disabled auto-refresh; re-enable then toggle off so the
+    // observable transition to disabled is exercised.
+    cy.get('@toggle').click();
+    cy.get('@toggle').should('have.attr', 'aria-checked', 'true');
     cy.get('@toggle').click();
     cy.get('@toggle').should('have.attr', 'aria-checked', 'false');
     cy.get('@dropdown').should('be.disabled');
@@ -359,13 +384,11 @@ describe('Inflight Queries Dashboard', () => {
   });
 
   it('displays WLM group as text when WLM is disabled', () => {
-    cy.get('tbody tr')
-      .first()
-      .within(() => {
-        cy.get('td')
-          .contains('ANALYTICS_WORKLOAD_GROUP')
-          .should('not.have.attr', 'href');
-      });
+    // Use cy.contains(selector, text) which requeries on retry instead of latching
+    // onto a `tbody tr:first` handle that can go stale across React re-renders.
+    cy.contains('tbody td', 'ANALYTICS_WORKLOAD_GROUP', { timeout: 60000 })
+      .should('be.visible')
+      .and('not.have.attr', 'href');
   });
 });
 

--- a/cypress/integration/plugins/query-insights-dashboards/5_live_queries_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/5_live_queries_spec.js
@@ -126,9 +126,12 @@ describe('Inflight Queries Dashboard', () => {
 
   it('navigates to next page in table pagination', () => {
     cy.get('.euiPagination').should('be.visible');
-    cy.get('[data-test-subj="pagination-button-1"]')
-      .should('be.visible')
-      .click();
+    // Break chain and force the click — the EuiPagination button can briefly
+    // re-render between visibility check and click on slow CI; aliasing then
+    // forcing avoids the 'page updated while this command was executing' race.
+    cy.get('[data-test-subj="pagination-button-1"]').as('nextPage');
+    cy.get('@nextPage').should('be.visible');
+    cy.get('@nextPage').click({ force: true });
     cy.get('[data-test-subj="pagination-button-1"]').should(
       'have.attr',
       'aria-current',
@@ -221,6 +224,9 @@ describe('Inflight Queries Dashboard', () => {
     });
 
     cy.navigateToLiveQueries();
+    // Force reload — under testIsolation:false, cy.visit() to the same URL is a
+    // no-op, so the new intercept above never fires without an explicit reload.
+    cy.reload();
 
     cy.wait('@getPeriodicQueries');
     cy.wait('@getPeriodicQueries');
@@ -243,6 +249,9 @@ describe('Inflight Queries Dashboard', () => {
     }).as('getEmptyQueries');
 
     cy.navigateToLiveQueries();
+    // Force reload — under testIsolation:false, cy.visit() to the same URL is a
+    // no-op, so the new intercept above never fires without an explicit reload.
+    cy.reload();
     cy.wait('@getEmptyQueries');
     cy.get('[data-test-subj="panel-active-queries"]').within(() => {
       cy.contains('Active queries');
@@ -270,6 +279,9 @@ describe('Inflight Queries Dashboard', () => {
       }).as('getCancelledQuery');
 
       cy.navigateToLiveQueries();
+      // Force reload — under testIsolation:false, cy.visit() to the same URL is
+      // a no-op, so the new intercept above never fires without an explicit reload.
+      cy.reload();
       cy.wait('@getCancelledQuery');
 
       cy.contains(data.response.live_queries[0].id)


### PR DESCRIPTION
## Summary

Fix the persistent failures in the `queryInsightsDashboards` integ-test on Windows seen in builds [#8601](https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test-opensearch-dashboards/detail/integ-test-opensearch-dashboards/8601/pipeline/) and [#8605](https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test-opensearch-dashboards/detail/integ-test-opensearch-dashboards/8605/pipeline/) (autocut [#506](https://github.com/opensearch-project/query-insights-dashboards/issues/506)). The same tests pass on Linux ARM64 (build #8584) — the failures only reproduce on the Windows test agent, which is running cached Cypress 9.5.4 instead of the package-declared 13.17.0. The race conditions exposed by the slower Windows + older Cypress combination are real test-side bugs that this PR addresses with retry-friendly assertions.

### `1_top_queries_spec.js`

- **QUERY ONLY / GROUP ONLY header tests:** reorder `assertRowCountEquals(...)` BEFORE `getHeaders().should('deep.equal', ...)`. `assertRowCountEquals` uses `.should('have.length', N)` which retries until React state populates `items`; once row count matches, `columnsToShow` has evaluated against the populated data, so the deep-equal header assertion reads stable headers. Without this reorder, headers were read while `items.length === 0` → `defaultColumns` was rendered → header count mismatch.
- **Stats & Visualizations and DynamicSearchBar `beforeEach`:** the page fires three sequential GETs (`/api/top_queries/latency`, `/cpu`, `/memory`) and only flips `loading=false` after all three resolve. Wait for all three `@topQueries` plus the table to render so React state is settled and the conditionally-rendered `DynamicSearchBar` is stable before tests interact with it. This fixes the `'shows empty state when Group mode is selected'` DOM-detach failure and the 8 `cy.type` "disabled element" failures.

### `5_live_queries_spec.js`

- **`beforeEach`:** disable auto-refresh after the initial fetch so the inflight-queries table stops re-rendering every 5s. The auto-refresh `setInterval` was the root cause of the pagination "detached from DOM" error and the WLM-disabled "never did" content match.
- **Pagination test:** use the stable `[data-test-subj="pagination-button-1"]` selector (which appeared in the original failure log) instead of `.contains('2')`, and assert `aria-current="true"` to confirm the click took effect.
- **WLM-disabled-text test:** swap `cy.get('tbody tr').first().within(...)` for `cy.contains('tbody td', text)` which requeries the parent on every retry, surviving any incidental React reconciliation.
- **`'disables auto-refresh when toggled off'`:** since `beforeEach` now leaves auto-refresh off, this test re-enables it then toggles off so the observable transition to disabled is still exercised.

A companion PR with the equivalent change is open against the plugin repo to keep the cypress specs in sync. Plan to cherry-pick to `main` after merge.

## Test plan

- [ ] Re-run integ-test-opensearch-dashboards on a Windows distribution build with this branch and confirm queryInsightsDashboards passes on both with-security and without-security configs.
- [ ] Linux ARM64 / x64 integ-test still passes (no regressions).
- [ ] Existing `'disables auto-refresh when toggled off'` and the auto-refresh interval tests continue to behave correctly.