### PR TITLE
fix(sa): Add visibility checks and waits to alerts row button acknowl…

### DIFF
--- a/cypress/integration/plugins/security-analytics-dashboards-plugin/3_alerts.spec.js
+++ b/cypress/integration/plugins/security-analytics-dashboards-plugin/3_alerts.spec.js
@@ -369,10 +369,12 @@ describe('Alerts', () => {
 
   it('can be acknowledged via row button', () => {
     // Filter the table to show only "Active" alerts
-    cy.get('[data-text="Status"]').click({ force: true });
-    cy.get('[class="euiFilterSelect__items"]').within(() => {
-      cy.contains('Active').click({ force: true });
-    });
+    cy.get('[data-text="Status"]').should('be.visible').click({ force: true });
+    cy.get('[class="euiFilterSelect__items"]')
+      .should('be.visible')
+      .within(() => {
+        cy.contains('Active').click({ force: true });
+      });
 
     cy.get('tbody > tr')
       .filter(`:contains(${alertName})`)
@@ -385,16 +387,24 @@ describe('Alerts', () => {
         cy.get('[aria-label="Acknowledge"]').click({ force: true });
       });
 
+    // Wait for acknowledge to go through
+    cy.wait(2000);
     cy.get('tbody > tr')
       .filter(`:contains(${alertName})`)
       .should('have.length', 1);
 
     // Filter the table to show only "Acknowledged" alerts
-    cy.get('[class="euiFilterSelect__items"]').within(() => {
-      cy.contains('Active').click({ force: true });
-      cy.contains('Acknowledged').click({ force: true });
-    });
+    cy.wait(2000);
+    cy.get('[data-text="Status"]').should('be.visible').click({ force: true });
+    cy.get('[class="euiFilterSelect__items"]')
+      .should('be.visible')
+      .within(() => {
+        cy.contains('Active').click({ force: true });
+        cy.contains('Acknowledged').click({ force: true });
+      });
 
+    // Wait for filter to apply
+    cy.wait(2000);
     // Confirm there are now 3 "Acknowledged" alerts
     cy.get('tbody > tr')
       .filter(`:contains(${alertName})`)


### PR DESCRIPTION
…edge test

The 'can be acknowledged via row button' test fails because the Status filter popover is not ready when the test interacts with it. Added .should('be.visible') assertions and short waits to ensure the popover renders before clicking filter options.

### Description

Fix flaky "can be acknowledged via row button" test in 3_alerts.spec.js. The Status filter popover wasn't ready when the test interacted with it. Added .should('be.visible') assertions and short waits to ensure the popover renders before clicking filter options.

### Issues Resolved

Resolves consistent failure of `can be acknowledged` via row button test .

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
