### PR TITLE
fix: replace removed Cypress.Cookies API in proxy auth setup with cy.session

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -59,15 +59,15 @@ Cypress.on('uncaught:exception', () => {
 });
 
 // Proxy layer of OpenSearch domain may redirect to login page
-//  if you haven't authenticate
+//  if you haven't authenticated.
+// Cypress >= 12 removed Cypress.Cookies.debug() and
+// Cypress.Cookies.preserveOnce(). Use cy.session() to log in once and restore
+// the auth cookie before every test instead of preserving it manually.
 if (Cypress.env('ENDPOINT_WITH_PROXY')) {
-  Cypress.Cookies.debug(false);
-  before(() => {
-    cy.login();
-  });
-
   beforeEach(() => {
-    Cypress.Cookies.preserveOnce('security_authentication');
+    cy.session('security_authentication', () => {
+      cy.login();
+    });
   });
 }
 


### PR DESCRIPTION
### Description

Replaces `Cypress.Cookies` API since 'Cypress.Cookies.preserveOnce() was removed in Cypress version 12.0.0.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
