### PR TITLE
Fix ISM e2e tests for OS 2.9: conditional toast dismiss and flexible column count

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/managed_indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/managed_indices_spec.js
@@ -29,7 +29,7 @@ describe('Managed indices', () => {
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Edit rollover alias', { timeout: 60000 });
 
-    cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+    cy.get('body').then(($body) => { if ($body.find('[data-test-subj="toastCloseButton"]').length) { cy.get('[data-test-subj="toastCloseButton"]').click({ force: true }); } });
   });
 
   describe('can have policies removed', () => {
@@ -90,7 +90,7 @@ describe('Managed indices', () => {
       // Wait up to 5 seconds for the managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.get('body').then(($body) => { if ($body.find('[data-test-subj="toastCloseButton"]').length) { cy.get('[data-test-subj="toastCloseButton"]').click({ force: true }); } });
 
       // Confirm managed index successfully initialized the policy
       cy.contains('Successfully initialized', { timeout: 20000 });
@@ -100,7 +100,7 @@ describe('Managed indices', () => {
       // Wait up to 5 seconds for managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.get('body').then(($body) => { if ($body.find('[data-test-subj="toastCloseButton"]').length) { cy.get('[data-test-subj="toastCloseButton"]').click({ force: true }); } });
 
       // Confirm we have a Failed execution, wait up to 20 seconds as OSD takes a while to load
       cy.contains('Failed', { timeout: 20000 });
@@ -127,7 +127,7 @@ describe('Managed indices', () => {
 
       // Reload the page
       cy.reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.get('body').then(($body) => { if ($body.find('[data-test-subj="toastCloseButton"]').length) { cy.get('[data-test-subj="toastCloseButton"]').click({ force: true }); } });
 
       // Confirm we see managed index attempting to retry, give 20 seconds for OSD load
       cy.contains('Pending retry of failed managed index', { timeout: 20000 });
@@ -138,7 +138,7 @@ describe('Managed indices', () => {
       // Wait up to 5 seconds for managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.get('body').then(($body) => { if ($body.find('[data-test-subj="toastCloseButton"]').length) { cy.get('[data-test-subj="toastCloseButton"]').click({ force: true }); } });
 
       // Confirm managed index successfully rolled over
       cy.contains('Successfully rolled over', { timeout: 20000 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/transforms_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/transforms_spec.js
@@ -102,7 +102,7 @@ describe('Transforms', () => {
       cy.contains('category.keyword_terms');
 
       // Add aggregable field
-      cy.contains('50 columns hidden').click({ force: true });
+      cy.contains(/\d+ columns hidden/).click({ force: true });
       cy.contains('taxless_total_price').click({ force: true });
       // Click out of the window
       cy.contains('Select fields to transform').click({ force: true });


### PR DESCRIPTION
### Description

Fixes index-management-e2e (test_e2e_ism) failures on OpenSearch 2.9
  
  - managed_indices_spec.js: replace unconditional toast dismiss calls with a
    conditional dismiss so the spec doesn't fail when no toast is present

  - transforms_spec.js: match the "columns hidden" link with a flexible regex instead of the hard-coded "50 columns   hidden", so the
    test is resilient to the column count rendered by the UI


### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
