### PR TITLE
Sync query-insights top_queries spec with plugin column-visibility changes (#569)

### DIFF
--- a/cypress/integration/plugins/query-insights-dashboards/1_top_queries_spec.js
+++ b/cypress/integration/plugins/query-insights-dashboards/1_top_queries_spec.js
@@ -311,10 +311,7 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
       'Avg CPU Time / CPU Time',
       'Avg Memory Usage / Memory Usage',
       'Indices',
-      'Search Type',
-      'Coordinator Node ID',
       'WLM Group',
-      'Total Shards',
     ];
     getHeaders().should('deep.equal', expected);
     assertRowCountEquals(totalRowCount);
@@ -335,10 +332,7 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
       'CPU Time',
       'Memory Usage',
       'Indices',
-      'Search Type',
-      'Coordinator Node ID',
       'WLM Group',
-      'Total Shards',
     ];
     getHeaders().should('deep.equal', expected);
 
@@ -388,10 +382,7 @@ describe('Query Insights — Dynamic Columns with Intercepted Top Queries (MIXED
       'Avg CPU Time / CPU Time',
       'Avg Memory Usage / Memory Usage',
       'Indices',
-      'Search Type',
-      'Coordinator Node ID',
       'WLM Group',
-      'Total Shards',
     ];
     getHeaders().should('deep.equal', expected);
     assertRowCountEquals(totalRowCount);
@@ -427,10 +418,7 @@ describe('Query Insights — Dynamic Columns (QUERY ONLY fixture)', () => {
       'CPU Time',
       'Memory Usage',
       'Indices',
-      'Search Type',
-      'Coordinator Node ID',
       'WLM Group',
-      'Total Shards',
     ];
     // assertRowCountEquals uses .should('have.length', N) which retries until items
     // has populated; once row count matches, columnsToShow has evaluated against the
@@ -470,7 +458,7 @@ describe('Query Insights — Dynamic Columns (GROUP ONLY fixture)', () => {
     getHeaders().should('deep.equal', expected);
   });
 
-  it('renders dash in status column for group rows', () => {
+  it('renders no status badges in group-only view', () => {
     cy.get('.euiTableRow').each(($row) => {
       cy.wrap($row).find('.euiBadge').should('not.exist');
     });
@@ -772,11 +760,6 @@ describe('Query Insights — DynamicSearchBar', () => {
       .last()
       .find('.euiTableRow')
       .should('have.length.greaterThan', 0);
-    cy.get('.euiBasicTable')
-      .last()
-      .find('.euiTableRow')
-      .first()
-      .should('contain.text', 'query then fetch');
   });
 
   it('shows filter badges for active conditions', () => {
@@ -827,5 +810,157 @@ describe('Query Insights — DynamicSearchBar', () => {
       .last()
       .contains('No items found')
       .should('be.visible');
+  });
+});
+
+describe('Query Insights — Column Visibility', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/api/top_queries/**', (req) => {
+      req.reply({ statusCode: 200, body: makeTimestampedBody(MIXED) });
+    }).as('topQueries');
+
+    // Clear localStorage before visiting so column preferences start fresh
+    cy.clearLocalStorage('queryInsights_topn_visibleColumns');
+
+    cy.waitForQueryInsightsPlugin();
+    // Force reload because testIsolation is disabled in this repo's cypress.config —
+    // without it, cy.visit() to the same URL is a no-op and the intercepted request never fires.
+    cy.reload();
+    cy.wait('@topQueries', { timeout: 60000 });
+
+    // Ensure the table is rendered before interacting
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .should('have.length.greaterThan', 0);
+  });
+
+  it('displays the Columns button', () => {
+    cy.get('[data-test-subj="column-visibility-button"]')
+      .should('exist')
+      .and('be.visible');
+  });
+
+  it('opens popover with column checkboxes on click', () => {
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.get('[data-test-subj="column-visibility-show-all"]').should(
+      'be.visible'
+    );
+    cy.get('[data-test-subj="column-visibility-hide-all"]').should(
+      'be.visible'
+    );
+    cy.get('[data-test-subj^="column-toggle-"]').should(
+      'have.length.greaterThan',
+      0
+    );
+    // Close popover
+    cy.get('body').click(0, 0);
+  });
+
+  // Opens the popover and waits for its content to be rendered/visible,
+  // avoiding arbitrary fixed sleeps.
+  const openColumnPopover = () => {
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.get('[data-test-subj="column-visibility-show-all"]').should(
+      'be.visible'
+    );
+  };
+
+  // Closes the popover and waits for its content to be removed from the DOM.
+  const closeColumnPopover = () => {
+    cy.get('[data-test-subj="column-visibility-button"]').click();
+    cy.get('[data-test-subj="column-visibility-show-all"]').should('not.exist');
+  };
+
+  it('hides a column when unchecked', () => {
+    // Verify Indices column is visible initially
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .contains('Indices')
+      .should('exist');
+
+    // Open popover and toggle "Indices" column off
+    openColumnPopover();
+    cy.get('[data-test-subj="column-toggle-indices"]').click({ force: true });
+    closeColumnPopover();
+
+    // Verify "Indices" header is gone
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .contains('Indices')
+      .should('not.exist');
+  });
+
+  it('shows a column when checked', () => {
+    // First hide Indices
+    openColumnPopover();
+    cy.get('[data-test-subj="column-toggle-indices"]').click({ force: true });
+    closeColumnPopover();
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .contains('Indices')
+      .should('not.exist');
+
+    // Now show it again
+    openColumnPopover();
+    cy.get('[data-test-subj="column-toggle-indices"]').click({ force: true });
+    closeColumnPopover();
+
+    // Verify "Indices" header is back
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .contains('Indices')
+      .should('exist');
+  });
+
+  it('ID column checkbox is disabled (pinned)', () => {
+    openColumnPopover();
+    cy.get('[data-test-subj="column-toggle-id"]').should('be.disabled');
+    closeColumnPopover();
+  });
+
+  it('Show all makes all columns visible', () => {
+    // First hide a column
+    openColumnPopover();
+    cy.get('[data-test-subj="column-toggle-type"]').click({ force: true });
+    closeColumnPopover();
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .contains('Type')
+      .should('not.exist');
+
+    // Open popover and click Show all
+    openColumnPopover();
+    cy.get('[data-test-subj="column-visibility-show-all"]').click();
+    closeColumnPopover();
+
+    // Verify Type column is back
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .contains('Type')
+      .should('exist');
+  });
+
+  it('Hide all keeps only pinned columns', () => {
+    openColumnPopover();
+    cy.get('[data-test-subj="column-visibility-hide-all"]').click();
+    closeColumnPopover();
+
+    // Only "Id" should remain (pinned)
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .should('have.length', 1);
+    cy.get('.euiBasicTable')
+      .last()
+      .find('.euiTableHeaderCell')
+      .contains('Id')
+      .should('exist');
   });
 });


### PR DESCRIPTION
### Description

Syncs `cypress/integration/plugins/query-insights-dashboards/1_top_queries_spec.js` with the plugin-repo spec after plugin PR [#569](https://github.com/opensearch-project/query-insights-dashboards/pull/569) ("reusable column visibility system"), which this repo's copy had not yet picked up.

**Why:** #569 sets `defaultVisible: false` on three Top N Queries columns — **Search Type**, **Coordinator Node ID** (Node ID), and **Total Shards** — so the table now renders 10 columns by default instead of 13. The plugin repo updated its own spec's expected headers, but the copy here still asserted the old 13-column list, so the release integration test (which runs this repo's specs with security) failed on:

- `Dynamic Columns … renders combined headers when Nothing is selected in type`
- `Dynamic Columns … renders query-only headers when Type=query`
- `Dynamic Columns … renders combined headers when Type=both`
- `Dynamic Columns (QUERY ONLY fixture) renders only query headers`
- `DynamicSearchBar filters table by field = value expression`

all with `expected [Array(10)] to deeply equal [Array(13)]`.

**Changes (mirrors plugin #569's spec delta):**
- Trim `Search Type`, `Coordinator Node ID`, `Total Shards` from the four expected-header arrays (now 10 columns ending at `WLM Group`).
- Drop the `search_type` value assertion (`'query then fetch'`) in the field-filter test — that column is hidden by default.
- Rename `renders dash in status column for group rows` → `renders no status badges in group-only view`.
- Add the `Query Insights — Column Visibility` describe block (Columns popover, show/hide/pinned/show-all/hide-all), adapted to this repo's `testIsolation: false` config (force `cy.reload()` so the intercept fires; clear `queryInsights_topn_visibleColumns` localStorage for a fresh start).

After this, the header expectations match the plugin's current `main` (both assert 10 columns).

### Issues Resolved
Resolves opensearch-project/query-insights-dashboards#572

### Check List
- [x] All tests pass (lint clean; header expectations verified to match plugin `main`)
- [x] New functionality has been documented / commented
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
