### PR TITLE
Fix flaky query-insights-dashboards Cypress tests (top_queries sort, live queries, dynamic columns)

### DIFF
--- a/cypress/integration/plugins/query-insights-dashboards/1_top_queries_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/1_top_queries_spec.js
@@ -107,6 +107,46 @@ const resetTypeFilterToNone = () => {
 const indexName = 'sample_index';
 
 /**
+ * Reload the overview page until the main Top N queries table is populated.
+ *
+ * The overview page fetches top queries exactly once per load (on mount) — it
+ * does not poll. Under security the query-insights collection queue drains more
+ * slowly, so the initial fetch can land before any queries are recorded and the
+ * table renders its "No items found" empty state. Because nothing re-fetches, a
+ * passive `.should('not.contain', 'No items found')` can never recover and just
+ * times out. Reloading re-issues the fetch, which is what actually lets the data
+ * appear.
+ *
+ * The empty-state check is scoped to the main data table (last `.euiBasicTable`
+ * on the page, as the sort assertion below targets) rather than the whole body:
+ * the page also renders a chart table whose own "No items found" state would
+ * otherwise keep this loop retrying even after the main table populated. EUI
+ * renders `noItemsMessage` inside a `.euiTableRow`, so a row-count check alone
+ * passes on an empty table — match on the message text instead.
+ *
+ * Worst-case runtime is bounded to roughly 3 minutes so a genuine failure
+ * surfaces in CI quickly rather than burning the full command timeout.
+ */
+const waitForTopQueriesTable = (attempts = 6) => {
+  cy.get('.euiBasicTable', { timeout: 30000 })
+    .last()
+    .then(($table) => {
+      if (!$table.text().includes('No items found')) {
+        return;
+      }
+      if (attempts <= 0) {
+        throw new Error('Top N queries table never populated after reloads');
+      }
+      cy.wait(3000);
+      cy.reload();
+      cy.contains('Query insights - Top N queries', { timeout: 30000 }).should(
+        'be.visible'
+      );
+      waitForTopQueriesTable(attempts - 1);
+    });
+};
+
+/**
  Helper function to clean up the environment:
  - Deletes the test index.
  - Disables the top queries features.
@@ -169,12 +209,14 @@ describe('Query Insights Dashboard', () => {
     // waiting for the query insights queue to drain
     cy.wait(10000);
     cy.navigateToOverview();
-    // Ensure main table has data before attempting to sort
+    // Ensure main table has data before attempting to sort. The page fetches
+    // once on load and does not poll, so reload until the queue has drained and
+    // the table is populated rather than waiting passively on a stale fetch.
+    waitForTopQueriesTable();
     cy.get('.euiBasicTable', { timeout: 30000 })
       .last()
       .find('.euiTableRow')
       .should('have.length.greaterThan', 0);
-    cy.get('body').should('not.contain', 'No items found');
     // Click the Timestamp column header in main table to sort
     cy.get('.euiBasicTable')
       .last()
@@ -390,8 +432,11 @@ describe('Query Insights — Dynamic Columns (QUERY ONLY fixture)', () => {
       'WLM Group',
       'Total Shards',
     ];
-    getHeaders().should('deep.equal', expected);
+    // assertRowCountEquals uses .should('have.length', N) which retries until items
+    // has populated; once row count matches, columnsToShow has evaluated against the
+    // populated data and headers are stable for the deep-equal assertion.
     assertRowCountEquals(getRowsFromRaw(QUERY_ONLY).length);
+    getHeaders().should('deep.equal', expected);
   });
 });
 
@@ -418,8 +463,11 @@ describe('Query Insights — Dynamic Columns (GROUP ONLY fixture)', () => {
       'Average CPU Time',
       'Average Memory Usage',
     ];
-    getHeaders().should('deep.equal', expected);
+    // assertRowCountEquals uses .should('have.length', N) which retries until items
+    // has populated; once row count matches, columnsToShow has evaluated against the
+    // populated data and headers are stable for the deep-equal assertion.
     assertRowCountEquals(getRowsFromRaw(GROUP_ONLY).length);
+    getHeaders().should('deep.equal', expected);
   });
 
   it('renders dash in status column for group rows', () => {
@@ -439,7 +487,16 @@ describe('Query Insights — Stats & Visualizations Panel', () => {
     // Force reload because testIsolation is disabled in this repo's cypress.config —
     // without it, cy.visit() to the same URL is a no-op and the intercepted request never fires.
     cy.reload();
+    // The page fires three GETs (latency, cpu, memory) and only flips loading=false
+    // after all three resolve. Wait for all three plus the table to render so the
+    // visualizations panel is stable and React state has settled.
     cy.wait('@topQueries', { timeout: 60000 });
+    cy.wait('@topQueries', { timeout: 60000 });
+    cy.wait('@topQueries', { timeout: 60000 });
+    cy.get('.euiBasicTable', { timeout: 30000 })
+      .last()
+      .find('.euiTableRow')
+      .should('have.length.greaterThan', 0);
   });
 
   it('displays visualizations panel with Query/Group toggle', () => {
@@ -637,7 +694,19 @@ describe('Query Insights — DynamicSearchBar', () => {
     // Force reload because testIsolation is disabled in this repo's cypress.config —
     // without it, cy.visit() to the same URL is a no-op and the intercepted request never fires.
     cy.reload();
+    // The page fires three GETs (latency, cpu, memory) and only flips loading=false
+    // after all three resolve. The DynamicSearchBar is conditionally rendered on
+    // `!loading`, so wait for all three plus the table to render before any test
+    // interacts with the search input — otherwise the input may be detached/re-mounted
+    // between Cypress commands, surfacing as a misleading 'disabled element' error.
     cy.wait('@topQueries', { timeout: 60000 });
+    cy.wait('@topQueries', { timeout: 60000 });
+    cy.wait('@topQueries', { timeout: 60000 });
+    cy.get('.euiBasicTable', { timeout: 30000 })
+      .last()
+      .find('.euiTableRow')
+      .should('have.length.greaterThan', 0);
+    cy.get(`input[placeholder="${SEARCH_PLACEHOLDER}"]`).should('be.visible');
   });
 
   it('renders the search bar with correct placeholder', () => {

--- a/cypress/integration/plugins/query-insights-dashboards/5_live_queries_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/5_live_queries_spec.js
@@ -19,6 +19,21 @@ describe('Inflight Queries Dashboard', () => {
     // never fires for subsequent tests.
     cy.reload();
     cy.wait('@getLiveQueries', { timeout: 60000 });
+
+    // Disable auto-refresh to keep the DOM stable across assertions. Without this,
+    // every refreshInterval (default 5s) the table re-renders, detaching row and
+    // pagination handles mid-test (root cause of the pagination 'detached from DOM'
+    // and WLM-disabled content-match failures).
+    cy.get('[data-test-subj="live-queries-autorefresh-toggle"]').then(($t) => {
+      if ($t.attr('aria-checked') === 'true') {
+        cy.wrap($t).click();
+      }
+    });
+    cy.get('[data-test-subj="live-queries-autorefresh-toggle"]').should(
+      'have.attr',
+      'aria-checked',
+      'false'
+    );
   });
 
   it('displays the correct page title', () => {
@@ -110,9 +125,18 @@ describe('Inflight Queries Dashboard', () => {
   });
 
   it('navigates to next page in table pagination', () => {
-    cy.wait('@getLiveQueries');
     cy.get('.euiPagination').should('be.visible');
-    cy.get('.euiPagination__item').contains('2').click();
+    // Break chain and force the click — the EuiPagination button can briefly
+    // re-render between visibility check and click on slow CI; aliasing then
+    // forcing avoids the 'page updated while this command was executing' race.
+    cy.get('[data-test-subj="pagination-button-1"]').as('nextPage');
+    cy.get('@nextPage').should('be.visible');
+    cy.get('@nextPage').click({ force: true });
+    cy.get('[data-test-subj="pagination-button-1"]').should(
+      'have.attr',
+      'aria-current',
+      'true'
+    );
     cy.get('tbody tr').should('exist');
   });
 
@@ -152,6 +176,10 @@ describe('Inflight Queries Dashboard', () => {
     cy.get('[data-test-subj="live-queries-autorefresh-toggle"]').as('toggle');
     cy.get('[data-test-subj="live-queries-refresh-interval"]').as('dropdown');
 
+    // beforeEach already disabled auto-refresh; re-enable then toggle off so the
+    // observable transition to disabled is exercised.
+    cy.get('@toggle').click();
+    cy.get('@toggle').should('have.attr', 'aria-checked', 'true');
     cy.get('@toggle').click();
     cy.get('@toggle').should('have.attr', 'aria-checked', 'false');
     cy.get('@dropdown').should('be.disabled');
@@ -196,6 +224,9 @@ describe('Inflight Queries Dashboard', () => {
     });
 
     cy.navigateToLiveQueries();
+    // Force reload — under testIsolation:false, cy.visit() to the same URL is a
+    // no-op, so the new intercept above never fires without an explicit reload.
+    cy.reload();
 
     cy.wait('@getPeriodicQueries');
     cy.wait('@getPeriodicQueries');
@@ -218,6 +249,9 @@ describe('Inflight Queries Dashboard', () => {
     }).as('getEmptyQueries');
 
     cy.navigateToLiveQueries();
+    // Force reload — under testIsolation:false, cy.visit() to the same URL is a
+    // no-op, so the new intercept above never fires without an explicit reload.
+    cy.reload();
     cy.wait('@getEmptyQueries');
     cy.get('[data-test-subj="panel-active-queries"]').within(() => {
       cy.contains('Active queries');
@@ -245,6 +279,9 @@ describe('Inflight Queries Dashboard', () => {
       }).as('getCancelledQuery');
 
       cy.navigateToLiveQueries();
+      // Force reload — under testIsolation:false, cy.visit() to the same URL is
+      // a no-op, so the new intercept above never fires without an explicit reload.
+      cy.reload();
       cy.wait('@getCancelledQuery');
 
       cy.contains(data.response.live_queries[0].id)
@@ -359,13 +396,11 @@ describe('Inflight Queries Dashboard', () => {
   });
 
   it('displays WLM group as text when WLM is disabled', () => {
-    cy.get('tbody tr')
-      .first()
-      .within(() => {
-        cy.get('td')
-          .contains('ANALYTICS_WORKLOAD_GROUP')
-          .should('not.have.attr', 'href');
-      });
+    // Use cy.contains(selector, text) which requeries on retry instead of latching
+    // onto a `tbody tr:first` handle that can go stale across React re-renders.
+    cy.contains('tbody td', 'ANALYTICS_WORKLOAD_GROUP', { timeout: 60000 })
+      .should('be.visible')
+      .and('not.have.attr', 'href');
   });
 });
 


### PR DESCRIPTION
### Description

Fixes a set of flaky query-insights-dashboards Cypress tests, including the one that causes the recurring release integration-test autocut. Three commits:

**1. Fix flaky query-insights cypress tests on Windows** (`1_top_queries_spec.js`, `5_live_queries_spec.js`)
- Dynamic-columns tests: assert row count *before* the header deep-equal, so `columnsToShow` has evaluated against populated data (headers are otherwise unstable).
- Stats/Visualizations and DynamicSearchBar `beforeEach`: wait for all three `@topQueries` GETs (latency/cpu/memory — the page only flips `loading=false` after all three resolve) plus table render, so conditionally-rendered UI is stable before interaction.
- Live queries: disable auto-refresh in `beforeEach` so the 5s `refreshInterval` re-render doesn't detach row/pagination handles mid-test; requery `tbody td` by text instead of latching a stale `tbody tr:first` handle.

**2. Force reload after `navigateToLiveQueries`; harden pagination click**
- Under `testIsolation:false`, `cy.visit()` to the same URL is a no-op, so newly-registered intercepts never fire — force an explicit `cy.reload()`.
- Alias-then-force the pagination click to avoid the "page updated while this command was executing" re-render race.

**3. Fix flaky top_queries Timestamp-sort test by reloading until data populates**
- Root cause: the overview page fetches top queries once on mount with no polling; under security the collection queue can drain after that single fetch, leaving a `No items found` table. The old passive `should('not.contain', 'No items found')` can never recover and times out at 60s. Replace it with a `waitForTopQueriesTable()` helper that reloads (re-issuing the fetch) until the table populates. This is the failure behind the release autocut (opensearch-project/query-insights-dashboards#572).

### Issues Resolved

Addresses the recurring `[AUTOCUT] Integration Test Failed for queryInsightsDashboards` failures — this is the copy of the spec the release integration-test actually runs. Paired with a sync PR in `opensearch-project/query-insights-dashboards` (independent — no merge-order dependency).

### Check List
- [x] All tests pass (lint clean; behavior verified by source-tracing — the with-security failure is a non-deterministic race that can't be forced locally)
- [x] New functionality has been documented / commented
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
