### PR TITLE
Fix reportsDashboards edit spec flakiness with API intercepts

### DIFF
--- a/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
+++ b/cypress/integration/plugins/reports-dashboards/02-edit.spec.js
@@ -5,8 +5,58 @@
 
 import { BASE_PATH, TIMEOUT } from '../../../utils/constants';
 
+const REPORT_DEFINITION_API = '**/api/reporting/reportDefinitions/**';
+
+const setupEditIntercepts = () => {
+  cy.intercept('GET', REPORT_DEFINITION_API).as('getReportDefinition');
+
+  cy.intercept('PUT', REPORT_DEFINITION_API, (req) => {
+    req.headers['origin'] = BASE_PATH;
+    if (
+      req.body &&
+      req.body.report_params &&
+      req.body.report_params.core_params
+    ) {
+      req.body.report_params.core_params.origin = BASE_PATH;
+    }
+  }).as('updateReportDefinition');
+};
+
+const openEditPage = () => {
+  cy.get('#reportDefinitionDetailsLink').first().click({ force: true });
+
+  cy.get('#editReportDefinitionButton', { timeout: TIMEOUT }).should('exist');
+  cy.get('#editReportDefinitionButton').click();
+
+  cy.url().should('include', 'edit');
+
+  cy.wait('@getReportDefinition', { timeout: TIMEOUT });
+
+  cy.get('#reportSettingsName', { timeout: TIMEOUT })
+    .should('exist')
+    .and(($el) => {
+      expect($el.val()).to.not.equal('');
+    });
+};
+
+const clickSaveChanges = () => {
+  cy.get('#editReportDefinitionButton')
+    .contains('Save Changes')
+    .trigger('mouseover')
+    .click({ force: true });
+
+  cy.wait('@updateReportDefinition', { timeout: TIMEOUT })
+    .its('response.statusCode')
+    .should('eq', 200);
+
+  // check that re-direct to home page
+  cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should('exist');
+};
+
 describe('Cypress', () => {
   beforeEach(() => {
+    setupEditIntercepts();
+
     // Wait before visiting to allow index refresh after previous test's save
     cy.wait(5000);
     cy.visit(`${BASE_PATH}/app/reports-dashboards#/`, {
@@ -29,12 +79,7 @@ describe('Cypress', () => {
   });
 
   it('Visit edit page, update name and description', () => {
-    cy.get('#reportDefinitionDetailsLink').first().click({ force: true });
-
-    cy.get('#editReportDefinitionButton').should('exist');
-    cy.get('#editReportDefinitionButton').click();
-
-    cy.url().should('include', 'edit');
+    openEditPage();
 
     // update the report name
     cy.get('#reportSettingsName').type('{selectall}{backspace} update name');
@@ -44,61 +89,30 @@ describe('Cypress', () => {
       '{selectall}{backspace} update description'
     );
 
-    cy.get('#editReportDefinitionButton')
-      .contains('Save Changes')
-      .trigger('mouseover')
-      .click({ force: true });
-
-    // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
-      'exist'
-    );
+    clickSaveChanges();
   });
 
   it('Visit edit page, change report trigger', () => {
-    cy.get('#reportDefinitionDetailsLink').first().click();
-
-    cy.get('#editReportDefinitionButton').should('exist');
-    cy.get('#editReportDefinitionButton').click();
-
-    cy.url().should('include', 'edit');
+    openEditPage();
 
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(2)').click({
       force: true,
     });
 
-    cy.get('#Schedule').check({ force: true });
-    cy.get('#editReportDefinitionButton')
-      .contains('Save Changes')
-      .trigger('mouseover')
-      .click({ force: true });
+    cy.get('#Schedule').check({ force: true }).should('be.checked');
 
-    // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
-      'exist'
-    );
+    clickSaveChanges();
   });
 
   it('Visit edit page, change report trigger back', () => {
-    cy.get('#reportDefinitionDetailsLink').first().click();
-
-    cy.get('#editReportDefinitionButton').should('exist');
-    cy.get('#editReportDefinitionButton').click();
-
-    cy.url().should('include', 'edit');
+    openEditPage();
 
     cy.get('#reportDefinitionTriggerTypes > div:nth-child(1)').click({
       force: true,
     });
 
-    cy.get('#editReportDefinitionButton')
-      .contains('Save Changes')
-      .trigger('mouseover')
-      .click({ force: true });
+    cy.get('#On\\ demand').check({ force: true }).should('be.checked');
 
-    // check that re-direct to home page
-    cy.get('#reportDefinitionDetailsLink', { timeout: TIMEOUT }).should(
-      'exist'
-    );
+    clickSaveChanges();
   });
 });


### PR DESCRIPTION
## Summary

Fixes intermittent failures in the `reportsDashboards` integration test (`02-edit.spec.js`) caused by the edit page tests clicking and asserting UI state without waiting for the underlying API responses.

**Changes:**
- Add `REPORT_DEFINITION_API` constant for the reportDefinitions endpoint pattern
- Add `setupEditIntercepts()` — registers `cy.intercept` for GET and PUT on the report definition API
- Add `openEditPage()` — clicks into the edit page and waits for `@getReportDefinition` before asserting
- Add `clickSaveChanges()` — clicks Save and waits for `@updateReportDefinition` with status 200 assertion
- Replace inline click sequences with the new helpers in all three test cases
- Add `.should('be.checked')` assertions after radio button interactions

**Root cause:** Tests were clicking without waiting for API responses, causing the "before all" hook to fail when the edit page hadn't loaded yet.

Fixes: opensearch-project/dashboards-reporting#785

## Test plan
- [x] `reportsDashboards` integration tests pass on 3.8.0 without-security