### PR TITLE
[3.7] Make sure certs files are used as files on Windows

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -39,6 +39,8 @@ module.exports = defineConfig({
     SAVED_OBJECTS_PERMISSION_ENABLED: false,
     DASHBOARDS_INVESTIGATION_ENABLED: true,
     DISABLE_LOCAL_CLUSTER: false,
+    SECURITY_CERT_PATH: 'cypress/resources/kirk.pem',
+    SECURITY_KEY_PATH: 'cypress/resources/kirk-key.pem',
     browserPermissions: {
       clipboard: 'allow',
     },

--- a/cypress/utils/plugins/dashboards-assistant/commands.js
+++ b/cypress/utils/plugins/dashboards-assistant/commands.js
@@ -217,9 +217,19 @@ Cypress.Commands.add('putAgentIdConfig', ({ type, agentName, agentId }) => {
     !Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')
   ) {
     // The .plugins-ml-config index is a system index and need to call the API by using certificate file
-    return cy.exec(
-      `curl -k --cert <(cat <<EOF \n${certPublicKeyContent}\nEOF\n) --key <(cat <<EOF\n${certPrivateKeyContent}\nEOF\n) -XPUT '${endpoint}'  -H 'Content-Type: application/json' -d '{"type":"os_chat_root_agent","configuration":{"agent_id":"${agentId}"}}'`
-    );
+    if (Cypress.platform === 'win32') {
+      return cy.exec(
+        `curl -k --cert "${Cypress.env(
+          'SECURITY_CERT_PATH'
+        )}" --key "${Cypress.env(
+          'SECURITY_KEY_PATH'
+        )}" -XPUT "${endpoint}" -H "Content-Type: application/json" -d "{\\"type\\":\\"os_chat_root_agent\\",\\"configuration\\":{\\"agent_id\\":\\"${agentId}\\"}}"`
+      );
+    } else {
+      return cy.exec(
+        `curl -k --cert <(cat <<EOF \n${certPublicKeyContent}\nEOF\n) --key <(cat <<EOF\n${certPrivateKeyContent}\nEOF\n) -XPUT '${endpoint}'  -H 'Content-Type: application/json' -d '{"type":"os_chat_root_agent","configuration":{"agent_id":"${agentId}"}}'`
+      );
+    }
   } else {
     return cy.request('PUT', endpoint, {
       type,
@@ -241,9 +251,19 @@ Cypress.Commands.add('deleteAgentConfig', ({ agentName }) => {
     !Cypress.env('DATASOURCE_MANAGEMENT_ENABLED')
   ) {
     // The .plugins-ml-config index is a system index and need to call the API by using certificate file
-    return cy.exec(
-      `curl -k --cert <(cat <<EOF \n${certPublicKeyContent}\nEOF\n) --key <(cat <<EOF\n${certPrivateKeyContent}\nEOF\n) -XDELETE '${endpoint}'  -H 'Content-Type: application/json'`
-    );
+    if (Cypress.platform === 'win32') {
+      return cy.exec(
+        `curl -k --cert "${Cypress.env(
+          'SECURITY_CERT_PATH'
+        )}" --key "${Cypress.env(
+          'SECURITY_KEY_PATH'
+        )}" -XDELETE "${endpoint}" -H "Content-Type: application/json"`
+      );
+    } else {
+      return cy.exec(
+        `curl -k --cert <(cat <<EOF \n${certPublicKeyContent}\nEOF\n) --key <(cat <<EOF\n${certPrivateKeyContent}\nEOF\n) -XDELETE '${endpoint}'  -H 'Content-Type: application/json'`
+      );
+    }
   } else {
     return cy.request('DELETE', endpoint);
   }
@@ -277,7 +297,7 @@ Cypress.Commands.add('startDummyServer', () => {
   const isWindows = Cypress.platform === 'win32';
   if (isWindows) {
     cy.exec(
-      'nohup yarn start-assistant-dummy-llm-server > /tmp/assistant-llm.log 2>&1 & echo $(cat /proc/$!/winpid) > /tmp/assistant-llm.winpid && sleep 1',
+      'bash -c "nohup yarn start-assistant-dummy-llm-server > /tmp/assistant-llm.log 2>&1 & echo $(cat /proc/$!/winpid) > /tmp/assistant-llm.winpid && sleep 1"',
       { timeout: 10000 }
     );
   } else {
@@ -302,7 +322,7 @@ Cypress.Commands.add('stopDummyServer', () => {
   const isWindows = Cypress.platform === 'win32';
   if (isWindows) {
     cy.exec(
-      'pid=$(cat /tmp/assistant-llm.winpid); while child=$(wmic process where "ParentProcessId=$pid" get ProcessId 2>/dev/null | tail -2 | head -1 | tr -d \' \\r\') && [ -n "$child" ]; do pid=$child; done; taskkill //F //PID $pid',
+      'bash -c "pid=$(cat /tmp/assistant-llm.winpid); while child=$(wmic process where \\"ParentProcessId=$pid\\" get ProcessId 2>/dev/null | tail -2 | head -1 | tr -d \' \\r\') && [ -n \\"$child\\" ]; do pid=$child; done; taskkill //F //PID $pid"',
       { failOnNonZeroExit: false }
     );
   } else {

--- a/cypress/utils/plugins/dashboards-investigation/commands.js
+++ b/cypress/utils/plugins/dashboards-investigation/commands.js
@@ -237,9 +237,19 @@ Cypress.Commands.add(
       agentName
     )}`;
     if (BACKEND_BASE_PATH.startsWith('https')) {
-      return cy.exec(
-        `curl -k --cert <(cat <<EOF \n${certPublicKeyContent}\nEOF\n) --key <(cat <<EOF\n${certPrivateKeyContent}\nEOF\n) -XPUT '${endpoint}'  -H 'Content-Type: application/json' -d '{"type":"${type}","configuration":{"agent_id":"${agentId}"}}'`
-      );
+      if (Cypress.platform === 'win32') {
+        return cy.exec(
+          `curl -k --cert "${Cypress.env(
+            'SECURITY_CERT_PATH'
+          )}" --key "${Cypress.env(
+            'SECURITY_KEY_PATH'
+          )}" -XPUT "${endpoint}" -H "Content-Type: application/json" -d "{\\"type\\":\\"${type}\\",\\"configuration\\":{\\"agent_id\\":\\"${agentId}\\"}}"`
+        );
+      } else {
+        return cy.exec(
+          `curl -k --cert <(cat <<EOF \n${certPublicKeyContent}\nEOF\n) --key <(cat <<EOF\n${certPrivateKeyContent}\nEOF\n) -XPUT '${endpoint}'  -H 'Content-Type: application/json' -d '{"type":"${type}","configuration":{"agent_id":"${agentId}"}}'`
+        );
+      }
     } else {
       return cy.request('PUT', endpoint, {
         type,
@@ -255,10 +265,21 @@ Cypress.Commands.add('deleteInvestigationAgentConfig', ({ agentName }) => {
     agentName
   )}`;
   if (BACKEND_BASE_PATH.startsWith('https')) {
-    return cy.exec(
-      `curl -k --cert <(cat <<EOF \n${certPublicKeyContent}\nEOF\n) --key <(cat <<EOF\n${certPrivateKeyContent}\nEOF\n) -XDELETE '${endpoint}'  -H 'Content-Type: application/json'`,
-      { failOnNonZeroExit: false }
-    );
+    if (Cypress.platform === 'win32') {
+      return cy.exec(
+        `curl -k --cert "${Cypress.env(
+          'SECURITY_CERT_PATH'
+        )}" --key "${Cypress.env(
+          'SECURITY_KEY_PATH'
+        )}" -XDELETE "${endpoint}" -H "Content-Type: application/json"`,
+        { failOnNonZeroExit: false }
+      );
+    } else {
+      return cy.exec(
+        `curl -k --cert <(cat <<EOF \n${certPublicKeyContent}\nEOF\n) --key <(cat <<EOF\n${certPrivateKeyContent}\nEOF\n) -XDELETE '${endpoint}'  -H 'Content-Type: application/json'`,
+        { failOnNonZeroExit: false }
+      );
+    }
   } else {
     return cy.request({
       method: 'DELETE',
@@ -313,7 +334,7 @@ Cypress.Commands.add('startInvestigationDummyServer', () => {
   const isWindows = Cypress.platform === 'win32';
   if (isWindows) {
     cy.exec(
-      'nohup yarn start-investigation-dummy-llm-server > /tmp/investigation-llm.log 2>&1 & echo $(cat /proc/$!/winpid) > /tmp/investigation-llm.winpid && sleep 1',
+      'bash -c "nohup yarn start-investigation-dummy-llm-server > /tmp/investigation-llm.log 2>&1 & echo $(cat /proc/$!/winpid) > /tmp/investigation-llm.winpid && sleep 1"',
       { timeout: 10000 }
     );
   } else {
@@ -329,7 +350,7 @@ Cypress.Commands.add('stopInvestigationDummyServer', () => {
   const isWindows = Cypress.platform === 'win32';
   if (isWindows) {
     cy.exec(
-      'pid=$(cat /tmp/investigation-llm.winpid); while child=$(wmic process where "ParentProcessId=$pid" get ProcessId 2>/dev/null | tail -2 | head -1 | tr -d \' \\r\') && [ -n "$child" ]; do pid=$child; done; taskkill //F //PID $pid',
+      'bash -c "pid=$(cat /tmp/investigation-llm.winpid); while child=$(wmic process where \\"ParentProcessId=$pid\\" get ProcessId 2>/dev/null | tail -2 | head -1 | tr -d \' \\r\') && [ -n \\"$child\\" ]; do pid=$child; done; taskkill //F //PID $pid"',
       { failOnNonZeroExit: false }
     );
   } else {

--- a/integtest.sh
+++ b/integtest.sh
@@ -2,6 +2,19 @@
 
 set -e
 
+DIR="$(dirname "$0")"
+pwd && cd $DIR
+
+# Handle keys properly with path set for assistantDashboards and investigationDashboards
+if [ "$OSTYPE" = "msys" ] || [ "$OSTYPE" = "cygwin" ] || [ "$OSTYPE" = "win32" ]; then
+  PATH="$(cygpath -w "$HOME/scoop/shims"):$PATH"
+  export CYPRESS_SECURITY_CERT_PATH="$(cygpath -w "$(pwd)/cypress/resources/kirk.pem")"
+  export CYPRESS_SECURITY_KEY_PATH="$(cygpath -w "$(pwd)/cypress/resources/kirk-key.pem")"
+else
+  export CYPRESS_SECURITY_CERT_PATH="$(pwd)/cypress/resources/kirk.pem"
+  export CYPRESS_SECURITY_KEY_PATH="$(pwd)/cypress/resources/kirk-key.pem"
+fi
+
 . ./browser_downloader.sh
 
 function usage() {


### PR DESCRIPTION
### Description

[3.7] Make sure certs files are used as files on Windows

mingw curl and libssl curl are very different in handling certs

```
$ curl --version
curl 8.10.1 (x86_64-w64-mingw32) libcurl/8.10.1 Schannel zlib/1.3.1 brotli/1.1.0 zstd/1.5.6 libidn2/2.3
.7 libpsl/0.21.5 libssh2/1.11.0
Release-Date: 2024-09-18
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns ldap ldaps mqtt pop3 pop3s
 rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli HSTS HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM PSL SPNEGO SS
L SSPI threadsafe UnixSockets zstd

ContainerAdministrator@48b77a15887b MINGW64 ~/scoop/shims
$ ./curl.exe --version
curl 8.15.0 (x86_64-w64-mingw32) libcurl/8.15.0 LibreSSL/4.1.0 zlib/1.3.1.zlib-ng brotli/1.1.0 zstd/1.5
.7 WinIDN libpsl/0.21.5 libssh2/1.11.1 nghttp2/1.66.0 ngtcp2/1.14.0 nghttp3/1.11.0
Release-Date: 2025-07-16
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns ldap ldaps mqtt pop3 pop3s
 rtsp scp sftp smb smbs smtp smtps telnet tftp ws wss
Features: alt-svc AsynchDNS brotli CAcert HSTS HTTP2 HTTP3 HTTPS-proxy IDN IPv6 Kerberos Largefile libz
 NTLM PSL SPNEGO SSL SSLS-EXPORT SSPI threadsafe UnixSockets zstd
```

```
curl: (58) schannel: Failed to import cert file
```

Schannel (Windows native TLS): Uses the Windows certificate store and only accepts PKCS#12 (.pfx/.p12) files for client certificates. PEM files are not supported because Windows' crypto APIs don't parse that format.

LibreSSL/OpenSSL (cross-platform TLS): Reads PEM files directly — this is the standard format for certificates and private keys on Linux/macOS and what most tools (including OpenSearch security plugin) generate by default.

### Issues Resolved

https://ci.opensearch.org/ci/dbc/integ-test-opensearch-dashboards/3.7.0/8924/windows/x64/zip/test-results/8615/integ-test/assistantDashboards/with-security/stdout.txt

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
