### PR TITLE
fix(sa): increase detectorsSearch wait timeout

### DIFF
--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/1_detectors.spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/1_detectors.spec.js
@@ -281,7 +281,7 @@ describe('Detectors', () => {
 
       // Visit Detectors page before any test
       cy.visit(`${OPENSEARCH_DASHBOARDS_URL}/detectors`);
-      cy.wait('@detectorsSearch', { timeout: 300000 }).should(
+      cy.wait('@detectorsSearch', { timeout: 500000 }).should(
         'have.property',
         'state',
         'Complete'
@@ -436,7 +436,7 @@ describe('Detectors', () => {
 
       // Visit Detectors page before any test
       cy.visit(`${OPENSEARCH_DASHBOARDS_URL}/detectors`);
-      cy.wait('@detectorsSearch', { timeout: 300000 }).should(
+      cy.wait('@detectorsSearch', { timeout: 500000 }).should(
         'have.property',
         'state',
         'Complete'


### PR DESCRIPTION
### Description

Increase `detectorsSearch` wait timeout from 300s to 500s in the SA detector tests. The 300s timeout is insufficient when running against domains with higher network latency, causing flaky failures in the beforeEach hooks.

### Issues Resolved

Resolves flaky `cy.wait('@detectorsSearch')` timeout in `1_detectors.spec.js` 

```
(Run Finished)


       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  plugins/security-analytics-dashboar      06:03       14       12        -        2        - │
  │    ds-plugin/1_detectors.spec.js                                                               │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        06:03       14       12        -        2        -  

✨  Done in 394.84s.
```

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
