### PR TITLE
[SRD] Set failOnStatusCode: false for enableSearchRelevanceWorkbench

### DIFF
--- a/cypress/utils/plugins/search-relevance-dashboards/commands.js
+++ b/cypress/utils/plugins/search-relevance-dashboards/commands.js
@@ -13,6 +13,6 @@ Cypress.Commands.add('enableSearchRelevanceWorkbench', () => {
         'plugins.search_relevance.workbench_enabled': true,
       },
     },
-    failOnStatusCode: true,
+    failOnStatusCode: false,
   });
 });


### PR DESCRIPTION
### Description

The `enableSearchRelevanceWorkbench` Cypress command in
`cypress/utils/plugins/search-relevance-dashboards/commands.js` currently sets
`failOnStatusCode: true` on a `PUT /_cluster/settings` call. On managed
Amazon OpenSearch Service (AOS) domains the endpoint filter rejects the plugin
scoped setting with:

```
Status: 401 - Unauthorized
Body: { "Message": "Your request: '/_cluster/settings' payload is not allowed." }
```

Because the request is made from a `before all` hook, Cypress skips every test
in the suite. The three suites that use this command all fail this way in the
downstream Amazon integration run:

- `Search Configuration Create`
- `Judgment Create`
- `Experiment Create`

Example failing run (internal):
https://tod.amazon.com/test_runs/574659549585-eu-west-1-4a02f171-bfaa-4f94-afe8-1db36f9ad64a-1784116629

The workbench setting already defaults to `true` in the plugin on the
`opensearch-3.7.0` branch of `AWSOpenSearchSearchRelevancePlugin`
(`SearchRelevanceSettings.java`), so tolerating a non-2xx response here does
not change effective behavior on either self-managed OpenSearch (where the
`PUT` succeeds) or AOS (where the setting is already enabled by default and
the `PUT` cannot mutate cluster state).

This matches the pattern already used in this repo by other plugins whose
setup hooks call `_cluster/settings`:
- `cypress/utils/plugins/ml-commons-dashboards/commands.js` (`disableConnectorAccessControl`)
- `cypress/utils/plugins/query-insights-dashboards/commands.js`
- `cypress/utils/plugins/dashboards-investigation/commands.js`

### Issues Resolved

_None linked; internal-only failure surfaced through the AOS integration test pipeline._

### Check List

- [x] Commits are signed per the DCO using --signoff
- [x] Backport labels will be requested for `3.7` and other active release branches after merge

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Assisted by fix-integration-test