### PR TITLE
Stabilize flaky search-relevance dashboards e2e tests (judgment async, page load, combo options)

### DIFF
--- a/cypress/integration/plugins/search-relevance-dashboards/5_judgment_creation.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/5_judgment_creation.spec.js
@@ -10,6 +10,7 @@ import { BASE_PATH } from '../../../utils/base_constants';
 import {
   initializeUbiIndices,
   enableWorkbenchUI,
+  waitForJudgmentCompleted,
 } from '../../../utils/plugins/search-relevance-dashboards/common-setup';
 
 const PLUGIN_TIMEOUT = 30000;
@@ -97,9 +98,16 @@ describe('Judgment Create', () => {
       ).to.be.true;
     });
 
+    // Judgment ratings are computed asynchronously (status PROCESSING -> COMPLETED).
+    // Wait for completion before opening the detail view, which fetches once and
+    // does not poll.
+    waitForJudgmentCompleted('Test UBI Judgment');
+
     cy.visit(`${BASE_PATH}/app/${SEARCH_RELEVANCE_PLUGIN_NAME}#/judgment`);
     cy.contains('Test UBI Judgment', { timeout: PLUGIN_TIMEOUT }).click();
     cy.url().should('include', '/judgment/view/');
-    cy.contains('futon frames full size without mattress').should('be.visible');
+    cy.contains('futon frames full size without mattress', {
+      timeout: PLUGIN_TIMEOUT,
+    }).should('be.visible');
   });
 });

--- a/cypress/integration/plugins/search-relevance-dashboards/6_experiment_creation.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/6_experiment_creation.spec.js
@@ -11,6 +11,7 @@ import {
   initializeUbiIndices,
   enableWorkbenchUI,
   prepareSampleIndex,
+  waitForJudgmentCompleted,
 } from '../../../utils/plugins/search-relevance-dashboards/common-setup';
 
 describe('Experiment Create', () => {
@@ -108,6 +109,11 @@ describe('Experiment Create', () => {
     cy.get('input[type="number"]').clear().type('20');
     cy.get('[data-test-subj="createJudgmentButton"]').click();
     cy.contains(`Judgment created successfully`, { timeout: 10000 });
+
+    // Judgment ratings are computed asynchronously. The search evaluation
+    // experiment below consumes this judgment, so wait for it to reach
+    // COMPLETED before running the tests.
+    waitForJudgmentCompleted(judgmentName);
   });
 
   beforeEach(() => {

--- a/cypress/integration/plugins/search-relevance-dashboards/6_experiment_creation.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/6_experiment_creation.spec.js
@@ -208,40 +208,77 @@ describe('Experiment Create', () => {
     const configName1 = Cypress.env('configName1');
     const judgmentName = Cypress.env('judgmentName');
 
-    // Navigate to search evaluation page
-    cy.visit(
-      `${BASE_PATH}/app/${SEARCH_RELEVANCE_PLUGIN_NAME}#/experiment/create/searchEvaluation`
-    );
-    cy.wait(3000);
-    // NOTE: Do not use cy.waitForLoader() here. This page fires several data
-    // fetches on mount (query_sets, search_configurations, judgments) that can
-    // keep the browser 'load' event pending, so waitForLoader()'s homeIcon
-    // assertion times out even though the page is usable. Gate on the page's
-    // own readiness instead: wait for the Query Set combo box to finish loading
-    // (it renders "Loading..." until its query_sets fetch resolves).
-    cy.get('[data-test-subj="comboBoxInput"]', { timeout: 60000 })
-      .first()
-      .should('be.visible')
-      .and('not.be.disabled');
+    // The combo boxes on this form (QuerySetsComboBox, SearchConfigForm,
+    // JudgmentsComboBox) fetch their options once on mount and briefly show
+    // "Loading..." before the options render. Occasionally against the managed
+    // domain a combo stays stuck on "Loading..." (its on-mount fetch does not
+    // populate), which is only fixable by re-mounting the page. Since re-mounting
+    // wipes any selections already made, verify the options have loaded BEFORE
+    // selecting anything -- open the query set combo (all three fetch on the
+    // same mount, so it is a reliable canary) and, if its option is missing,
+    // re-navigate to re-fire the fetches and retry. Once confirmed loaded, select
+    // all three in one pass.
+    //
+    // NOTE: Re-mount by re-visiting the URL, NOT cy.reload(). Reloading this
+    // client-side hash route lands on a blank OpenSearch Dashboards app shell;
+    // a fresh cy.visit() re-bootstraps the SPA the same way the initial load
+    // does.
+    const openSearchEvaluationForm = (attemptsLeft = 3) => {
+      cy.visit(
+        `${BASE_PATH}/app/${SEARCH_RELEVANCE_PLUGIN_NAME}#/experiment/create/searchEvaluation`
+      );
+      cy.wait(3000);
 
-    // Select query set from dropdown
-    cy.get('[data-test-subj="comboBoxInput"]').first().click();
-    cy.wait(500);
-    cy.contains('.euiComboBoxOption__content', querySetName, {
-      timeout: 30000,
-    }).click();
+      // NOTE: Do not use cy.waitForLoader() here. This page's on-mount data
+      // fetches can keep the browser 'load' event pending, so waitForLoader()'s
+      // homeIcon assertion times out even though the page is usable. Wait for
+      // the first combo box to render and become enabled instead.
+      cy.get('[data-test-subj="comboBoxInput"]', { timeout: 60000 })
+        .first()
+        .should('be.visible')
+        .and('not.be.disabled');
 
-    // Select search configuration
-    cy.get('[data-test-subj="comboBoxInput"]').eq(1).click();
-    cy.wait(500);
-    cy.contains('.euiComboBoxOption__content', configName1).click();
-    cy.get('h2').first().click(); // Click on a blank area to close dropdown
-    cy.wait(500); // Wait for dropdown to close
+      // Open the query set combo and check whether its options populated.
+      cy.get('[data-test-subj="comboBoxInput"]').first().click();
+      cy.wait(1000);
+      cy.get('body').then(($body) => {
+        const optionLoaded =
+          $body
+            .find('.euiComboBoxOption__content')
+            .filter((_i, el) => (el.textContent || '').includes(querySetName))
+            .length > 0;
 
-    // Select judgment
-    cy.get('[data-test-subj="comboBoxInput"]').eq(2).click();
-    cy.wait(500);
-    cy.contains('.euiComboBoxOption__content', judgmentName).click();
+        if (!optionLoaded && attemptsLeft > 1) {
+          // Re-mount via a fresh visit (the recursive call re-visits the URL).
+          openSearchEvaluationForm(attemptsLeft - 1);
+          return;
+        }
+
+        // Select query set (retry a little longer here in case it is still
+        // finishing the brief "Loading..." state).
+        cy.contains('.euiComboBoxOption__content', querySetName, {
+          timeout: 30000,
+        }).click();
+
+        // Select search configuration
+        cy.get('[data-test-subj="comboBoxInput"]').eq(1).click();
+        cy.wait(500);
+        cy.contains('.euiComboBoxOption__content', configName1, {
+          timeout: 30000,
+        }).click();
+        cy.get('h2').first().click(); // Click on a blank area to close dropdown
+        cy.wait(500); // Wait for dropdown to close
+
+        // Select judgment
+        cy.get('[data-test-subj="comboBoxInput"]').eq(2).click();
+        cy.wait(500);
+        cy.contains('.euiComboBoxOption__content', judgmentName, {
+          timeout: 30000,
+        }).click();
+      });
+    };
+
+    openSearchEvaluationForm();
 
     // Click start evaluation button
     cy.contains('button', 'Start Evaluation').click();

--- a/cypress/integration/plugins/search-relevance-dashboards/6_experiment_creation.spec.js
+++ b/cypress/integration/plugins/search-relevance-dashboards/6_experiment_creation.spec.js
@@ -213,12 +213,23 @@ describe('Experiment Create', () => {
       `${BASE_PATH}/app/${SEARCH_RELEVANCE_PLUGIN_NAME}#/experiment/create/searchEvaluation`
     );
     cy.wait(3000);
-    cy.waitForLoader();
+    // NOTE: Do not use cy.waitForLoader() here. This page fires several data
+    // fetches on mount (query_sets, search_configurations, judgments) that can
+    // keep the browser 'load' event pending, so waitForLoader()'s homeIcon
+    // assertion times out even though the page is usable. Gate on the page's
+    // own readiness instead: wait for the Query Set combo box to finish loading
+    // (it renders "Loading..." until its query_sets fetch resolves).
+    cy.get('[data-test-subj="comboBoxInput"]', { timeout: 60000 })
+      .first()
+      .should('be.visible')
+      .and('not.be.disabled');
 
     // Select query set from dropdown
     cy.get('[data-test-subj="comboBoxInput"]').first().click();
     cy.wait(500);
-    cy.contains('.euiComboBoxOption__content', querySetName).click();
+    cy.contains('.euiComboBoxOption__content', querySetName, {
+      timeout: 30000,
+    }).click();
 
     // Select search configuration
     cy.get('[data-test-subj="comboBoxInput"]').eq(1).click();

--- a/cypress/utils/plugins/search-relevance-dashboards/common-setup.js
+++ b/cypress/utils/plugins/search-relevance-dashboards/common-setup.js
@@ -5,6 +5,41 @@
 
 // Common setup functions for search relevance tests
 
+import { SEARCH_RELEVANCE_PLUGIN_NAME } from './constants';
+import { BASE_PATH } from '../../base_constants';
+
+/**
+ * Wait for an asynchronously-created judgment to finish processing.
+ *
+ * UBI/LLM judgments are created asynchronously: the create call returns HTTP 200
+ * immediately with status=PROCESSING and an empty ratings list, then the ratings
+ * are computed in the background and the status flips to COMPLETED. The judgment
+ * detail view fetches once on mount and does not poll, so asserting on ratings
+ * right after the create call races the background job and intermittently sees an
+ * empty ("No items found") ratings table. The listing page reflects the final
+ * COMPLETED status, so poll it (reloading each attempt to get a fresh DOM) until
+ * the named judgment completes before navigating to the detail view.
+ */
+export const waitForJudgmentCompleted = (judgmentName, attemptsLeft = 18) => {
+  cy.visit(`${BASE_PATH}/app/${SEARCH_RELEVANCE_PLUGIN_NAME}#/judgment`);
+  cy.contains('tr', judgmentName, { timeout: 30000 }).then(($row) => {
+    const rowText = $row.text();
+    if (rowText.includes('COMPLETED')) {
+      return;
+    }
+    if (rowText.includes('ERROR')) {
+      throw new Error(`Judgment "${judgmentName}" finished with ERROR status`);
+    }
+    if (attemptsLeft <= 0) {
+      throw new Error(
+        `Judgment "${judgmentName}" did not reach COMPLETED status in time`
+      );
+    }
+    cy.wait(10000);
+    waitForJudgmentCompleted(judgmentName, attemptsLeft - 1);
+  });
+};
+
 /**
  * Enable the search relevance workbench UI toggle
  */


### PR DESCRIPTION
### Description

Fixes intermittent failures in the search-relevance-dashboards Cypress specs (`5_judgment_creation` and `6_experiment_creation`), which were flaky against a managed OpenSearch domain while passing when run manually. Three related root causes, each fixed:

1. **Async judgment ratings race** — UBI/LLM judgments are created asynchronously: the create call returns `200` immediately with `status=PROCESSING` and empty ratings, then ratings compute in the background and status flips to `COMPLETED`. The detail view fetches once on mount and does not poll, so asserting right after creation raced the background job and intermittently rendered an empty ratings table. Added a `waitForJudgmentCompleted()` helper that polls the judgment listing until `COMPLETED` before navigating to the detail view / consuming the judgment. Used in spec 5 and in spec 6's setup.

2. **`cy.waitForLoader()` hang on the search evaluation page** — this page's on-mount data fetches can keep the browser `load` event pending, so `waitForLoader()`'s `homeIcon` assertion timed out even though the page was usable. Replaced it with a wait for the first combo box to render and become enabled.

3. **Combo options stuck on "Loading..."** — the query set / search configuration / judgment combo boxes fetch their options only on mount. Occasionally a combo stayed stuck on "Loading..." (its on-mount fetch didn't populate). Since waiting longer can't help (options are only fetched on mount), wrapped the form interaction in a bounded retry (up to 3): open the query set combo as a canary and, if its option hasn't rendered, re-visit the route to re-fire the fetches before retrying. Re-mount is done via a fresh `cy.visit()`, **not** `cy.reload()` — reloading this client-side hash route lands on a blank OpenSearch Dashboards app shell, whereas a fresh visit re-bootstraps the SPA like the initial load.

### Issues Resolved

N/A

### Check List
- [x] All tests pass (search-relevance specs run locally against OpenSearch + OpenSearch-Dashboards with the search-relevance, ubi, and ml plugins)
- [x] New functionality has been documented via inline comments explaining the non-obvious timing/SPA behavior

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.