### PR TITLE
fix ism e2e: dismissToast and failOnStatusCode for managed service

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/managed_indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/managed_indices_spec.js
@@ -29,7 +29,7 @@ describe('Managed indices', () => {
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Edit rollover alias', { timeout: 60000 });
 
-    cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+    cy.dismissToast();
   });
 
   describe('can have policies removed', () => {
@@ -90,7 +90,7 @@ describe('Managed indices', () => {
       // Wait up to 5 seconds for the managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.dismissToast();
 
       // Confirm managed index successfully initialized the policy
       cy.contains('Successfully initialized', { timeout: 20000 });
@@ -100,7 +100,7 @@ describe('Managed indices', () => {
       // Wait up to 5 seconds for managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.dismissToast();
 
       // Confirm we have a Failed execution, wait up to 20 seconds as OSD takes a while to load
       cy.contains('Failed', { timeout: 20000 });
@@ -127,7 +127,7 @@ describe('Managed indices', () => {
 
       // Reload the page
       cy.reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.dismissToast();
 
       // Confirm we see managed index attempting to retry, give 20 seconds for OSD load
       cy.contains('Pending retry of failed managed index', { timeout: 20000 });
@@ -138,7 +138,7 @@ describe('Managed indices', () => {
       // Wait up to 5 seconds for managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.dismissToast();
 
       // Confirm managed index successfully rolled over
       cy.contains('Successfully rolled over', { timeout: 20000 });

--- a/cypress/utils/commands.js
+++ b/cypress/utils/commands.js
@@ -159,12 +159,13 @@ Cypress.Commands.add('login', () => {
 // This function does not delete all indices
 Cypress.Commands.add('deleteAllIndices', () => {
   cy.log('Deleting all indices');
-  cy.request(
-    'DELETE',
-    `${Cypress.env(
+  cy.request({
+    method: 'DELETE',
+    url: `${Cypress.env(
       'openSearchUrl'
-    )}/index*,sample*,opensearch_dashboards*,test*,cypress*`
-  );
+    )}/index*,sample*,opensearch_dashboards*,test*,cypress*`,
+    failOnStatusCode: false,
+  });
 });
 
 Cypress.Commands.add('deleteADSystemIndices', () => {

--- a/cypress/utils/plugins/index-management-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/index-management-dashboards-plugin/commands.js
@@ -171,3 +171,11 @@ Cypress.Commands.add('removeIndexAlias', (alias) => {
     failOnStatusCode: false,
   });
 });
+
+Cypress.Commands.add('dismissToast', () => {
+  cy.get('body').then(($body) => {
+    if ($body.find(`[data-test-subj="toastCloseButton"]`).length) {
+      cy.get(`[data-test-subj="toastCloseButton"]`).click({ force: true });
+    }
+  });
+});


### PR DESCRIPTION
### Description

[Describe what this change achieves]
Fix ISM E2E Cypress tests. Toast notifications from ISM job interval/jitter updates block UI interactions in managed_indices_spec.js, causing subsequent tests to fail when trying to click elements behind the toast.

###Testing
Ran `managed_indices_spec.js` locally against OpenSearch 2.17.0 with ISM plugin:

 Managed indices
      can have policies removed
        ✓ successfully (21028ms)
      can have policies retried
        ✓ successfully (37008ms)
      can edit rollover_alias
        ✓ successfully (7946ms)
      can change policies
        ✓ successfully (20119ms)
      can manage data stream indices
        ✓ successfully (8832ms)
  
  
    5 passing (2m)


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
