### PR TITLE
[2.17] Fix double click zoom counting on maps layers tests

### DIFF
--- a/cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js
+++ b/cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js
@@ -25,22 +25,11 @@ describe('Default OpenSearch base map layer', () => {
       'contain',
       'Default map'
     );
-    cy.get('canvas.maplibregl-canvas').trigger('mousemove', {
-      x: 100,
-      y: 100,
-      force: true,
-    });
-    cy.get('canvas.maplibregl-canvas').trigger('mousemove', {
-      x: 200,
-      y: 200,
-      force: true,
-    });
-    for (let i = 0; i < 21; i++) {
-      cy.wait(1000)
-        .get('canvas.maplibregl-canvas')
-        .trigger('dblclick', { force: true });
+    for (let i = 0; i < 5; i++) {
+      cy.get('.maplibregl-ctrl-zoom-in').click();
+      cy.wait(500);
     }
-    cy.get('[data-test-subj="mapStatusBar"]').should('contain', 'zoom: 22');
+    cy.get('[data-test-subj="mapStatusBar"]').should('contain', 'zoom: 6');
   });
 
   after(() => {


### PR DESCRIPTION
### Description
Fixes miscounted double click zooms on maps layer tests.

Tested locally with headless cypress
```
yarn cypress:run-without-security --browser electron --spec 'cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js' 
yarn run v1.22.22
$ env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=false --browser electron --spec cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js
Couldn't determine Mocha version

====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        9.5.4                                                                          │
  │ Browser:        Electron 94 (headless)                                                         │
  │ Node Version:   v20.20.2 (/Users/qinandy/.nvm/versions/node/v20.20.2/bin/node)                 │
  │ Specs:          1 found (plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js)    │
  │ Searched:       cypress/integration/plugins/custom-import-map-dashboards/2_opensearchMapLayer. │
  │                 spec.js                                                                        │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js               (1 of 1)
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Couldn't determine Mocha version


  Default OpenSearch base map layer
[31289:0716/161720.680228:ERROR:shared_image_manager.cc(214)] SharedImageManager::ProduceSkia: Trying to Produce a Skia representation from a non-existent mailbox.
    ✓ check if default OpenSearch map layer can be open (53632ms)


  1 passing (57s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        1                                                                                │
  │ Passing:      1                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     57 seconds                                                                       │
  │ Spec Ran:     plugins/custom-import-map-dashboards/2_opensearchMapLayer.spec.js                │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/qinandy/opensearch/opensearch-dashboards-functional-    (2 seconds)
                          test/cypress/videos/plugins/custom-import-map-dashboards/2_               
                          opensearchMapLayer.spec.js.mp4                                            


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/custom-import-map-dashboard      00:57        1        1        -        -        - │
  │    s/2_opensearchMapLayer.spec.js                                                              │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:57        1        1        -        -        -  

✨  Done in 70.90s.
```

### Issues Resolved

n/a
### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
