### PR TITLE
[3.7] Update windows and linux to have different llm js startup/stop scripts

### DIFF
--- a/cypress/utils/plugins/dashboards-assistant/commands.js
+++ b/cypress/utils/plugins/dashboards-assistant/commands.js
@@ -274,10 +274,18 @@ Cypress.Commands.add('cleanProvisionedAgents', () => {
 Cypress.Commands.add('startDummyServer', () => {
   // Not a good practice to start a server inside Cypress https://docs.cypress.io/guides/references/best-practices#Web-Servers
   // But in out case, we need to reuse release e2e template and let's make it a tradeoff.
-  cy.exec(
-    "nohup yarn start-assistant-dummy-llm-server > /tmp/assistant-llm.log 2>&1 & sleep 1 && ps -ef | grep [a]ssistant-dummy-llm.js | head -n 1 | awk '{print $2}' > /tmp/assistant-llm.pid",
-    { timeout: 10000 }
-  );
+  const isWindows = Cypress.platform === 'win32';
+  if (isWindows) {
+    cy.exec(
+      'nohup yarn start-assistant-dummy-llm-server > /tmp/assistant-llm.log 2>&1 & echo $(cat /proc/$!/winpid) > /tmp/assistant-llm.winpid && sleep 1',
+      { timeout: 10000 }
+    );
+  } else {
+    cy.exec(
+      "nohup yarn start-assistant-dummy-llm-server > /tmp/assistant-llm.log 2>&1 & sleep 1 && ps -ef | grep [a]ssistant-dummy-llm.js | head -n 1 | awk '{print $2}' > /tmp/assistant-llm.pid",
+      { timeout: 10000 }
+    );
+  }
   // Wait for server to start and verify it's running
   cy.wait(3000);
   cy.exec(
@@ -291,9 +299,17 @@ Cypress.Commands.add('startDummyServer', () => {
 });
 
 Cypress.Commands.add('stopDummyServer', () => {
-  cy.exec('kill -9 $(cat /tmp/assistant-llm.pid) || true', {
-    failOnNonZeroExit: false,
-  });
+  const isWindows = Cypress.platform === 'win32';
+  if (isWindows) {
+    cy.exec(
+      'pid=$(cat /tmp/assistant-llm.winpid); while child=$(wmic process where "ParentProcessId=$pid" get ProcessId 2>/dev/null | tail -2 | head -1 | tr -d \' \\r\') && [ -n "$child" ]; do pid=$child; done; taskkill //F //PID $pid',
+      { failOnNonZeroExit: false }
+    );
+  } else {
+    cy.exec('kill -9 $(cat /tmp/assistant-llm.pid) || true', {
+      failOnNonZeroExit: false,
+    });
+  }
 });
 
 Cypress.Commands.add('sendAssistantMessage', (body, dataSourceId) => {

--- a/cypress/utils/plugins/dashboards-investigation/commands.js
+++ b/cypress/utils/plugins/dashboards-investigation/commands.js
@@ -310,15 +310,31 @@ Cypress.Commands.add('startInvestigationDummyServer', () => {
   //   failOnNonZeroExit: false,
   // });
   cy.wait(500);
-  cy.exec(
-    "nohup yarn start-investigation-dummy-llm-server > /tmp/investigation-llm.log 2>&1 & sleep 1 && ps -ef | grep [i]nvestigation-dummy-llm.js | head -n 1 | awk '{print $2}' > /tmp/investigation-llm.pid",
-    { timeout: 10000 }
-  );
+  const isWindows = Cypress.platform === 'win32';
+  if (isWindows) {
+    cy.exec(
+      'nohup yarn start-investigation-dummy-llm-server > /tmp/investigation-llm.log 2>&1 & echo $(cat /proc/$!/winpid) > /tmp/investigation-llm.winpid && sleep 1',
+      { timeout: 10000 }
+    );
+  } else {
+    cy.exec(
+      "nohup yarn start-investigation-dummy-llm-server > /tmp/investigation-llm.log 2>&1 & sleep 1 && ps -ef | grep [i]nvestigation-dummy-llm.js | head -n 1 | awk '{print $2}' > /tmp/investigation-llm.pid",
+      { timeout: 10000 }
+    );
+  }
   cy.wait(2000);
 });
 
 Cypress.Commands.add('stopInvestigationDummyServer', () => {
-  cy.exec('kill -9 $(cat /tmp/investigation-llm.pid) || true', {
-    failOnNonZeroExit: false,
-  });
+  const isWindows = Cypress.platform === 'win32';
+  if (isWindows) {
+    cy.exec(
+      'pid=$(cat /tmp/investigation-llm.winpid); while child=$(wmic process where "ParentProcessId=$pid" get ProcessId 2>/dev/null | tail -2 | head -1 | tr -d \' \\r\') && [ -n "$child" ]; do pid=$child; done; taskkill //F //PID $pid',
+      { failOnNonZeroExit: false }
+    );
+  } else {
+    cy.exec('kill -9 $(cat /tmp/investigation-llm.pid) || true', {
+      failOnNonZeroExit: false,
+    });
+  }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1949,9 +1949,10 @@
       }
     },
     "node_modules/@opensearch-dashboards-test/opensearch-dashboards-test-library": {
-      "version": "1.0.6",
-      "resolved": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.6.tar.gz",
-      "integrity": "sha512-vNO9ZlwfTucL2L2/YSEqLbSpT8ihrKUGApRDSkkIwq+kxg5OOwI+Gw+5En/I9tIrnC8IzGew9vc11Mvrm8M8cQ=="
+      "version": "1.0.7",
+      "resolved": "https://github.com/opensearch-project/opensearch-dashboards-test-library/archive/refs/tags/1.0.7.tar.gz",
+      "integrity": "sha512-poA3X8qgENvd0HOY5EAWMC9Q9fQsOPGjpO8gS38/SIAiQmmrLFJnSvIOjpOkyhGdfaVDpV1hOQYNsZdQcF4zXA==",
+      "license": "ISC"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",


### PR DESCRIPTION
### Description

[3.7] Update windows and linux to have different llm js startup/stop scripts

### Issues Resolved

https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/3.7.0/8924/windows/x64/zip/test-results/8615/integ-test/investigationDashboards/with-security/stdout.txt
https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/3.7.0/8924/windows/x64/zip/test-results/8615/integ-test/assistantDashboards/without-security/stdout.txt

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
