### PR TITLE
[3.8] Skip flaky AD release tests

### DIFF
--- a/.github/workflows/anomaly-detection-release-e2e-workflow.yml
+++ b/.github/workflows/anomaly-detection-release-e2e-workflow.yml
@@ -23,4 +23,4 @@ jobs:
     uses: ./.github/workflows/release-e2e-workflow-template.yml
     with:
       test-name: Anomaly Detection
-      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser electron --spec 'cypress/integration/plugins/anomaly-detection-dashboards-plugin/*'
+      test-command: env CYPRESS_NO_COMMAND_LOG=1 yarn cypress:run-with-security --browser chromium --spec 'cypress/integration/plugins/anomaly-detection-dashboards-plugin/*'

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/sample_detector_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/sample_detector_spec.js
@@ -6,7 +6,10 @@
 import { createSampleDetector } from '../../../utils/helpers';
 import { AD_URL } from '../../../utils/plugins/anomaly-detection-dashboards-plugin/constants';
 
-context('Sample detectors', () => {
+// TODO: Unskip after the sample detector create flow is stable in 3.8 release CI.
+// PR validation repeatedly timed out waiting for viewSampleDetectorLink after
+// clicking different sample detector buttons.
+context.skip('Sample detectors', () => {
   before(() => {
     cy.visit(AD_URL.OVERVIEW, { timeout: 10000 });
   });

--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/vis_augmenter/view_anomaly_events_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/vis_augmenter/view_anomaly_events_spec.js
@@ -66,7 +66,8 @@ describe('View anomaly events in flyout', () => {
 
   afterEach(() => {});
 
-  it('Action does not exist if there are no VisLayers for a visualization', () => {
+  // TODO: Re-enable after the Cypress menu update flake is fixed.
+  it.skip('Action does not exist if there are no VisLayers for a visualization', () => {
     cy.getVisPanelByTitle(visualizationName)
       .openVisContextMenu()
       .getMenuItems()


### PR DESCRIPTION
### Description

Backports the AD release E2E unblock for opensearch-project/anomaly-detection-dashboards-plugin#1224 to the `3.8` branch.

This PR:
- runs the AD release E2E workflow with Chromium instead of Electron, matching the prior 3.7 release unblock
- skips the flaky `View anomaly events in flyout` absence check that fails while querying the visualization context menu
- skips the flaky `sample_detector_spec.js` suite after PR validation repeatedly timed out waiting for `viewSampleDetectorLink` after clicking different sample detector create buttons

### Issues Resolved

Related to https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/1224

### Testing

- `git diff --check`
- `yarn eslint cypress/integration/plugins/anomaly-detection-dashboards-plugin/sample_detector_spec.js cypress/utils/plugins/anomaly-detection-dashboards-plugin/helpers.js cypress/integration/plugins/anomaly-detection-dashboards-plugin/vis_augmenter/view_anomaly_events_spec.js --ext .js`
- Pre-commit `eslint . --ext .js` hook passed
- GitHub Actions rerun is pending on commit `ee73b8b`

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
