### PR TITLE
fix ism e2e: conditional toast dismiss, failOnStatusCode and notification settings

### DIFF
--- a/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/aliases.js
@@ -171,6 +171,7 @@ describe('Aliases', () => {
       });
 
       cy.get('[data-test-subj="moreAction"]').click();
+      cy.wait(1000);
       // Flush btn should be disabled if no items selected
       cy.get('[data-test-subj="Flush Action"]').should(
         'have.class',

--- a/cypress/integration/plugins/index-management-dashboards-plugin/managed_indices_spec.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/managed_indices_spec.js
@@ -29,7 +29,11 @@ describe('Managed indices', () => {
     // Common text to wait for to confirm page loaded, give up to 60 seconds for initial load
     cy.contains('Edit rollover alias', { timeout: 60000 });
 
-    cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-test-subj="toastCloseButton"]').length > 0) {
+        cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      }
+    });
   });
 
   describe('can have policies removed', () => {
@@ -90,7 +94,11 @@ describe('Managed indices', () => {
       // Wait up to 5 seconds for the managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-test-subj="toastCloseButton"]').length > 0) {
+          cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+        }
+      });
 
       // Confirm managed index successfully initialized the policy
       cy.contains('Successfully initialized', { timeout: 20000 });
@@ -100,7 +108,11 @@ describe('Managed indices', () => {
       // Wait up to 5 seconds for managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-test-subj="toastCloseButton"]').length > 0) {
+          cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+        }
+      });
 
       // Confirm we have a Failed execution, wait up to 20 seconds as OSD takes a while to load
       cy.contains('Failed', { timeout: 20000 });
@@ -127,7 +139,11 @@ describe('Managed indices', () => {
 
       // Reload the page
       cy.reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-test-subj="toastCloseButton"]').length > 0) {
+          cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+        }
+      });
 
       // Confirm we see managed index attempting to retry, give 20 seconds for OSD load
       cy.contains('Pending retry of failed managed index', { timeout: 20000 });
@@ -138,7 +154,11 @@ describe('Managed indices', () => {
       // Wait up to 5 seconds for managed index to execute
       // eslint-disable-next-line cypress/no-unnecessary-waiting
       cy.wait(5000).reload();
-      cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-test-subj="toastCloseButton"]').length > 0) {
+          cy.get('[data-test-subj="toastCloseButton"]').click({ force: true });
+        }
+      });
 
       // Confirm managed index successfully rolled over
       cy.contains('Successfully rolled over', { timeout: 20000 });

--- a/cypress/integration/plugins/index-management-dashboards-plugin/notification_settings.js
+++ b/cypress/integration/plugins/index-management-dashboards-plugin/notification_settings.js
@@ -96,14 +96,25 @@ describe('NotificationSettings', () => {
       cy.get(`[data-test-subj="dataSource.0.failure"]`).check({
         force: true,
       });
+      // Wait for combobox and click to focus
       cy.get(
         `[data-test-subj="dataSource.0.channels"] [data-test-subj="comboBoxSearchInput"]`
-      ).type(`${channel}{enter}`);
+      )
+        .should('be.visible')
+        .click({ force: true });
+      // Type and wait for dropdown option
+      cy.get(
+        `[data-test-subj="dataSource.0.channels"] [data-test-subj="comboBoxSearchInput"]`
+      ).type(channel);
+      cy.get(`[role="option"]`)
+        .contains(channel, { timeout: 10000 })
+        .click({ force: true });
       cy.get('[data-test-subj="submitNotifcationSettings"]').click({
         force: true,
       });
       cy.contains(
-        'Notifications settings for index operations have been successfully updated.'
+        'Notifications settings for index operations have been successfully updated.',
+        { timeout: 60000 }
       );
       cy.reload();
       cy.contains(channel);

--- a/cypress/utils/plugins/index-management-dashboards-plugin/commands.js
+++ b/cypress/utils/plugins/index-management-dashboards-plugin/commands.js
@@ -7,10 +7,11 @@ import { BACKEND_BASE_PATH, IM_API, IM_CONFIG_INDEX } from '../../constants';
 
 Cypress.Commands.add('deleteIMJobs', () => {
   // TODO don't directly delete system index, use other way
-  cy.request(
-    'DELETE',
-    `${Cypress.env('openSearchUrl')}/.opendistro-ism*?expand_wildcards=all`
-  );
+  cy.request({
+    method: 'DELETE',
+    url: `${Cypress.env('openSearchUrl')}/.opendistro-ism*?expand_wildcards=all`,
+    failOnStatusCode: false,
+  });
   // Clean all ISM policies
   cy.request('GET', `${BACKEND_BASE_PATH}${IM_API.POLICY_BASE}`).then(
     (resp) => {


### PR DESCRIPTION
### Description

 Fixes failing ISM e2e Cypress specs on OpenSearch 2.15:
  
  - **`managed_indices_spec.js`** — conditional toast dismiss (only click `toastCloseButton` if present) to avoid the detached/absent-toast race.
  - **`aliases.js`** — add `cy.wait(1000)` after opening the `moreAction` menu before asserting the Flush action state.
  - **`commands.js` (`deleteIMJobs`)** — add `failOnStatusCode: false` so setup/teardown doesn't crash when `.opendistro-ism*` is missing.
  - **`notification_settings.js`** — deterministic channel selection (focus → type → click matching `[role="option"]`) + 60s timeout on the success toast.
  
### Testing
  
  Full `index-management-dashboards-plugin` e2e suite passes on a 2.15 cluster + Dashboards (all 16 specs)

### Check List

- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
