### PR TITLE
Fix alerting dashboards multi-index update tests failing without security

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js
@@ -353,8 +353,11 @@ describe('Bucket-Level Monitors', () => {
           .click({ force: true })
           .type(`${TESTING_INDEX_A}{enter}${TESTING_INDEX_B}{enter}`, {
             force: true,
-          })
-          .trigger('blur', { force: true });
+          });
+
+        // Re-query the element before triggering blur since typing {enter}
+        // causes a React re-render that detaches the original input element
+        cy.get('#index').trigger('blur', { force: true });
 
         // Confirm Index field only contains the expected text
         cy.get('[data-test-subj="indicesComboBox"]').contains('*', {

--- a/cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js
@@ -227,8 +227,11 @@ describe('Query-Level Monitors', () => {
         .click({ force: true })
         .type(`${TESTING_INDEX_A}{enter}${TESTING_INDEX_B}{enter}`, {
           force: true,
-        })
-        .trigger('blur', { force: true });
+        });
+
+      // Re-query the element before triggering blur since typing {enter}
+      // causes a React re-render that detaches the original input element
+      cy.get('#index').trigger('blur', { force: true });
 
       // Confirm Index field only contains the expected text
       cy.get('[data-test-subj="indicesComboBox"]').contains('*', {


### PR DESCRIPTION
### Description
Break the Cypress command chain between .type() and .trigger('blur') in the "to have multiple indices" tests. Typing {enter} into the index combo box triggers a React re-render that detaches the input element, causing the chained .trigger('blur') to fail with a stale DOM reference.

Re-querying the element with cy.get('#index') after the type command ensures Cypress operates on the newly-rendered input.


### Issues Resolved
Resolves opensearch-project/alerting-dashboards-plugin#1492


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
