### PR TITLE
feat: add windows platform test for assistant / investigation plugin

### DIFF
--- a/.github/workflows/assistant-release-e2e-workflow.yml
+++ b/.github/workflows/assistant-release-e2e-workflow.yml
@@ -83,3 +83,4 @@ jobs:
       osd-serve-args: --assistant.chat.enabled=true --home.disableExperienceModal=true --home.disableWelcomeScreen=true
       security-enabled: false
       artifact-name-suffix: '-windows-without-security'
+      multi-opensearch-enabled: false

--- a/.github/workflows/assistant-release-e2e-workflow.yml
+++ b/.github/workflows/assistant-release-e2e-workflow.yml
@@ -27,6 +27,7 @@ jobs:
       test-command: env CYPRESS_DASHBOARDS_ASSISTANT_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/dashboards-assistant/*chatbot*.js'
       osd-serve-args: --assistant.chat.enabled=true --home.disableExperienceModal=true --home.disableWelcomeScreen=true
       artifact-name-suffix: '-linux-with-security'
+      multi-opensearch-enabled: false
 
   tests-without-security-linux:
     needs: changes
@@ -72,6 +73,7 @@ jobs:
       osd-serve-args: --assistant.chat.enabled=true --home.disableExperienceModal=true --home.disableWelcomeScreen=true
       security-enabled: true
       artifact-name-suffix: '-windows-with-security'
+      multi-opensearch-enabled: false
 
   tests-without-security-windows:
     needs: changes

--- a/.github/workflows/assistant-release-e2e-workflow.yml
+++ b/.github/workflows/assistant-release-e2e-workflow.yml
@@ -16,8 +16,9 @@ jobs:
               - 'cypress/**/dashboards-assistant/**'
               - 'cypress/support/assistant-dummy-llm.js'
               - '.github/workflows/release-e2e-workflow-template.yml'
+              - '.github/workflows/release-e2e-workflow-template-windows.yml'
 
-  tests-with-security:
+  tests-with-security-linux:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
@@ -25,9 +26,9 @@ jobs:
       test-name: dashboards assistant
       test-command: env CYPRESS_DASHBOARDS_ASSISTANT_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/dashboards-assistant/*chatbot*.js'
       osd-serve-args: --assistant.chat.enabled=true --home.disableExperienceModal=true --home.disableWelcomeScreen=true
-      artifact-name-suffix: '-with-security'
+      artifact-name-suffix: '-linux-with-security'
 
-  tests-without-security:
+  tests-without-security-linux:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
@@ -36,10 +37,10 @@ jobs:
       test-command: env CYPRESS_DASHBOARDS_ASSISTANT_ENABLED=true yarn cypress:run-without-security --browser chromium --spec 'cypress/integration/plugins/dashboards-assistant/*chatbot*.js'
       osd-serve-args: --assistant.chat.enabled=true --home.disableExperienceModal=true --home.disableWelcomeScreen=true
       security-enabled: false
-      artifact-name-suffix: '-without-security'
+      artifact-name-suffix: '-linux-without-security'
       multi-opensearch-enabled: false
 
-  tests-with-multiple-data-source-and-disabled-local-cluster:
+  tests-with-multiple-data-source-and-disabled-local-cluster-linux:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
@@ -48,9 +49,9 @@ jobs:
       test-command: env CYPRESS_DISABLE_LOCAL_CLUSTER=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true CYPRESS_DASHBOARDS_ASSISTANT_ENABLED=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/dashboards-assistant/mds_chatbot*.js'
       osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --data_source.hideLocalCluster=true --assistant.chat.enabled=true --home.disableExperienceModal=true --home.disableWelcomeScreen=true
       security-enabled: true
-      artifact-name-suffix: '-with-security-and-mds'
+      artifact-name-suffix: '-linux-with-security-and-mds'
 
-  tests-with-query-enhancements:
+  tests-with-query-enhancements-linux:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
@@ -59,4 +60,26 @@ jobs:
       test-command: env CYPRESS_DISABLE_LOCAL_CLUSTER=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true CYPRESS_DASHBOARDS_ASSISTANT_ENABLED=true CYPRESS_WORKSPACE_ENABLED=true CYPRESS_SKIP_HEAVY_DISCOVER_TESTS=true yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/dashboards-assistant/mds_query_enhancements*.js'
       osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --data_source.hideLocalCluster=true --assistant.chat.enabled=true --assistant.alertInsight.enabled=true --assistant.smartAnomalyDetector.enabled=true --queryEnhancements.queryAssist.summary.enabled=true --uiSettings.overrides.home:useNewHomePage=true --uiSettings.overrides.query:enhancements:enabled=true --workspace.enabled=true --savedObjects.permission.enabled=true --assistant.text2viz.enabled=true  --opensearchDashboards.dashboardAdmin.users='["admin"]' --opensearch_security.multitenancy.enabled=false --home.disableExperienceModal=true --home.disableWelcomeScreen=true
       security-enabled: true
-      artifact-name-suffix: '-with-query-enhancements'
+      artifact-name-suffix: '-linux-with-query-enhancements'
+
+  tests-with-security-windows:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template-windows.yml
+    with:
+      test-name: dashboards assistant
+      test-command: env CYPRESS_DASHBOARDS_ASSISTANT_ENABLED=true yarn cypress:run-with-security --browser chrome --spec 'cypress/integration/plugins/dashboards-assistant/*chatbot*.js'
+      osd-serve-args: --assistant.chat.enabled=true --home.disableExperienceModal=true --home.disableWelcomeScreen=true
+      security-enabled: true
+      artifact-name-suffix: '-windows-with-security'
+
+  tests-without-security-windows:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template-windows.yml
+    with:
+      test-name: dashboards assistant
+      test-command: env CYPRESS_DASHBOARDS_ASSISTANT_ENABLED=true yarn cypress:run-without-security --browser chrome --spec 'cypress/integration/plugins/dashboards-assistant/*chatbot*.js'
+      osd-serve-args: --assistant.chat.enabled=true --home.disableExperienceModal=true --home.disableWelcomeScreen=true
+      security-enabled: false
+      artifact-name-suffix: '-windows-without-security'

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-windows.yml
@@ -17,14 +17,12 @@ jobs:
     with:
       test-name: Core Dashboards using Bundle Snapshot
       test-command: env CYPRESS_NO_COMMAND_LOG=1 CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true CYPRESS_BANNER_ENABLED=true yarn cypress:run-with-security --browser chrome --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
-      # not useful now as the windows e2e template currently do not allow serving parameters
-      #osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
+      osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true --banner.enabled=true
 
   tests-without-security:
     uses: ./.github/workflows/release-e2e-workflow-template-windows.yml
     with:
       test-name: Core Dashboards using Bundle Snapshot
       test-command: env CYPRESS_NO_COMMAND_LOG=1 CYPRESS_VISBUILDER_ENABLED=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true CYPRESS_BANNER_ENABLED=true yarn cypress:run-without-security --browser chrome --spec 'cypress/integration/core-opensearch-dashboards/opensearch-dashboards/**/*.js'
-      # not useful now as the windows e2e template currently do not allow serving parameters
-      #osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true
+      osd-serve-args: --data_source.enabled=true --vis_builder.enabled=true --banner.enabled=true
       security-enabled: false

--- a/.github/workflows/investigation-release-e2e-workflow.yml
+++ b/.github/workflows/investigation-release-e2e-workflow.yml
@@ -28,6 +28,7 @@ jobs:
       osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --data_source.hideLocalCluster=true --investigation.enabled=true --investigation.agenticFeaturesEnabled=true --uiSettings.overrides.home:useNewHomePage=true --workspace.enabled=true --savedObjects.permission.enabled=true --opensearchDashboards.dashboardAdmin.users='["admin"]' --opensearch_security.multitenancy.enabled=false --explore.enabled=true
       security-enabled: true
       artifact-name-suffix: '-linux-with-workspace'
+      multi-opensearch-enabled: false
 
   tests-with-workspace-windows:
     needs: changes
@@ -39,3 +40,4 @@ jobs:
       osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --data_source.hideLocalCluster=true --investigation.enabled=true --investigation.agenticFeaturesEnabled=true --uiSettings.overrides.home:useNewHomePage=true --workspace.enabled=true --savedObjects.permission.enabled=true --opensearchDashboards.dashboardAdmin.users='["admin"]' --opensearch_security.multitenancy.enabled=false --explore.enabled=true
       security-enabled: true
       artifact-name-suffix: '-windows-with-workspace'
+      multi-opensearch-enabled: false

--- a/.github/workflows/investigation-release-e2e-workflow.yml
+++ b/.github/workflows/investigation-release-e2e-workflow.yml
@@ -14,6 +14,9 @@ jobs:
           filters: |
             tests:
               - 'cypress/**/dashboards-investigation/**'
+              - '.github/workflows/release-e2e-workflow-template.yml'
+              - '.github/workflows/release-e2e-workflow-template-windows.yml'
+              - '.github/workflows/investigation-release-e2e-workflow.yml'
 
   tests-with-workspace-linux:
     needs: changes

--- a/.github/workflows/investigation-release-e2e-workflow.yml
+++ b/.github/workflows/investigation-release-e2e-workflow.yml
@@ -15,7 +15,7 @@ jobs:
             tests:
               - 'cypress/**/dashboards-investigation/**'
 
-  tests-with-workspace:
+  tests-with-workspace-linux:
     needs: changes
     if: ${{ needs.changes.outputs.tests == 'true' }}
     uses: ./.github/workflows/release-e2e-workflow-template.yml
@@ -24,4 +24,15 @@ jobs:
       test-command: env CYPRESS_DISABLE_LOCAL_CLUSTER=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true CYPRESS_DASHBOARDS_INVESTIGATION_ENABLED=true CYPRESS_WORKSPACE_ENABLED=true yarn cypress:run-with-security --browser electron --spec 'cypress/integration/plugins/dashboards-investigation/*'
       osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --data_source.hideLocalCluster=true --investigation.enabled=true --investigation.agenticFeaturesEnabled=true --uiSettings.overrides.home:useNewHomePage=true --workspace.enabled=true --savedObjects.permission.enabled=true --opensearchDashboards.dashboardAdmin.users='["admin"]' --opensearch_security.multitenancy.enabled=false --explore.enabled=true
       security-enabled: true
-      artifact-name-suffix: '-with-workspace'
+      artifact-name-suffix: '-linux-with-workspace'
+
+  tests-with-workspace-windows:
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' }}
+    uses: ./.github/workflows/release-e2e-workflow-template-windows.yml
+    with:
+      test-name: dashboards investigation
+      test-command: env CYPRESS_DISABLE_LOCAL_CLUSTER=true CYPRESS_DATASOURCE_MANAGEMENT_ENABLED=true CYPRESS_DASHBOARDS_INVESTIGATION_ENABLED=true CYPRESS_WORKSPACE_ENABLED=true yarn cypress:run-with-security --browser chrome --spec 'cypress/integration/plugins/dashboards-investigation/*'
+      osd-serve-args: --data_source.enabled=true --data_source.ssl.verificationMode=none --data_source.hideLocalCluster=true --investigation.enabled=true --investigation.agenticFeaturesEnabled=true --uiSettings.overrides.home:useNewHomePage=true --workspace.enabled=true --savedObjects.permission.enabled=true --opensearchDashboards.dashboardAdmin.users='["admin"]' --opensearch_security.multitenancy.enabled=false --explore.enabled=true
+      security-enabled: true
+      artifact-name-suffix: '-windows-with-workspace'

--- a/.github/workflows/release-e2e-workflow-template-windows.yml
+++ b/.github/workflows/release-e2e-workflow-template-windows.yml
@@ -17,6 +17,10 @@ on:
       artifact-name-suffix:
         required: false
         type: string
+      multi-opensearch-enabled:
+        required: false
+        type: boolean
+        default: true
 jobs:
   tests:
     name: Run Cypress E2E tests for ${{ inputs.test-name }} (Windows)
@@ -78,15 +82,17 @@ jobs:
           netstat -anP tcp | grep LISTEN | grep 9200 || netstat -ntlp | grep 9200
         shell: bash
       - uses: ./.github/actions/start-opensearch
+        if: ${{ inputs.multi-opensearch-enabled }}
         with:
           opensearch-version: ${{ env.VERSION }}
           security-enabled: false
           port: 9201
       - uses: ./.github/actions/start-opensearch
+        if: ${{ inputs.multi-opensearch-enabled }}
         with:
           opensearch-version: ${{ env.VERSION }}
           security-enabled: true
-          admin-password: admin
+          admin-password: myStrongPassword123!
           port: 9202
       - name: Get and run OpenSearch-Dashboards
         run: |

--- a/.github/workflows/release-e2e-workflow-template-windows.yml
+++ b/.github/workflows/release-e2e-workflow-template-windows.yml
@@ -8,7 +8,13 @@ on:
       test-command:
         required: true
         type: string
+      osd-serve-args:
+        required: false
+        type: string
       security-enabled:
+        required: false
+        type: string
+      artifact-name-suffix:
         required: false
         type: string
 jobs:
@@ -96,20 +102,28 @@ jobs:
         with:
           node-version: ${{ env.node_version }}
           registry-url: 'https://registry.npmjs.org'
+      - name: Apply OSD serve args to config
+        if: ${{ inputs.osd-serve-args != '' }}
+        run: |
+          cd opensearch-dashboards-${{ env.VERSION }}
+          # Convert CLI --key=value args to opensearch_dashboards.yml entries
+          for arg in ${{ inputs.osd-serve-args }}; do
+            # Strip leading dashes
+            arg="${arg#--}"
+            key="${arg%%=*}"
+            value="${arg#*=}"
+            # Convert dot notation to yaml (nested keys written in dot form are supported)
+            echo "${key}: ${value}" >> config/opensearch_dashboards.yml
+          done
+        shell: bash
       - name: Run OpenSearch-Dashboards server
         run: |
           netstat -anP tcp | grep LISTEN | grep 9200 || netstat -ntlp | grep 9200
           cd opensearch-dashboards-${{ env.VERSION }}
-          # Temporary solution to add vis_builder and data_source enabled parameters
           echo "vis_builder.enabled: true" >> config/opensearch_dashboards.yml
           echo "data_source.enabled: true" >> config/opensearch_dashboards.yml
           echo "banner.enabled: true" >> config/opensearch_dashboards.yml
           echo 'banner.content: "This is an important announcement for all users. [Learn more](http://opensearch.org) about OpenSearch."' >> config/opensearch_dashboards.yml
-          # echo "data_source.encryption.wrappingKeyName: 'changeme'" >> config/opensearch_dashboards.yml
-          # echo "data_source.encryption.wrappingKeyNamespace: 'changeme'" >> config/opensearch_dashboards.yml
-          # echo "data_source.encryption.wrappingKey: [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]" >> config/opensearch_dashboards.yml
-          # Not useful now as error shows when trying to force a background run with parameters on Windows
-          # bin/opensearch-dashboards.bat serve ${{ inputs.osd-serve-args }} &
           if [ "$SECURITY_ENABLED" = 'false' ]; then
               echo "Remove Dashboards Security"
               ./bin/opensearch-dashboards-plugin.bat remove securityDashboards
@@ -141,17 +155,17 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
-          name: cypress-screenshots
+          name: cypress-screenshots${{ inputs.artifact-name-suffix }}
           path: cypress-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
-          name: cypress-videos
+          name: cypress-videos${{ inputs.artifact-name-suffix }}
           path: cypress-test/cypress/videos
       # Test reports was always captured, so this action uses "always()" condition
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
-          name: cypress-results
+          name: cypress-results${{ inputs.artifact-name-suffix }}
           path: cypress-test/cypress/results

--- a/.github/workflows/release-e2e-workflow-template-windows.yml
+++ b/.github/workflows/release-e2e-workflow-template-windows.yml
@@ -118,7 +118,8 @@ jobs:
             arg="${arg#--}"
             key="${arg%%=*}"
             value="${arg#*=}"
-            # Convert dot notation to yaml (nested keys written in dot form are supported)
+            # Remove any existing line with the same key to avoid duplicated mapping key errors
+            sed -i "/^${key}:/d" config/opensearch_dashboards.yml
             echo "${key}: ${value}" >> config/opensearch_dashboards.yml
           done
         shell: bash
@@ -126,10 +127,8 @@ jobs:
         run: |
           netstat -anP tcp | grep LISTEN | grep 9200 || netstat -ntlp | grep 9200
           cd opensearch-dashboards-${{ env.VERSION }}
-          echo "vis_builder.enabled: true" >> config/opensearch_dashboards.yml
-          echo "data_source.enabled: true" >> config/opensearch_dashboards.yml
-          echo "banner.enabled: true" >> config/opensearch_dashboards.yml
-          echo 'banner.content: "This is an important announcement for all users. [Learn more](http://opensearch.org) about OpenSearch."' >> config/opensearch_dashboards.yml
+          # No hardcoded plugin settings here — each workflow passes what it needs
+          # via osd-serve-args (e.g. --data_source.enabled=true --vis_builder.enabled=true)
           if [ "$SECURITY_ENABLED" = 'false' ]; then
               echo "Remove Dashboards Security"
               ./bin/opensearch-dashboards-plugin.bat remove securityDashboards

--- a/cypress/utils/plugins/dashboards-assistant/commands.js
+++ b/cypress/utils/plugins/dashboards-assistant/commands.js
@@ -219,11 +219,12 @@ Cypress.Commands.add('putAgentIdConfig', ({ type, agentName, agentId }) => {
     // The .plugins-ml-config index is a system index and need to call the API by using certificate file
     if (Cypress.platform === 'win32') {
       return cy.exec(
-        `curl -k --cert "${Cypress.env(
+        `bash -c "curl -k --cert '${Cypress.env(
           'SECURITY_CERT_PATH'
-        )}" --key "${Cypress.env(
+        )}' --key '${Cypress.env(
           'SECURITY_KEY_PATH'
-        )}" -XPUT "${endpoint}" -H "Content-Type: application/json" -d "{\\"type\\":\\"os_chat_root_agent\\",\\"configuration\\":{\\"agent_id\\":\\"${agentId}\\"}}"`
+        )}' -XPUT '${endpoint}' -H 'Content-Type: application/json' -d '{\\"type\\":\\"os_chat_root_agent\\",\\"configuration\\":{\\"agent_id\\":\\"${agentId}\\"}}'"`,
+        { timeout: 30000 }
       );
     } else {
       return cy.exec(
@@ -253,11 +254,12 @@ Cypress.Commands.add('deleteAgentConfig', ({ agentName }) => {
     // The .plugins-ml-config index is a system index and need to call the API by using certificate file
     if (Cypress.platform === 'win32') {
       return cy.exec(
-        `curl -k --cert "${Cypress.env(
+        `bash -c "curl -k --cert '${Cypress.env(
           'SECURITY_CERT_PATH'
-        )}" --key "${Cypress.env(
+        )}' --key '${Cypress.env(
           'SECURITY_KEY_PATH'
-        )}" -XDELETE "${endpoint}" -H "Content-Type: application/json"`
+        )}' -XDELETE '${endpoint}' -H 'Content-Type: application/json'"`,
+        { timeout: 30000, failOnNonZeroExit: false }
       );
     } else {
       return cy.exec(
@@ -265,7 +267,11 @@ Cypress.Commands.add('deleteAgentConfig', ({ agentName }) => {
       );
     }
   } else {
-    return cy.request('DELETE', endpoint);
+    return cy.request({
+      method: 'DELETE',
+      url: endpoint,
+      failOnStatusCode: false,
+    });
   }
 });
 

--- a/cypress/utils/plugins/dashboards-investigation/commands.js
+++ b/cypress/utils/plugins/dashboards-investigation/commands.js
@@ -239,11 +239,12 @@ Cypress.Commands.add(
     if (BACKEND_BASE_PATH.startsWith('https')) {
       if (Cypress.platform === 'win32') {
         return cy.exec(
-          `curl -k --cert "${Cypress.env(
+          `bash -c "curl -k --cert '${Cypress.env(
             'SECURITY_CERT_PATH'
-          )}" --key "${Cypress.env(
+          )}' --key '${Cypress.env(
             'SECURITY_KEY_PATH'
-          )}" -XPUT "${endpoint}" -H "Content-Type: application/json" -d "{\\"type\\":\\"${type}\\",\\"configuration\\":{\\"agent_id\\":\\"${agentId}\\"}}"`
+          )}' -XPUT '${endpoint}' -H 'Content-Type: application/json' -d '{\\"type\\":\\"${type}\\",\\"configuration\\":{\\"agent_id\\":\\"${agentId}\\"}}'"`,
+          { timeout: 30000 }
         );
       } else {
         return cy.exec(
@@ -267,12 +268,12 @@ Cypress.Commands.add('deleteInvestigationAgentConfig', ({ agentName }) => {
   if (BACKEND_BASE_PATH.startsWith('https')) {
     if (Cypress.platform === 'win32') {
       return cy.exec(
-        `curl -k --cert "${Cypress.env(
+        `bash -c "curl -k --cert '${Cypress.env(
           'SECURITY_CERT_PATH'
-        )}" --key "${Cypress.env(
+        )}' --key '${Cypress.env(
           'SECURITY_KEY_PATH'
-        )}" -XDELETE "${endpoint}" -H "Content-Type: application/json"`,
-        { failOnNonZeroExit: false }
+        )}' -XDELETE '${endpoint}' -H 'Content-Type: application/json'"`,
+        { timeout: 30000, failOnNonZeroExit: false }
       );
     } else {
       return cy.exec(


### PR DESCRIPTION
### Description

- Add Windows E2E test jobs for the **investigation** and **assistant** plugins by consolidating Linux and Windows runs into single workflow files (one path filter, shared config)
- Enhance the Windows reusable template (`release-e2e-workflow-template-windows.yml`) to support `osd-serve-args` (converted to YAML config entries since `.bat` doesn't support CLI serve args) and `artifact-name-suffix` for unique artifact names

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
