### PR TITLE
[2.15] Fix double click zoom counting on maps layers tests and click on samp…

### DIFF
--- a/cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js
@@ -13,13 +13,15 @@ describe('Default OpenSearch base map layer', () => {
       retryOnStatusCodeFailure: true,
       timeout: 60000,
     });
-    cy.wait(5000);
     cy.get('div[data-test-subj="sampleDataSetCardflights"]', {
       timeout: 60000,
     })
       .contains(/(Add|View) data/)
       .click();
-    cy.wait(60000);
+    cy.get(
+      'div[data-test-subj="sampleDataSetCardflights"] > span > span[title="INSTALLED"]',
+      { timeout: 60000 }
+    ).should('have.text', 'INSTALLED');
   });
 
   it('check if default OpenSearch map layer can be open', () => {
@@ -30,22 +32,11 @@ describe('Default OpenSearch base map layer', () => {
       'contain',
       'Default map'
     );
-    cy.get('canvas.maplibregl-canvas').trigger('mousemove', {
-      x: 100,
-      y: 100,
-      force: true,
-    });
-    cy.get('canvas.maplibregl-canvas').trigger('mousemove', {
-      x: 200,
-      y: 200,
-      force: true,
-    });
-    for (let i = 0; i < 21; i++) {
-      cy.wait(1000)
-        .get('canvas.maplibregl-canvas')
-        .trigger('dblclick', { force: true });
+    for (let i = 0; i < 5; i++) {
+      cy.get('.maplibregl-ctrl-zoom-in').click();
+      cy.wait(500);
     }
-    cy.get('[data-test-subj="mapStatusBar"]').should('contain', 'zoom: 22');
+    cy.get('[data-test-subj="mapStatusBar"]').should('contain', 'zoom: 6');
   });
 
   after(() => {

--- a/cypress/integration/plugins/custom-import-map-dashboards/3_add_saved_object.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/3_add_saved_object.spec.js
@@ -13,13 +13,18 @@ describe('Add flights dataset saved object', () => {
       retryOnStatusCodeFailure: true,
       timeout: 60000,
     });
-    cy.wait(5000);
+    // Accept either "Add data" (flights not installed) or "View data"
+    // (already installed from an earlier spec whose after-hook may not have
+    // completed uninstall in time). Matches spec #2's own regex.
     cy.get('div[data-test-subj="sampleDataSetCardflights"]', {
       timeout: 60000,
     })
-      .contains(/Add data/)
+      .contains(/(Add|View) data/)
       .click();
-    cy.wait(60000);
+    cy.get(
+      'div[data-test-subj="sampleDataSetCardflights"] > span > span[title="INSTALLED"]',
+      { timeout: 60000 }
+    ).should('have.text', 'INSTALLED');
   });
 
   after(() => {


### PR DESCRIPTION
### Description

Fixes miscounted double click zooms on maps layer tests.

Tested locally with headless cypress
```
yarn cypress:run-without-security --browser electron \
    --spec 'cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js,cypress/integration/plugins/custom-import-map-dashboards/3_add_saved_object.spec.js'

yarn run v1.22.22
$ env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=false --browser electron --spec cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js,cypress/integration/plugins/custom-import-map-dashboards/3_add_saved_object.spec.js
Couldn't determine Mocha version

===========================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        9.5.4                                                                          │
  │ Browser:        Electron 94 (headless)                                                         │
  │ Node Version:   v20.20.2 (/Users/qinandy/.nvm/versions/node/v20.20.2/bin/node)                 │
  │ Specs:          2 found (plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js, pl │
  │                 ugins/custom-import-map-dashboards/3_add_saved_object.spec.js)                 │
  │ Searched:       cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer. │
  │                 spec.js, cypress/integration/plugins/custom-import-map-dashboards/3_add_saved_ │
  │                 object.spec.js                                                                 │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js               (1 of 2)
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Couldn't determine Mocha version


  Default OpenSearch base map layer
[5829:0716/154946.667686:ERROR:shared_image_manager.cc(214)] SharedImageManager::ProduceSkia: Trying to Produce a Skia representation from a non-existent mailbox.
    ✓ check if default OpenSearch map layer can be open (34759ms)


  1 passing (40s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     39 seconds                                                                       │
  │ Spec Ran:     plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js                │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/qinandy/opensearch/opensearch-dashboards-functional-     (1 second)
                          test/cypress/videos/plugins/custom-import-map-dashboards/2_               
                          opensearchMapLayer.spec.js.mp4                                            


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  plugins/custom-import-map-dashboards/3_add_saved_object.spec.js                 (2 of 2)


  Add flights dataset saved object
    ✓ check if maps saved object of flights dataset can be found and open (32226ms)


  1 passing (37s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     37 seconds                                                                       │
  │ Spec Ran:     plugins/custom-import-map-dashboards/3_add_saved_object.spec.js                  │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/qinandy/opensearch/opensearch-dashboards-functional-     (1 second)
                          test/cypress/videos/plugins/custom-import-map-dashboards/3_               
                          add_saved_object.spec.js.mp4                                              


===========================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/custom-import-map-dashboard      00:39        1        1        -        -        - │
  │    s/2_opensearchMapLayer.spec.js                                                              │
  ├────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ ✔  plugins/custom-import-map-dashboard      00:37        1        1        -        -        - │
  │    s/3_add_saved_object.spec.js                                                                │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        01:17        2        2        -        -        -  

✨  Done in 96.66s.
```

### Issues Resolved

n/a

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
