### PR TITLE
[2.17] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/start-opensearch/action.yml
+++ b/.github/actions/start-opensearch/action.yml
@@ -38,7 +38,7 @@ runs:
       shell: pwsh
 
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
       with:
         java-version: 21
 
@@ -49,14 +49,14 @@ runs:
 
     # Download OpenSearch
     - name: Download OpenSearch for Windows
-      uses: peternied/download-file@v2
+      uses: peternied/download-file@6a5025a112bb8811a2eb5ee6dd3417acf6d928e4 # v2
       if: ${{ runner.os == 'Windows' }}
       with:
         url: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ inputs.opensearch-version }}/latest/windows/x64/zip/dist/opensearch/opensearch-${{ inputs.opensearch-version }}-windows-x64.zip
 
 
     - name: Download OpenSearch for Linux
-      uses: peternied/download-file@v2
+      uses: peternied/download-file@6a5025a112bb8811a2eb5ee6dd3417acf6d928e4 # v2
       if: ${{ runner.os == 'Linux' }}
       with:
         url: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ inputs.opensearch-version }}/latest/linux/x64/tar/dist/opensearch/opensearch-${{ inputs.opensearch-version }}-linux-x64.tar.gz
@@ -151,7 +151,7 @@ runs:
 
     # Give the OpenSearch process some time to boot up before sending any requires, might need to increase the default time!
     - name: Sleep while OpenSearch starts
-      uses: peternied/action-sleep@v1
+      uses: peternied/action-sleep@7472dd1367f502fffd8b22251e44b0ac1a89ed80 # v1
       with:
         seconds: 30
 

--- a/.github/workflows/alerting-release-e2e-workflow.yml
+++ b/.github/workflows/alerting-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/anomaly-detection-release-e2e-workflow.yml
+++ b/.github/workflows/anomaly-detection-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/assistant-release-e2e-workflow.yml
+++ b/.github/workflows/assistant-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
         id: filter
         with:
           filters: |

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
-      - uses: actions/checkout@v2
-      - uses: ncipollo/release-action@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           body: "Functional tests for OpenSearch Dashboards and OpenSearch Dashboards Plugins ${GITHUB_REF/refs\/tags\//}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -25,7 +25,7 @@ jobs:
       # Using fork of https://github.com/tibdex/backport
       # https://github.com/tibdex/backport/pull/81
       - name: Backport
-        uses: VachaShah/backport@v1.1.4
+        uses: VachaShah/backport@28c49d91ceec57d7c9f625f1031c1a4d637251f5 # v1.1.4
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           branch_name: backport/backport-${{ github.event.number }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@231aa2c8a89117b126725a0e11897209b7118144 # v1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@231aa2c8a89117b126725a0e11897209b7118144 # v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@231aa2c8a89117b126725a0e11897209b7118144 # v1

--- a/.github/workflows/custom-import-map-dashboards-release-e2e-workflow.yml
+++ b/.github/workflows/custom-import-map-dashboards-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
+++ b/.github/workflows/cypress-workflow-bundle-snapshot-based-ci-groups.yml
@@ -28,9 +28,9 @@ jobs:
       MATRIX_INCLUDES: ${{ steps.get_spec.outputs.MATRIX_INCLUDES }}
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Checkout cypress-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: spec-detect

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -10,6 +10,6 @@ jobs:
     if: startsWith(github.event.pull_request.head.ref,'backport/')
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
+        uses: SvanBoxel/delete-merged-branch@2b5b058e3db41a3328fd9a6a58fd4c2545a14353 # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gantt-chart-release-e2e-workflow.yml
+++ b/.github/workflows/gantt-chart-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/index-management-release-e2e-workflow.yml
+++ b/.github/workflows/index-management-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/lint_checker.yml
+++ b/.github/workflows/lint_checker.yml
@@ -18,7 +18,7 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=6144 --dns-result-order=ipv4first'
     steps:
       - name: Checkout cypress-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: cypress-test

--- a/.github/workflows/ml-commons-release-e2e-workflow.yml
+++ b/.github/workflows/ml-commons-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
         id: filter
         with:
           filters: |

--- a/.github/workflows/notifications-release-e2e-workflow.yml
+++ b/.github/workflows/notifications-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/observability-release-e2e-workflow.yml
+++ b/.github/workflows/observability-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/query-workbench-release-e2e-workflow.yml
+++ b/.github/workflows/query-workbench-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/release-e2e-workflow-template-windows.yml
+++ b/.github/workflows/release-e2e-workflow-template-windows.yml
@@ -26,13 +26,13 @@ jobs:
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
         with:
           java-version: 21
       - name: Checkout cypress-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: cypress-test
@@ -92,7 +92,7 @@ jobs:
           echo "node_version=$(jq -r '.engines.node' ./opensearch-dashboards-${{ env.VERSION }}/package.json)" >> $GITHUB_ENV
         shell: bash
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ env.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -130,25 +130,25 @@ jobs:
           npm install
         shell: bash
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: cypress-test
           command: ${{ inputs.test-command }}
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos
           path: cypress-test/cypress/videos
       # Test reports was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-results

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -117,7 +117,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release-e2e-workflow-template.yml
+++ b/.github/workflows/release-e2e-workflow-template.yml
@@ -29,13 +29,13 @@ jobs:
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: 'myStrongPassword123!'
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
         with:
           java-version: 21
       - name: Checkout cypress-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: cypress-test
@@ -89,7 +89,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -117,7 +117,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -126,25 +126,25 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: cypress-test
           command: ${{ inputs.test-command }}
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos
           path: cypress-test/cypress/videos
       # Test reports was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-results

--- a/.github/workflows/release-signoff-chrome.yml
+++ b/.github/workflows/release-signoff-chrome.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: functional-test
@@ -55,7 +55,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -71,7 +71,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -84,19 +84,19 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: functional-test
           command: yarn cypress:release-chrome
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/release-signoff-chrome.yml
+++ b/.github/workflows/release-signoff-chrome.yml
@@ -71,7 +71,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release-signoff-chromium-ad-only.yml
+++ b/.github/workflows/release-signoff-chromium-ad-only.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: functional-test
@@ -44,7 +44,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -73,19 +73,19 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: functional-test
           command: yarn cypress:release-ad-only
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/release-signoff-chromium-ad-only.yml
+++ b/.github/workflows/release-signoff-chromium-ad-only.yml
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release-signoff-chromium-ism-only.yml
+++ b/.github/workflows/release-signoff-chromium-ism-only.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: functional-test
@@ -44,7 +44,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -73,19 +73,19 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: functional-test
           command: yarn cypress:release-ism-only
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/release-signoff-chromium-ism-only.yml
+++ b/.github/workflows/release-signoff-chromium-ism-only.yml
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: functional-test
@@ -44,7 +44,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -73,19 +73,19 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: functional-test
           command: yarn cypress:release-chromium-0
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-0.yml
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: functional-test
@@ -44,7 +44,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -73,19 +73,19 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: functional-test
           command: yarn cypress:release-chromium-10
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-10.yml
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: functional-test
@@ -44,7 +44,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -73,19 +73,19 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: functional-test
           command: yarn cypress:release-chromium-20
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-20.yml
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: functional-test
@@ -44,7 +44,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -73,19 +73,19 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: functional-test
           command: yarn cypress:release-chromium-5
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
+++ b/.github/workflows/release-signoff-chromium-tests-in-memory-5.yml
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release-signoff-chromium.yml
+++ b/.github/workflows/release-signoff-chromium.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: functional-test
@@ -44,7 +44,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -73,19 +73,19 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: functional-test
           command: yarn cypress:release-chromium
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/release-signoff-chromium.yml
+++ b/.github/workflows/release-signoff-chromium.yml
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release-signoff-electron.yml
+++ b/.github/workflows/release-signoff-electron.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: functional-test
@@ -44,7 +44,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -73,19 +73,19 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: functional-test
           command: yarn cypress:release-electron
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/release-signoff-electron.yml
+++ b/.github/workflows/release-signoff-electron.yml
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/release-signoff-firefox.yml
+++ b/.github/workflows/release-signoff-firefox.yml
@@ -19,7 +19,7 @@ jobs:
       CYPRESS_NO_COMMAND_LOG: 1
     steps:
       - name: Checkout functional-test
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           repository: ${{github.repository}}
           path: functional-test
@@ -44,7 +44,7 @@ jobs:
           node_version_temp=$(node -p "(require('./opensearch-dashboards-${{ env.VERSION }}/package.json').engines.node).match(/[.0-9]+/)[0]")
           echo "node_version=$node_version_temp" >> $GITHUB_ENV
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ steps.versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@v1
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
@@ -73,19 +73,19 @@ jobs:
       - run: npx cypress cache list
       - run: npx cypress cache path
       - name: Cypress tests
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@f5bea478b80a774068179089247f13d60abc5010 # v2
         with:
           working-directory: functional-test
           command: yarn cypress:release-firefox
           wait-on: 'http://localhost:5601'
       # Screenshots are only captured on failure, will change this once we do visual regression tests
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure()
         with:
           name: cypress-screenshots
           path: functional-test/cypress/screenshots
       # Test run video was always captured, so this action uses "always()" condition
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/release-signoff-firefox.yml
+++ b/.github/workflows/release-signoff-firefox.yml
@@ -60,7 +60,7 @@ jobs:
           echo "cypress_version=$cypress_version_temp" >> $GITHUB_ENV
       - name: Cache Cypress
         id: cache-cypress
-        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/remote-cypress-workflow.yml
+++ b/.github/workflows/remote-cypress-workflow.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         
       - name: Run Bash Script
         env:

--- a/.github/workflows/reports-release-e2e-workflow.yml
+++ b/.github/workflows/reports-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/search-relevance-release-e2e-workflow.yml
+++ b/.github/workflows/search-relevance-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/security-analytics-release-e2e-workflow.yml
+++ b/.github/workflows/security-analytics-release-e2e-workflow.yml
@@ -11,7 +11,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
         id: filter
         with:
           filters: |

--- a/.github/workflows/security-release-e2e-workflow.yml
+++ b/.github/workflows/security-release-e2e-workflow.yml
@@ -8,7 +8,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
       id: filter
       with:
         filters: |

--- a/.github/workflows/workspace-release-e2e-workflow.yml
+++ b/.github/workflows/workspace-release-e2e-workflow.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       tests: ${{ steps.filter.outputs.tests }}
     steps:
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2
         id: filter
         with:
           filters: |


### PR DESCRIPTION
### Description
Pin third-party GitHub Action references in release-branch workflows to full-length commit SHAs to satisfy the repository action policy.

OpenSearch-managed reusable workflows are intentionally left unchanged.

### Verification
- Scanned `.github/workflows` for non-`opensearch-project` `uses:` refs not pinned to 40-character SHAs
- Ran `git diff --check`
- Parsed changed workflow YAML files