### PR TITLE
fix: update deleteAllNotebooks() to not use specific value

### DIFF
--- a/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
+++ b/cypress/integration/plugins/observability-dashboards/6_notebooks.spec.js
@@ -83,7 +83,7 @@ const deleteAllNotebooks = () => {
   cy.get('input[data-test-subj="checkboxSelectAll"]').should('exist');
   cy.get('input[data-test-subj="checkboxSelectAll"]').click();
   cy.get('button[data-test-subj="deleteSelectedNotebooks"]')
-    .contains('Delete 4 notebooks')
+    .contains(/Delete \d+ notebooks?/)
     .should('exist');
   cy.get('button[data-test-subj="deleteSelectedNotebooks"]').click();
   cy.get('input[data-test-subj="delete-notebook-modal-input"]').type('delete');


### PR DESCRIPTION
### Description

Update `deleteAllNotebooks()` to not check for a specific number of notebooks before deleting.

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
