### PR TITLE
Fix alerting dashboards multi-index update tests failing

### DIFF
--- a/cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/bucket_level_monitor_spec.js
@@ -348,15 +348,13 @@ describe('Bucket-Level Monitors', () => {
         // Wait for page to load
         cy.contains('Select data');
 
-        // Click on the Index field and type in multiple index names to replicate the bug
-        cy.get('#index')
-          .click({ force: true })
-          .type(`${TESTING_INDEX_A}{enter}${TESTING_INDEX_B}{enter}`, {
-            force: true,
-          });
-
-        // Re-query the element before triggering blur since typing {enter}
-        // causes a React re-render that detaches the original input element
+        // Click on the Index field and type in multiple index names to replicate the bug.
+        // Each step re-queries the element because clicking triggers an async fetch
+        // of remote indexes, and each {enter} causes a React re-render that detaches
+        // the original input element from the DOM.
+        cy.get('#index').click({ force: true });
+        cy.get('#index').type(`${TESTING_INDEX_A}{enter}`, { force: true });
+        cy.get('#index').type(`${TESTING_INDEX_B}{enter}`, { force: true });
         cy.get('#index').trigger('blur', { force: true });
 
         // Confirm Index field only contains the expected text

--- a/cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js
+++ b/cypress/integration/plugins/alerting-dashboards-plugin/query_level_monitor_spec.js
@@ -222,15 +222,13 @@ describe('Query-Level Monitors', () => {
       // Wait for page to load
       cy.contains('Select data');
 
-      // Click on the Index field and type in multiple index names to replicate the bug
-      cy.get('#index')
-        .click({ force: true })
-        .type(`${TESTING_INDEX_A}{enter}${TESTING_INDEX_B}{enter}`, {
-          force: true,
-        });
-
-      // Re-query the element before triggering blur since typing {enter}
-      // causes a React re-render that detaches the original input element
+      // Click on the Index field and type in multiple index names to replicate the bug.
+      // Each step re-queries the element because clicking triggers an async fetch
+      // of remote indexes, and each {enter} causes a React re-render that detaches
+      // the original input element from the DOM.
+      cy.get('#index').click({ force: true });
+      cy.get('#index').type(`${TESTING_INDEX_A}{enter}`, { force: true });
+      cy.get('#index').type(`${TESTING_INDEX_B}{enter}`, { force: true });
       cy.get('#index').trigger('blur', { force: true });
 
       // Confirm Index field only contains the expected text


### PR DESCRIPTION
### Description
The "to have multiple indices" tests in `bucket_level_monitor_spec.js` and `query_level_monitor_spec.js` fail because:

1. `cy.get('#index').click()` triggers an async fetch (`/api/alerting/remote/indexes`) that causes a React re-render, detaching the DOM element before `.type()` can execute.
2. Each `{enter}` within `.type()` also triggers a re-render that detaches the input element mid-command.

The fix breaks the chained Cypress command into separate `cy.get('#index')` calls for each operation (click, type index-a, type index-b, blur). This forces Cypress to re-query the DOM between each step, ensuring the element is always attached.

### Issues resolved
Fixes opensearch-project/alerting-dashboards-plugin#1492

## Testing
<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/fa8563eb-8958-4452-9047-e38f44420f8f" />

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/843af185-4608-4540-bab4-0fcfee545677" />


### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
