### PR TITLE
Fix filter_editor combo box assertion for Cypress 13

### DIFF
--- a/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/filter_editor.spec.js
+++ b/cypress/integration/core-opensearch-dashboards/opensearch-dashboards/apps/data_explorer/filter_editor.spec.js
@@ -54,11 +54,11 @@ describe('discover filter editor', () => {
       cy.get('[data-test-subj~="filter-key-extension.raw"]').click();
       cy.getElementByTestId('editFilter').click();
       cy.getElementByTestId('filterFieldSuggestionList').should(
-        'have.text',
+        'contain.text',
         'extension.raw'
       );
       cy.get('[data-test-subj~="filterParamsComboBox"]').should(
-        'have.text',
+        'contain.text',
         'jpg'
       );
       cy.getElementByTestId('cancelSaveFilter').click();


### PR DESCRIPTION
### Description

Fix `filter_editor.spec.js` test failure caused by Cypress 13 reading full accessible text from combo box elements.

The test asserts `have.text` expecting just `extension.raw`, but Cypress 13 now returns the full accessible text including aria labels:
```
extension.rawCombo box. Selected. extension.raw. Press Backspace to delete...
```

Changed to `contain.text` which correctly matches the visible value within the full text content.

### Issues Resolved

Unblocks 3.7.0 release - ci-group-8 nosec filter_editor failure.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).