### PR TITLE
Fix alerting dashboards tests failing with security enabled

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js
@@ -166,7 +166,7 @@ describe('Bucket-Level Monitors', () => {
       cy.get('input[name="name"]').type(SAMPLE_EXTRACTION_QUERY_MONITOR);
 
       // Wait for input to load and then type in the index name
-      cy.contains('Select clusters');
+      cy.contains('Select data');
       cy.get('#index').type('*{enter}', { force: true });
 
       // Input extraction query
@@ -226,7 +226,7 @@ describe('Bucket-Level Monitors', () => {
 
       // Wait for input to load and then type in the index name
       // Pressing enter at the end to create combo box entry and trigger change events for time field below
-      cy.contains('Select clusters');
+      cy.contains('Select data');
       cy.get('#index').type(`${ALERTING_INDEX.SAMPLE_DATA_ECOMMERCE}{enter}`, {
         force: true,
       });
@@ -346,7 +346,7 @@ describe('Bucket-Level Monitors', () => {
         cy.contains('Edit').click({ force: true });
 
         // Wait for page to load
-        cy.contains('Select clusters');
+        cy.contains('Select data');
 
         // Click on the Index field and type in multiple index names to replicate the bug
         cy.get('#index')

--- a/cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js
@@ -127,7 +127,7 @@ describe('Query-Level Monitors', () => {
       cy.get('input[name="name"]').type(SAMPLE_MONITOR, { force: true });
 
       // Wait for input to load and then type in the index name
-      cy.contains('Select clusters');
+      cy.contains('Select data');
       cy.get('#index').type('*', { force: true });
 
       // Add a trigger
@@ -220,7 +220,7 @@ describe('Query-Level Monitors', () => {
       });
 
       // Wait for page to load
-      cy.contains('Select clusters');
+      cy.contains('Select data');
 
       // Click on the Index field and type in multiple index names to replicate the bug
       cy.get('#index')
@@ -350,7 +350,7 @@ describe('Query-Level Monitors', () => {
       cy.get('[data-test-subj="visualEditorRadioCard"]').click({ force: true });
 
       // Wait for page to load
-      cy.contains('Select clusters');
+      cy.contains('Select data');
 
       // Wait for input to load and then type in the index name
       cy.get('#index').type(


### PR DESCRIPTION
### Description
Replace 'Select clusters' with 'Select data' as the page-load wait assertion. 'Select clusters' is only rendered when cross-cluster monitoring is enabled AND the user has remote index permissions. In the with-security test config, the test user lacks these permissions, so the CrossClusterConfiguration component never renders.

'Select data' is the DataSource panel title which is always present regardless of security configuration or cross-cluster settings.

### Issues Resolved
Resolves opensearch-project/alerting-dashboards-plugin#1492

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
