### PR TITLE
[2.11]Fix gantt chart UI test failing on empty index-pattern fields

### DIFF
--- a/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
+++ b/cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js
@@ -18,38 +18,44 @@ const Y_LABEL = 'A unique label for Y-axis';
 const X_LABEL = 'A unique label for X-axis';
 const DEFAULT_SIZE = 10;
 
+const INDEX = 'jaeger';
+
 describe('Dump test data', () => {
   it('Indexes test data for gantt chart', () => {
-    const dumpDataSet = (ndjson, index) =>
-      cy.request({
-        method: 'POST',
-        form: false,
-        url: 'api/console/proxy',
-        headers: {
-          'content-type': 'application/json;charset=UTF-8',
-          'osd-xsrf': true,
-        },
-        qs: {
-          path: `${index}/_bulk`,
-          method: 'POST',
-        },
-        body: ndjson,
-      });
     cy.fixture('plugins/gantt-chart-dashboards/jaeger-sample.txt').then(
-      (ndjson) => {
-        dumpDataSet(ndjson, 'jaeger');
-      }
+      (ndjson) =>
+        cy.request({
+          method: 'POST',
+          url: 'api/console/proxy',
+          headers: {
+            'content-type': 'application/json;charset=UTF-8',
+            'osd-xsrf': true,
+          },
+          // refresh=wait_for makes the bulk-indexed docs immediately searchable
+          qs: { path: `${INDEX}/_bulk?refresh=wait_for`, method: 'POST' },
+          body: ndjson,
+        })
     );
 
+    // Create the index pattern with its field list for editor to read the stored `fields` attribute
     cy.request({
-      method: 'POST',
-      failOnStatusCode: false,
-      url: 'api/saved_objects/index-pattern/jaeger',
-      headers: {
-        'content-type': 'application/json',
-        'osd-xsrf': true,
-      },
-      body: JSON.stringify({ attributes: { title: 'jaeger' } }),
+      method: 'GET',
+      url: 'api/index_patterns/_fields_for_wildcard',
+      qs: { pattern: INDEX },
+      headers: { 'osd-xsrf': true },
+    }).then((resp) => {
+      cy.request({
+        method: 'POST',
+        failOnStatusCode: false,
+        url: `api/saved_objects/index-pattern/${INDEX}`,
+        headers: { 'content-type': 'application/json', 'osd-xsrf': true },
+        body: JSON.stringify({
+          attributes: {
+            title: INDEX,
+            fields: JSON.stringify(resp.body.fields),
+          },
+        }),
+      });
     });
   });
 });


### PR DESCRIPTION
### Description

Fixes the `gantt-chart-dashboards/gantt_ui.spec.js` test.

### Root cause


1. **Empty index-pattern `fields` attribute.** The test created the `jaeger`
   index pattern with only a `title`, leaving its `fields` attribute empty.
   The visualization editor reads the stored `fields` list to populate its
   field dropdowns — so every dropdown in the Gantt editor (Event, Start time,
   Duration) showed **no options**, and the chart could not be configured. The
   test then hung on `cy.contains('spanID')` until it timed out.

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11653 introduces the error:  An index-pattern created with only a title → fields stays empty → editor dropdowns are empty → the gantt chart can't be configured

### test result

```
yarn cypress:run-without-security --browser electron \
  --spec cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js

yarn run v1.22.19
$ env TZ=America/Los_Angeles NO_COLOR=1 cypress run --headless --env SECURITY_ENABLED=false --browser electron --spec cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js

====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        9.5.4                                                                          │
  │ Browser:        Electron 94 (headless)                                                         │
  │ Node Version:   v22.23.0 (/Users/qianxisy/.local/share/mise/installs/node/22.23.0/bin/node)    │
  │ Specs:          1 found (plugins/gantt-chart-dashboards/gantt_ui.spec.js)                      │
  │ Searched:       cypress/integration/plugins/gantt-chart-dashboards/gantt_ui.spec.js            │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
  Running:  plugins/gantt-chart-dashboards/gantt_ui.spec.js                                 (1 of 1)
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating


  Dump test data
    ✓ Indexes test data for gantt chart

  Save a gantt chart
    ✓ Creates and saves a gantt chart (17703ms)

  Render and configure a gantt chart
    ✓ Renders no data message
    ✓ Renders the chart (5779ms)

  Configure panel settings
    ✓ Changes y-axis label
    ✓ Changes x-axis label
    ✓ Changes time formats (10285ms)
    ✓ Hides legends

  Add gantt chart to dashboard
    ✓ Adds gantt chart to dashboard


  9 passing (58s)


  (Results)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Tests:        9                                                                                │
  │ Passing:      9                                                                                │
  │ Failing:      0                                                                                │
  │ Pending:      0                                                                                │
  │ Skipped:      0                                                                                │
  │ Screenshots:  0                                                                                │
  │ Video:        true                                                                             │
  │ Duration:     57 seconds                                                                       │
  │ Spec Ran:     plugins/gantt-chart-dashboards/gantt_ui.spec.js                                  │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


  (Video)

  -  Started processing:  Compressing to 32 CRF                                                     
  -  Finished processing: /Users/qianxisy/co404/testss/Opensearch-dashboards-function    (3 seconds)
                          al-test/cypress/videos/plugins/gantt-chart-dashboards/gantt               
                          _ui.spec.js.mp4                                                           


====================================================================================================

  (Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/gantt-chart-dashboards/gant      00:57        9        9        -        -        - │
  │    t_ui.spec.js                                                                                │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:57        9        9        -        -        -  

✨  Done in 75.90s.
```

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
