### PR TITLE
Resolve TOCTOU race condition in daily forecaster chart control click

### DIFF
--- a/cypress/integration/plugins/anomaly-detection-dashboards-plugin/daily_forecaster_spec.js
+++ b/cypress/integration/plugins/anomaly-detection-dashboards-plugin/daily_forecaster_spec.js
@@ -36,13 +36,16 @@ const clickControlAndVerifyChartUpdate = (buttonAriaLabel) => {
       cy.get('.echChartStatus')
         .invoke('attr', 'data-ech-render-count')
         .then((initialRenderCount) => {
-          cy.get(`button[aria-label="${buttonAriaLabel}"]`).click();
+          // Re-check disabled state right before clicking to avoid TOCTOU race
+          cy.get(`button[aria-label="${buttonAriaLabel}"]`).then(($btn) => {
+            if (!$btn.is(':disabled')) {
+              cy.wrap($btn).click();
 
-          // Cypress's .should() will automatically retry until the assertion passes or times out,
-          // which handles the async nature of the re-render.
-          cy.get('.echChartStatus')
-            .invoke('attr', 'data-ech-render-count')
-            .should('not.eq', initialRenderCount);
+              cy.get('.echChartStatus')
+                .invoke('attr', 'data-ech-render-count')
+                .should('not.eq', initialRenderCount);
+            }
+          });
         });
     }
   });


### PR DESCRIPTION
### Description
Fixes a race condition in `daily_forecaster_spec.js` where `clickControlAndVerifyChartUpdate` fails with `cy.click() failed because this element is disabled` on the "Zoom out" button. 

The outer `$body.find(":not(:disabled)")` guard (line 32) is a synchronous jQuery snapshot. Between that check and the actual `cy.get().click()` (line 39), the async echChartStatus render-count fetch allows time for the chart to re-render and disable the button. Cypress then retries `.click()` on the disabled element until it times out.

  **Fix:** Re-check `:disabled` state immediately before clicking using `cy.get().then($btn)`, and only proceed with the click and render-count assertion if the button is still enabled. This eliminates the TOCTOU (time-of-check-to-time-of-use) gap.

### Issues Resolved

https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/1224

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
